### PR TITLE
fix(ci): align release workflows with org PAT_TOKEN convention

### DIFF
--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -90,15 +90,17 @@ jobs:
             echo "EOF" >> $GITHUB_OUTPUT
           fi
 
-      - name: Commit changes
+      - name: Commit and push
+        env:
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           git add package.json package-lock.json CHANGELOG.md
           git commit -m "chore: release v$VERSION"
-          git push origin release/v$VERSION
+          git push https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git release/v$VERSION
 
       - name: Create Pull Request
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
           CHANGELOG_BODY: ${{ steps.changelog.outputs.CHANGELOG_CONTENT }}
         run: |
           printf '%s\n' "## Release v$VERSION" "" "$CHANGELOG_BODY" "" "---" "**Checklist:**" "- [ ] Version bump looks correct" "- [ ] Changelog entries are accurate" "- [ ] CI passes" "" "After merging, run the **Tag and Publish Release** workflow to create the git tag and trigger npm publish." > /tmp/pr-body.md

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create and push tag
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           VERSION="${{ github.event.inputs.version }}"
           TAG="v$VERSION"


### PR DESCRIPTION
## Summary

- Switch `RELEASE_TOKEN` → `PAT_TOKEN` to match EggAI/eggai-clutch org convention
- Use explicit `x-access-token` URL for git push (same pattern as EggAI)
- Fixes 401 error on release PR creation

## Test plan

- [ ] CI passes (no code changes)
- [ ] After merge, add `PAT_TOKEN` secret to repo and re-run Create Release PR workflow