### PR TITLE
fix(ci): workflow hardening — injection, permissions, reliability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
       - main
     types: [opened, synchronize, reopened, labeled]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -79,11 +82,13 @@ jobs:
 
       - name: Check changelog updated
         if: steps.needs-changelog.outputs.required == 'true'
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
           # Check if this is a release PR
-          if echo "${{ github.head_ref }}" | grep -qE '^release/v'; then
+          if echo "$HEAD_REF" | grep -qE '^release/v'; then
             echo "Release PR detected, checking for version entry..."
-            VERSION=$(echo "${{ github.head_ref }}" | sed 's/release\/v//')
+            VERSION=$(echo "$HEAD_REF" | sed 's/release\/v//')
             if grep -qE "^## \[$VERSION\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$" CHANGELOG.md; then
               echo "Found version entry for $VERSION"
               exit 0
@@ -142,10 +147,12 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           node dist/cli.js all \
-            --base origin/${{ github.base_ref }} \
-            --head ${{ github.event.pull_request.head.sha }} \
+            --base "origin/$BASE_REF" \
+            --head "$HEAD_SHA" \
             --stages analyze,review,report
 
       - name: Post GitHub Integration
@@ -167,17 +174,21 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check all jobs passed
+        env:
+          LINT_RESULT: ${{ needs.lint.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+          CHANGELOG_RESULT: ${{ needs.changelog.result }}
         run: |
-          if [ "${{ needs.lint.result }}" != "success" ]; then
+          if [ "$LINT_RESULT" != "success" ]; then
             echo "Lint job failed"
             exit 1
           fi
-          if [ "${{ needs.test.result }}" != "success" ]; then
+          if [ "$TEST_RESULT" != "success" ]; then
             echo "Test job failed"
             exit 1
           fi
           # Changelog is optional (skipped on push to main or when no code changes)
-          if [ "${{ needs.changelog.result }}" != "success" ] && [ "${{ needs.changelog.result }}" != "skipped" ]; then
+          if [ "$CHANGELOG_RESULT" != "success" ] && [ "$CHANGELOG_RESULT" != "skipped" ]; then
             echo "Changelog job failed"
             exit 1
           fi

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -94,9 +94,10 @@ jobs:
             echo "CHANGELOG_CONTENT=Pre-release version $VERSION" >> $GITHUB_OUTPUT
           else
             CONTENT=$(sed -n "/^## \[$VERSION\]/,/^## \[/p" CHANGELOG.md | tail -n +2 | head -n -1)
-            echo "CHANGELOG_CONTENT<<EOF" >> $GITHUB_OUTPUT
+            DELIMITER=$(openssl rand -hex 8)
+            echo "CHANGELOG_CONTENT<<${DELIMITER}" >> $GITHUB_OUTPUT
             echo "$CONTENT" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
+            echo "${DELIMITER}" >> $GITHUB_OUTPUT
           fi
 
       - name: Commit and push

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,7 +3,6 @@ name: Dependabot Auto-Merge
 on: pull_request
 
 permissions:
-  contents: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -60,9 +60,10 @@ jobs:
             echo "CONTENT=Pre-release version $VERSION" >> $GITHUB_OUTPUT
           else
             CONTENT=$(sed -n "/^## \[$VERSION\]/,/^## \[/p" CHANGELOG.md | tail -n +2 | head -n -1)
-            echo "CONTENT<<EOF" >> $GITHUB_OUTPUT
+            DELIMITER=$(openssl rand -hex 8)
+            echo "CONTENT<<${DELIMITER}" >> $GITHUB_OUTPUT
             echo "$CONTENT" >> $GITHUB_OUTPUT
-            echo "EOF" >> $GITHUB_OUTPUT
+            echo "${DELIMITER}" >> $GITHUB_OUTPUT
           fi
 
   build-and-test:
@@ -76,7 +77,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: npm
 
       - name: Install dependencies
@@ -96,6 +97,7 @@ jobs:
         with:
           name: npm-package
           path: '*.tgz'
+          retention-days: 7
 
   create-tag:
     needs: [prepare, build-and-test]
@@ -133,25 +135,39 @@ jobs:
       url: https://www.npmjs.com/package/@eggai/qualops
 
     steps:
+      - name: Check if already published
+        id: check
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://registry.npmjs.org/@eggai%2fqualops/$VERSION)
+          echo "exists=$([ "$STATUS" = "200" ] && echo true || echo false)" >> $GITHUB_OUTPUT
+
       - name: Checkout repository
+        if: steps.check.outputs.exists == 'false'
         uses: actions/checkout@v6
 
       - name: Setup Node.js
+        if: steps.check.outputs.exists == 'false'
         uses: actions/setup-node@v6
         with:
           node-version: 22.x
           registry-url: https://registry.npmjs.org
 
       - name: Upgrade npm
+        if: steps.check.outputs.exists == 'false'
         run: npm install -g npm@latest
 
       - name: Install dependencies
+        if: steps.check.outputs.exists == 'false'
         run: npm ci
 
       - name: Build
+        if: steps.check.outputs.exists == 'false'
         run: npm run build
 
       - name: Publish to npm
+        if: steps.check.outputs.exists == 'false'
         run: npm publish --access public --provenance
 
       - name: Verify publish
@@ -174,25 +190,47 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v7
         with:
           name: npm-package
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ needs.prepare.outputs.version }}
-          name: v${{ needs.prepare.outputs.version }}
-          body: |
-            ## What's Changed
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          PRERELEASE: ${{ needs.prepare.outputs.prerelease }}
+          CHANGELOG_BODY: ${{ needs.prepare.outputs.changelog }}
+        run: |
+          if gh release view "v$VERSION" > /dev/null 2>&1; then
+            echo "Release v$VERSION already exists, uploading artifacts."
+            gh release upload "v$VERSION" *.tgz --clobber
+          else
+            PRERELEASE_FLAG=""
+            if [ "$PRERELEASE" = "true" ]; then
+              PRERELEASE_FLAG="--prerelease"
+            fi
+            printf '%s\n' "## What's Changed" "" "$CHANGELOG_BODY" "" "## Installation" "" '```bash' "npm install @eggai/qualops@$VERSION" '```' > /tmp/notes.md
+            gh release create "v$VERSION" *.tgz \
+              --title "v$VERSION" \
+              --notes-file /tmp/notes.md \
+              $PRERELEASE_FLAG
+          fi
 
-            ${{ needs.prepare.outputs.changelog }}
+  notify-failure:
+    needs: [prepare, build-and-test, create-tag, publish-npm, github-release]
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
 
-            ## Installation
-
-            ```bash
-            npm install @eggai/qualops@${{ needs.prepare.outputs.version }}
-            ```
-          files: '*.tgz'
-          draft: false
-          prerelease: ${{ needs.prepare.outputs.prerelease == 'true' }}
+    steps:
+      - name: Create failure issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "Release v$VERSION failed" \
+            --body "Workflow run: $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
+            --label "bug"


### PR DESCRIPTION
## Summary

Addresses high-priority findings from the security + DevOps review.

**Security fixes:**
- Fix `github.head_ref` script injection in ci.yml changelog check (Critical)
- Fix `github.base_ref` injection in disabled qualops job (for re-enablement)
- Fix `needs.*.result` injection pattern in all-checks-passed
- Fix EOF heredoc injection in changelog extraction (random delimiter)
- Remove unnecessary `contents: write` from dependabot-auto-merge
- Add `permissions: contents: read` to ci.yml

**Reliability fixes:**
- Replace `softprops/action-gh-release` with `gh release create` (removes third-party action with contents:write)
- Add npm pre-flight check (skip publish if version exists — idempotent retry)
- Add failure notification job (creates GitHub issue on release failure)
- Align upload-artifact/download-artifact to v7
- Add artifact retention (7 days)
- Use Node 22 consistently across all publish jobs

## Test plan

- [ ] CI passes
- [ ] Workflow YAML is valid