### PR TITLE
fix(ci): switch to npm trusted publishing with provenance

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -127,6 +127,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     environment:
       name: npm
       url: https://www.npmjs.com/package/@eggai/qualops
@@ -151,9 +152,7 @@ jobs:
         run: npm run build
 
       - name: Publish to npm
-        run: npm publish --access public --provenance=false
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance
 
       - name: Verify publish
         env:


### PR DESCRIPTION
Repo is now public. Enable OIDC trusted publishing + provenance attestation. Remove NPM_TOKEN.