### PR TITLE
fix(ci): disable auto-provenance for private repo npm publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -151,7 +151,7 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
-        run: npm publish --access public
+        run: npm publish --access public --provenance=false
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 


### PR DESCRIPTION
npm 11+ auto-enables provenance in GitHub Actions. Private repos can't use it. Explicitly disable with --provenance=false.