### PR TITLE
fix(ci): upgrade npm for OIDC trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -139,8 +139,11 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 22.x
           registry-url: https://registry.npmjs.org
+
+      - name: Upgrade npm for OIDC trusted publishing
+        run: npm install -g npm@latest
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
npm trusted publishing needs npm >= 11.5.0. Node 20 ships npm 10.8 which causes E404. Use Node 22 + npm@latest in publish job.