### PR TITLE
feat: agentic mode Phase 1 — SDK integration and multi-agent delegation

### DIFF
--- a/docs/RFC-001-agentic-mode.md
+++ b/docs/RFC-001-agentic-mode.md
@@ -1,6 +1,6 @@
 # RFC-001: QualOps Agentic Review Mode
 
-**Status:** Draft
+**Status:** Phase 1 shipped (PR #67)
 **Author:** Stefano Tucci
 **Date:** 2026-03-16
 **Version:** 0.3.0 target

--- a/docs/RFC-001-agentic-mode.md
+++ b/docs/RFC-001-agentic-mode.md
@@ -1,0 +1,781 @@
+# RFC-001: QualOps Agentic Review Mode
+
+**Status:** Draft
+**Author:** Stefano Tucci
+**Date:** 2026-03-16
+**Version:** 0.3.0 target
+
+---
+
+## 1. Executive Summary
+
+QualOps agentic mode replaces the file-by-file review model with an AI agent that **explores the codebase autonomously** — tracing dependencies, detecting breaking changes, validating patterns, and finding security vulnerabilities across file boundaries.
+
+The Claude Agent SDK (`@anthropic-ai/claude-agent-sdk`) is the execution engine. It already provides multi-agent orchestration, subagent lifecycle management, MCP tool servers, structured output, cost tracking, and abort control — out of the box. QualOps doesn't need to build an agent framework. It needs to **properly leverage the one it already depends on**.
+
+This RFC documents the current state (v0.2.0), the SDK capabilities we're not using, and the concrete plan to ship production-grade agentic review in v0.3.0.
+
+---
+
+## 2. SDK Viability Analysis
+
+### 2.1 What the Claude Agent SDK Provides
+
+After a deep audit of `@anthropic-ai/claude-agent-sdk@0.2.75`, here's what the SDK gives us and what QualOps currently uses:
+
+| SDK Capability | Available | QualOps Uses It |
+|---------------|-----------|-----------------|
+| `query()` — agent execution loop | ✅ | ✅ Basic usage |
+| `agents` — named subagent definitions | ✅ | ⚠️ Passed but never invoked |
+| `agent` — run main thread as a named agent | ✅ | ❌ Not used |
+| `AgentDefinition` with `tools`, `disallowedTools`, `model`, `maxTurns` | ✅ | ⚠️ Partial (missing `disallowedTools`, `maxTurns`) |
+| `outputFormat: { type: 'json_schema', schema }` — structured output | ✅ | ❌ Using regex parsing instead |
+| `SDKResultSuccess.total_cost_usd` — total cost tracking | ✅ | ❌ Not read |
+| `SDKResultSuccess.modelUsage` — per-model token breakdown | ✅ | ❌ Not read |
+| `SDKTaskNotificationMessage` — subagent completion with usage | ✅ | ❌ Not read |
+| `SDKTaskProgressMessage` — subagent progress with tokens | ✅ | ❌ Not read |
+| `SDKAssistantMessage.message.usage` — per-turn token usage | ✅ | ❌ Not read |
+| `abortController` — cancel execution mid-run | ✅ | ❌ Not used |
+| `allowDangerouslySkipPermissions` — required for `bypassPermissions` | ✅ | ❌ Missing (current code may silently fail) |
+| `createSdkMcpServer()` — in-process MCP tools | ✅ | ✅ 6 tools defined |
+| `tool()` with Zod schemas — typed tool definitions | ✅ | ✅ |
+| `mcpServers` — register MCP servers | ✅ | ✅ |
+| Per-agent `mcpServers` — agent-specific MCP servers | ✅ | ❌ Not used |
+| `Query.interrupt()` — graceful stop | ✅ | ❌ Not used |
+
+### 2.2 Verdict: Highly Viable
+
+The SDK is not just viable — it's **the right choice** and we already depend on it. The problem isn't the SDK. The problem is that 70% of its capabilities are unused. Specifically:
+
+1. **Multi-agent delegation works out of the box.** When you pass `agents` to `query()`, the SDK exposes an `Agent` tool to the main conversation. The coordinator invokes subagents by name, each runs in its own context with its own prompt/tools/model, and results flow back. We just need to tell the coordinator to use them.
+
+2. **Cost tracking is already computed.** `SDKResultSuccess` includes `total_cost_usd` and `modelUsage` broken down by model. We're ignoring both.
+
+3. **Structured output eliminates regex parsing.** The SDK supports `outputFormat: { type: 'json_schema', schema }` which forces JSON output and returns it in `structured_output`. No more regex extraction.
+
+4. **Budget enforcement = `abortController` + cost monitoring.** Read `total_cost_usd` from progress messages, abort when threshold is crossed.
+
+**Alternatives considered and rejected:**
+
+| Alternative | Why Not |
+|-------------|---------|
+| Raw Anthropic API + manual tool loop | Reimplements what the SDK does. 10x more code, same result. |
+| LangChain/LangGraph | Python-centric, massive dependency tree, over-engineered for this. |
+| Custom agent framework | Reinventing the wheel when the SDK already handles lifecycle, tools, subagents. |
+| OpenAI Agents SDK | Different ecosystem, would require abstracting away Claude-specific features. |
+
+### 2.3 SDK Message Stream — What We Get for Free
+
+The `query()` async generator yields typed messages. Here's how they map to QualOps needs:
+
+```typescript
+for await (const message of result) {
+  switch (message.type) {
+    case 'assistant':
+      // message.message: BetaMessage — includes usage.input_tokens, output_tokens
+      // → Accumulate for budget tracking
+      break;
+
+    case 'system':
+      if (message.subtype === 'task_started') {
+        // → Subagent launched (log which agent, track start time)
+      }
+      if (message.subtype === 'task_progress') {
+        // message.usage: { total_tokens, tool_uses, duration_ms }
+        // → Live progress reporting
+      }
+      if (message.subtype === 'task_notification') {
+        // message.status: 'completed' | 'failed' | 'stopped'
+        // message.summary: string — subagent's final output
+        // message.usage: { total_tokens, tool_uses, duration_ms }
+        // → Parse subagent results, track per-agent metrics
+      }
+      break;
+
+    case 'result':
+      if (message.subtype === 'success') {
+        // message.total_cost_usd: number — THE source of truth for cost
+        // message.modelUsage: Record<string, ModelUsage> — per-model breakdown
+        // message.structured_output: unknown — parsed JSON if outputFormat was set
+        // message.num_turns: number
+        // message.duration_ms: number
+        // → Final results + comprehensive metrics
+      }
+      break;
+  }
+}
+```
+
+### 2.4 SDK Type Definitions (Key Types)
+
+```typescript
+// What we get back per model
+type ModelUsage = {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadInputTokens: number;
+  cacheCreationInputTokens: number;
+  costUSD: number;
+  contextWindow: number;
+  maxOutputTokens: number;
+};
+
+// Final result
+type SDKResultSuccess = {
+  type: 'result';
+  subtype: 'success';
+  duration_ms: number;
+  num_turns: number;
+  result: string;
+  total_cost_usd: number;
+  usage: NonNullableUsage;        // aggregate
+  modelUsage: Record<string, ModelUsage>; // per-model
+  structured_output?: unknown;    // if outputFormat was set
+};
+
+// Subagent definition — what we pass in
+type AgentDefinition = {
+  description: string;
+  prompt: string;
+  tools?: string[];
+  disallowedTools?: string[];
+  model?: string;
+  mcpServers?: AgentMcpServerSpec[];
+  maxTurns?: number;
+};
+```
+
+---
+
+## 3. Current State (v0.2.0)
+
+### 3.1 What Works
+
+| Component | Status | Location |
+|-----------|--------|----------|
+| `AgenticExecutor` orchestrator | Implemented | `src/stages/review/agentic/agentic-executor.ts` |
+| 4 built-in subagents | Defined | `src/stages/review/agentic/subagents/definitions.ts` |
+| 6 MCP tools | Implemented | `src/stages/review/agentic/tools/index.ts` |
+| Custom agent loader (markdown) | Implemented | `src/stages/review/agentic/loaders/agent-loader.ts` |
+| Context preloading (diff/full/auto) | Implemented | `agentic-executor.ts:171-231` |
+| Pipeline integration | Wired | `pipeline-executor.ts` branches on `mode: 'agentic'` |
+| Validation/dedup post-processing | Shared | Same path as file-by-file |
+| Config schema (`AgenticConfig`) | Defined | `src/shared/types/config.ts:17-27` |
+| 2 example custom agents | Provided | `examples/agents/{rxjs-migration,angular-signals}.md` |
+
+### 3.2 Architecture (Current)
+
+```
+┌──────────────────────────────────────────────────────┐
+│                    PipelineExecutor                   │
+│                                                      │
+│  ┌─────────────────┐      ┌────────────────────────┐ │
+│  │  File-by-File   │      │   AgenticExecutor      │ │
+│  │  (FileReviewer) │      │                        │ │
+│  │                 │      │  ┌──────────────────┐  │ │
+│  │  Per-file       │      │  │  query() loop    │  │ │
+│  │  concurrent     │      │  │  Claude Agent SDK│  │ │
+│  │  rate-limited   │      │  └────────┬─────────┘  │ │
+│  │                 │      │           │            │ │
+│  │                 │      │  ┌────────▼─────────┐  │ │
+│  │                 │      │  │  MCP Tools (6)   │  │ │
+│  │                 │      │  │  Subagents (4)   │  │ │
+│  │                 │      │  │  Custom agents   │  │ │
+│  │                 │      │  └──────────────────┘  │ │
+│  └────────┬────────┘      └────────────┬───────────┘ │
+│           │                            │             │
+│           └────────────┬───────────────┘             │
+│                        ▼                             │
+│              ReviewIssue[] output                     │
+│                        │                             │
+│           ┌────────────▼───────────────┐             │
+│           │  Validation → Dedup        │             │
+│           └────────────────────────────┘             │
+└──────────────────────────────────────────────────────┘
+```
+
+### 3.3 Built-in Subagents
+
+| Agent | Model | Purpose | Tools |
+|-------|-------|---------|-------|
+| `dependency-tracer` | sonnet | Cross-file coupling, circular deps, import chains | trace_imports, find_usages |
+| `breaking-change-detector` | sonnet | API changes, export removals, signature modifications | git_diff_analysis, analyze_exports, find_interface_changes |
+| `security-analyzer` | sonnet | Injections, auth, secrets, crypto, path traversal | find_usages, trace_imports |
+| `pattern-validator` | haiku | Codebase pattern consistency, code smells | Read, Grep, Glob only |
+
+### 3.4 MCP Tools
+
+| Tool | Purpose |
+|------|---------|
+| `find_usages` | ripgrep word-match symbol search |
+| `trace_imports` | Extract import/export graph for a file |
+| `git_diff_analysis` | Detailed git diff between refs |
+| `analyze_exports` | Compare public exports across versions |
+| `find_interface_changes` | TypeScript interface/type diff |
+| `list_changed_files` | Changed files with A/M/D status |
+
+---
+
+## 4. Gap Analysis
+
+### 4.1 Critical Issues
+
+#### G1: Flat orchestration — no actual multi-agent delegation
+
+The system prompt says "You are a code reviewer" and instructs the agent to output JSON. The `agents` object is passed to `query()` but the prompt never tells the coordinator to delegate work to subagents. The SDK automatically exposes an `Agent` tool when `agents` are defined, but the coordinator prompt doesn't mention it.
+
+**Impact:** The 4 specialized agents never actually execute. The main agent does everything itself.
+
+**Fix:** Rewrite the coordinator system prompt to instruct triage → delegate → synthesize. The SDK handles everything else.
+
+#### G2: Budget enforcement is a no-op
+
+`maxBudgetUsd` is configured (default $10) but never checked. No `abortController` is created. No cost is read from the message stream.
+
+**Impact:** A stuck agent loop could burn unlimited tokens.
+
+**Fix:** Create an `AbortController`, monitor `SDKAssistantMessage.message.usage` and `SDKTaskProgressMessage.usage` in the stream, call `abort()` when `total_cost_usd` approaches limit.
+
+#### G3: Token tracking disconnected
+
+The agentic executor doesn't report token usage back to `SessionContext`. The `SDKResultSuccess` contains `total_cost_usd`, `usage`, and `modelUsage` but none of it is captured. Agentic runs show as $0.00 in reports.
+
+**Impact:** No cost visibility. No comparison between file-by-file and agentic costs.
+
+**Fix:** Read `SDKResultSuccess.total_cost_usd` and `modelUsage`, feed into `SessionContext.addStageTokenStats()`.
+
+#### G4: 3 of 6 MCP tools missing from `allowedTools`
+
+`allowedTools` includes `find_usages`, `git_diff_analysis`, `list_changed_files`. Missing: `trace_imports`, `analyze_exports`, `find_interface_changes`.
+
+**Impact:** The dependency-tracer and breaking-change-detector subagents reference tools they can't call.
+
+**Fix:** Add the 3 missing tool names. One line.
+
+#### G5: `allowDangerouslySkipPermissions` not set
+
+The code passes `permissionMode: 'bypassPermissions'` but doesn't set `allowDangerouslySkipPermissions: true`. The SDK requires both — without the flag, permission bypass may silently fail or throw.
+
+**Fix:** Add `allowDangerouslySkipPermissions: true` to the options.
+
+#### G6: Structured output not used
+
+Issues are extracted via regex (`/```json...```/`). The SDK supports `outputFormat: { type: 'json_schema', schema }` which forces JSON and returns parsed output in `structured_output`.
+
+**Fix:** Define a JSON schema for the issues array, pass as `outputFormat`, read from `structured_output`.
+
+### 4.2 Robustness Issues
+
+| ID | Issue | Impact |
+|----|-------|--------|
+| G7 | No tests — zero coverage for agentic module | Can't refactor safely |
+| G8 | No error recovery — failure at turn 80 loses all findings | Wasted budget |
+| G9 | No progress feedback — just debug logs | Blind CI runs |
+
+### 4.3 Missing Features
+
+| ID | Feature | Value |
+|----|---------|-------|
+| G10 | No per-subagent metrics (all attributed to job) | Can't optimize cost per agent |
+| G11 | No smart agent activation (all agents run always) | Wasted budget on irrelevant agents |
+| G12 | No agent chaining (subagents can't feed each other) | Misses compound insights |
+
+---
+
+## 5. Proposed Architecture (v0.3.0)
+
+### 5.1 Coordinator-Delegates Pattern (SDK-Native)
+
+The SDK already implements multi-agent orchestration. When you pass `agents` to `query()`, the SDK:
+
+1. Exposes an `Agent` tool to the main conversation
+2. When the coordinator calls `Agent(name="security-analyzer", prompt="Review these files...")`, the SDK spawns a new Claude conversation with that agent's system prompt, tools, and model
+3. The subagent runs autonomously — making tool calls, reading files, exploring
+4. The subagent's final output flows back to the coordinator as the tool result
+5. The coordinator synthesizes all subagent outputs into the final answer
+
+**We don't need to build any of this.** We need to write the right coordinator prompt.
+
+```
+                         ┌───────────────────┐
+                         │    Coordinator     │
+                         │    (sonnet/opus)   │
+                         │                    │
+                         │  1. Read diffs     │
+                         │  2. Triage files   │
+                         │  3. Delegate       │──── SDK Agent tool
+                         │  4. Synthesize     │
+                         └────────┬──────────┘
+                                  │
+              ┌───────────────────┼───────────────────┐
+              │                   │                   │
+    ┌─────────▼────────┐ ┌───────▼────────┐ ┌────────▼───────┐
+    │ dependency-tracer │ │ security-      │ │ pattern-       │
+    │ (sonnet)          │ │ analyzer       │ │ validator      │
+    │                   │ │ (sonnet)       │ │ (haiku)        │
+    │ Tools:            │ │ Tools:         │ │ Tools:         │
+    │ · trace_imports   │ │ · find_usages  │ │ · Read         │
+    │ · find_usages     │ │ · trace_imports│ │ · Grep         │
+    │ · Read, Grep      │ │ · Read, Grep   │ │ · Glob         │
+    └─────────┬─────────┘ └───────┬────────┘ └────────┬───────┘
+              │                   │                   │
+              └───────────────────┼───────────────────┘
+                                  │
+                    ┌─────────────▼─────────────┐
+                    │  Coordinator synthesizes:  │
+                    │  · Merge findings          │
+                    │  · Resolve overlaps        │
+                    │  · Rank by severity        │
+                    │  · Output structured JSON  │
+                    └───────────────────────────┘
+                                  │
+                    ┌─────────────▼─────────────┐
+                    │  QualOps post-processing:  │
+                    │  · Validation pass         │
+                    │  · Deduplication pass       │
+                    │  · Report generation       │
+                    └───────────────────────────┘
+```
+
+### 5.2 The Coordinator Prompt
+
+This is the most important change. The current prompt is a generic "review code, output JSON." The new prompt makes the agent an **orchestrator**:
+
+```markdown
+You are a code review coordinator. Your job is to analyze changed files and
+delegate specialized analysis to subagents.
+
+## Available Subagents
+
+You have access to specialized agents via the Agent tool. Each agent has
+deep expertise in a specific domain:
+
+{dynamically list enabled subagents with descriptions}
+
+## Process
+
+1. **Analyze the diffs** — understand what changed and categorize the changes
+2. **Decide which agents are relevant** — don't invoke agents that have nothing
+   to review (e.g., skip security-analyzer for pure CSS changes)
+3. **Delegate** — invoke each relevant agent via the Agent tool. Include:
+   - The specific files they should focus on
+   - The diffs/context for those files
+   - Any cross-cutting concerns they should watch for
+4. **Synthesize** — collect all agent findings, remove duplicates, resolve
+   conflicts (if agents disagree), and rank by severity/impact
+
+## Rules
+
+- Only invoke agents that are relevant to the changes
+- Each agent returns issues as JSON — pass their output through as-is
+- If agents find conflicting issues, keep the higher-confidence one
+- Your final output must be a JSON array of all issues
+- Do NOT add your own issues — only report what subagents found
+- If no agents are relevant (trivial change), return []
+```
+
+### 5.3 Budget Enforcement via AbortController
+
+```typescript
+const abortController = new AbortController();
+let accumulatedCost = 0;
+
+const result = query({
+  prompt: userPrompt,
+  options: {
+    abortController,
+    // ...
+  },
+});
+
+for await (const message of result) {
+  // Track cost from assistant messages
+  if (message.type === 'assistant' && message.message?.usage) {
+    const usage = message.message.usage;
+    accumulatedCost += estimateCostFromUsage(usage);
+  }
+
+  // Track cost from subagent progress
+  if (message.type === 'system' && message.subtype === 'task_progress') {
+    // SDK provides running totals
+  }
+
+  // Budget gate
+  if (accumulatedCost >= this.config.maxBudgetUsd) {
+    logger.warn(`[Agentic] Budget exhausted ($${accumulatedCost.toFixed(2)}/${this.config.maxBudgetUsd})`);
+    abortController.abort();
+    break; // Keep partial results
+  }
+
+  // ... process messages
+}
+
+// Final cost from SDK (source of truth)
+if (message.type === 'result' && message.subtype === 'success') {
+  accumulatedCost = message.total_cost_usd; // overwrite estimate with real
+}
+```
+
+### 5.4 Structured Output (No More Regex)
+
+```typescript
+const issueSchema = {
+  type: 'object',
+  properties: {
+    issues: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          type: { type: 'string', enum: ['security', 'bug', 'performance', 'maintainability'] },
+          severity: { type: 'string', enum: ['critical', 'high', 'medium', 'low'] },
+          description: { type: 'string' },
+          location: { type: 'string' },
+          reasoning: { type: 'string' },
+          suggestion: { type: 'string' },
+          confidence: { type: 'number', minimum: 1, maximum: 10 },
+        },
+        required: ['type', 'severity', 'description', 'location', 'confidence'],
+      },
+    },
+  },
+  required: ['issues'],
+};
+
+const result = query({
+  prompt: userPrompt,
+  options: {
+    outputFormat: { type: 'json_schema', schema: issueSchema },
+    // ...
+  },
+});
+
+// In result handler:
+if (message.type === 'result' && message.subtype === 'success') {
+  const output = message.structured_output as { issues: RawIssue[] };
+  // No regex. No parsing. Guaranteed valid JSON.
+}
+```
+
+### 5.5 Per-Subagent Metrics via Task Messages
+
+```typescript
+const subagentMetrics: Record<string, SubagentMetric> = {};
+
+for await (const message of result) {
+  if (message.type === 'system' && message.subtype === 'task_started') {
+    subagentMetrics[message.task_id] = { startTime: Date.now() };
+  }
+
+  if (message.type === 'system' && message.subtype === 'task_notification') {
+    const metric = subagentMetrics[message.task_id];
+    if (metric) {
+      metric.status = message.status;          // 'completed' | 'failed'
+      metric.summary = message.summary;         // subagent's output
+      metric.totalTokens = message.usage?.total_tokens;
+      metric.toolUses = message.usage?.tool_uses;
+      metric.durationMs = message.usage?.duration_ms;
+    }
+  }
+}
+```
+
+### 5.6 Token Tracking → SessionContext
+
+```typescript
+// After query completes
+if (resultMessage.subtype === 'success') {
+  const { total_cost_usd, modelUsage, num_turns, duration_ms } = resultMessage;
+
+  // Aggregate into SessionContext
+  let totalInput = 0, totalOutput = 0, totalCached = 0;
+  for (const [model, usage] of Object.entries(modelUsage)) {
+    totalInput += usage.inputTokens;
+    totalOutput += usage.outputTokens;
+    totalCached += usage.cacheReadInputTokens;
+  }
+
+  SessionContext.getInstance().addStageTokenStats(
+    'review-agentic',
+    num_turns,
+    totalInput,
+    totalOutput,
+    totalCached,
+    total_cost_usd,
+  );
+}
+```
+
+---
+
+## 6. Implementation Plan
+
+### Phase 1: Make It Actually Work (v0.3.0-alpha)
+
+Everything in Phase 1 is about properly using SDK capabilities that already exist.
+
+| # | Task | What Changes | Effort |
+|---|------|-------------|--------|
+| 1.1 | Add 3 missing MCP tools to `allowedTools` | 1 line in `agentic-executor.ts` | 5 min |
+| 1.2 | Add `allowDangerouslySkipPermissions: true` | 1 line in `agentic-executor.ts` | 5 min |
+| 1.3 | Rewrite coordinator system prompt | `buildSystemPrompt()` method | 2 hrs |
+| 1.4 | Add `outputFormat` with JSON schema | Options + result reading | 1 hr |
+| 1.5 | Read `SDKResultSuccess` metrics into `SessionContext` | Message stream handler | 2 hrs |
+| 1.6 | Implement `AbortController` budget enforcement | Message stream + abort logic | 2 hrs |
+| 1.7 | Capture `SDKTaskNotificationMessage` for per-subagent results | Message stream handler | 2 hrs |
+| 1.8 | Preserve partial results on abort/failure | Collect issues incrementally | 1 hr |
+
+**Total: ~10 hours of work. No new dependencies. No new abstractions.**
+
+### Phase 2: Robustness (v0.3.0-beta)
+
+| # | Task | Effort |
+|---|------|--------|
+| 2.1 | Unit tests for `AgenticExecutor` (mock `query()` stream) | 4 hrs |
+| 2.2 | Unit tests for MCP tools | 3 hrs |
+| 2.3 | Unit tests for `AgentLoader` | 2 hrs |
+| 2.4 | Integration test: real agent run on fixture codebase | 4 hrs |
+| 2.5 | Progress reporting via `SDKTaskProgressMessage` | 2 hrs |
+| 2.6 | Per-subagent metrics in HTML/JSON reports | 3 hrs |
+| 2.7 | Agent transcript saving to session dir | 2 hrs |
+
+### Phase 3: Intelligence (v0.3.0)
+
+| # | Task | Effort |
+|---|------|--------|
+| 3.1 | Smart triage in coordinator prompt (already free — it's just prompt engineering) | 1 hr |
+| 3.2 | Per-subagent `maxTurns` enforcement (SDK supports it natively) | 30 min |
+| 3.3 | Custom agent `mcpServers` support (SDK supports per-agent MCP) | 2 hrs |
+| 3.4 | `disallowedTools` per subagent (SDK supports it natively) | 30 min |
+| 3.5 | Agent result caching via extract log | 4 hrs |
+
+### Phase 4: Ecosystem (v0.4.0+)
+
+| # | Task | Effort |
+|---|------|--------|
+| 4.1 | `qualops agent init` CLI — scaffold custom agent markdown | 2 hrs |
+| 4.2 | Agent chaining via coordinator prompt engineering | 4 hrs |
+| 4.3 | User-defined MCP servers in config | 4 hrs |
+| 4.4 | Agentic fix stage (agent generates fixes with full context) | Large |
+| 4.5 | Agent sharing/marketplace (curated `.qualops/agents/` collections) | Large |
+
+---
+
+## 7. Configuration
+
+### Current (v0.2.0)
+
+```json
+{
+  "name": "security-audit",
+  "mode": "agentic",
+  "agentic": {
+    "maxTurns": 20,
+    "maxBudgetUsd": 5.0,
+    "enabledSubagents": ["security-analyzer", "dependency-tracer"],
+    "systemPrompt": "Focus on OWASP Top 10"
+  }
+}
+```
+
+### v0.3.0 (Minimal Config Changes)
+
+The config shape stays mostly the same. The big changes are internal (how we use the SDK).
+
+```json
+{
+  "name": "security-audit",
+  "mode": "agentic",
+  "agentic": {
+    "maxTurns": 50,
+    "maxBudgetUsd": 3.0,
+    "model": "sonnet",
+    "enabledSubagents": ["security-analyzer", "dependency-tracer"],
+    "systemPrompt": "Focus on OWASP Top 10",
+    "contextMode": "auto",
+    "maxTokensPerFile": 8000,
+    "maxTotalTokens": 50000
+  }
+}
+```
+
+New fields:
+- `model` — coordinator model (subagent models come from their definitions)
+
+### v0.4.0+ (Extended)
+
+```json
+{
+  "name": "full-review",
+  "mode": "agentic",
+  "agentic": {
+    "maxBudgetUsd": 5.0,
+    "model": "sonnet",
+    "enabledSubagents": ["security-analyzer", "dependency-tracer", "pattern-validator"],
+    "customAgents": [
+      {
+        "name": "rxjs-migration",
+        "agentFile": "rxjs-migration.md"
+      }
+    ],
+    "customMcpServers": {
+      "my-linter": { "command": "npx", "args": ["my-mcp-linter"] }
+    }
+  }
+}
+```
+
+---
+
+## 8. Cost Model
+
+### Per-Review Estimates
+
+| Scenario | Agents Active | Est. Cost | vs File-by-File |
+|----------|--------------|-----------|-----------------|
+| Small PR (5 files, diffs) | 1-2 | $0.10–0.25 | 2-5x more |
+| Medium PR (20 files) | 2-3 | $0.30–0.80 | 5-10x more |
+| Large PR (50+ files) | 3-4 | $1.00–2.50 | 10-20x more |
+| Deep security audit | all | $1.50–3.00 | 15-30x more |
+
+### Why It's Worth It
+
+File-by-file reviews **cannot detect**:
+- Circular dependency introduced by a new import
+- Breaking change where a renamed export is used in 12 other files
+- Security issue where user input flows through 3 files before hitting `eval()`
+- Pattern violation only visible by comparing with 5 similar files
+
+Agentic mode catches these because subagents can explore the codebase, trace dependencies, and cross-reference.
+
+### Cost Controls
+
+| Control | Mechanism | Savings |
+|---------|-----------|---------|
+| Budget cap | `AbortController` abort at threshold | Hard limit |
+| Smart triage | Coordinator skips irrelevant agents | ~50-80% on small PRs |
+| Haiku for pattern-validator | Cheap model for simple pattern matching | ~10x per agent |
+| Diff-only context | `contextMode: "diff"` reduces prompt size | ~60% input tokens |
+| Per-subagent `maxTurns` | Prevent individual agent loops | Bounds worst case |
+| Extract log caching | Skip unchanged files across runs | Variable |
+
+---
+
+## 9. Success Criteria
+
+### v0.3.0 Release Gate
+
+- [ ] Coordinator delegates to subagents (verified: `task_started` + `task_notification` messages in logs)
+- [ ] Budget enforcement aborts at configured limit (test: set $0.10 budget, verify abort)
+- [ ] `total_cost_usd` and `modelUsage` appear in session reports
+- [ ] All 6 MCP tools callable (verified: subagent tool call logs)
+- [ ] Structured output — no regex JSON parsing
+- [ ] Partial results preserved on abort/error
+- [ ] Unit test coverage > 80% for agentic module
+- [ ] 1+ integration test with real agent run
+
+### Quality Metrics (ongoing)
+
+- False positive rate < 15%
+- Cross-file issue detection ≥ 1 per 20-file PR (when applicable)
+- Cost per actionable issue < $0.50
+- Agent completion rate > 95%
+
+---
+
+## 10. Risks
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Agent loops (repetitive tool calls) | Medium | High | Budget enforcement + per-agent `maxTurns` |
+| SDK breaking changes (v0.2.x → v1.0) | Medium | Medium | Pin exact version, integration tests, watch changelog |
+| Subagent prompt quality (false positives) | Medium | Medium | Validation pass + confidence thresholds + prompt iteration |
+| Cost perception ("too expensive for CI") | High | Medium | Smart triage, diff-only, clear cost reporting, budget defaults |
+| Coordinator doesn't delegate (ignores Agent tool) | Low | High | Explicit prompt engineering, integration test verification |
+| Agent hallucinating file paths | Medium | Low | Post-validation checks (file exists, line in range) |
+
+---
+
+## 11. Open Questions
+
+1. **Default budget?** Current: $10. Proposal: $3. Most PR reviews cost < $1.
+
+2. **Coordinator model?** Sonnet is the sweet spot (smart enough to triage, cheap enough for CI). Opus for high-stakes audits.
+
+3. **Should the coordinator add its own findings?** Current proposal says no — only relay subagent findings. But the coordinator sees the full picture. Maybe allow a "coordinator pass" for cross-cutting observations.
+
+4. **Agentic fix stage?** An agent that generates fixes with full codebase context would be powerful. Defer to v0.4.0.
+
+5. **Raw transcripts?** Save full agent conversation to session dir for debugging? Proposal: yes, opt-in via `reporting.includeTranscript`.
+
+---
+
+## Appendix A: File Map
+
+```
+src/stages/review/agentic/
+├── agentic-executor.ts      # Main orchestrator (query() loop)
+├── index.ts                 # Public exports
+├── types.ts                 # AgenticReviewContext, SubagentResult, etc.
+├── loaders/
+│   ├── agent-loader.ts      # Custom agent loading (markdown + inline)
+│   └── index.ts
+├── subagents/
+│   ├── definitions.ts       # 4 built-in subagent prompts + tools
+│   └── index.ts
+└── tools/
+    └── index.ts             # MCP server with 6 code analysis tools
+
+examples/agents/
+├── rxjs-migration.md        # Example custom agent
+└── angular-signals.md       # Example custom agent
+```
+
+## Appendix B: SDK Surface Used
+
+```
+@anthropic-ai/claude-agent-sdk@0.2.75
+
+Imports:
+  query()                  — Agent execution loop (async generator)
+  tool()                   — Define typed MCP tool with Zod schema
+  createSdkMcpServer()     — Create in-process MCP server
+
+Types consumed from SDK:
+  AgentDefinition          — Subagent definition shape
+  SDKMessage               — Union of all message types
+  SDKResultSuccess         — Final result with cost/usage/structured_output
+  SDKAssistantMessage      — Per-turn message with BetaMessage.usage
+  SDKTaskNotificationMessage — Subagent completion event
+  SDKTaskProgressMessage   — Subagent progress event
+  ModelUsage               — Per-model token/cost breakdown
+
+Options used:
+  agents                   — Named subagent definitions
+  allowedTools             — Auto-approved tool list
+  mcpServers               — MCP server registration
+  maxTurns                 — Turn limit
+  permissionMode           — 'bypassPermissions' for CI
+  allowDangerouslySkipPermissions — Required for bypass
+  abortController          — Budget enforcement / graceful stop
+  outputFormat             — JSON schema for structured output
+  cwd                      — Working directory
+```
+
+## Appendix C: What We Don't Need to Build
+
+Things the SDK handles that we'd otherwise have to implement:
+
+| Capability | SDK Provides | If We Built It |
+|-----------|-------------|----------------|
+| Agent tool-calling loop | `query()` async generator | 200+ lines of API calls + retry logic |
+| Subagent spawning + lifecycle | `agents` option + Agent tool | Custom process management, context isolation |
+| MCP tool serving | `createSdkMcpServer()` | Standalone MCP server process + stdio transport |
+| Permission management | `permissionMode` + `canUseTool` | Custom permission system |
+| Abort/cancel | `AbortController` support | Signal propagation through async chains |
+| Structured output | `outputFormat` + `structured_output` | JSON parsing + validation + retry on malformed |
+| Cost tracking | `total_cost_usd` + `modelUsage` | Manual token counting + pricing tables |
+| Progress events | `SDKTaskProgressMessage` | Custom event system |
+| Model routing per agent | `model` in `AgentDefinition` | Multi-provider routing logic |
+
+**Estimated savings: 1000+ lines of framework code we don't have to write or maintain.**

--- a/qualops-llm.txt
+++ b/qualops-llm.txt
@@ -248,19 +248,82 @@ Each stage (`reviewStage`, `fixStage`, `judgeStage`) has the same shape:
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `maxTurns` | number | 100 | Maximum agent conversation turns |
-| `maxBudgetUsd` | number | 10.0 | Cost limit for agentic session |
-| `contextMode` | `"diff"` \| `"full"` \| `"auto"` | — | How file context is provided |
-| `maxTokensPerFile` | number | — | Token limit per file in context |
-| `maxTotalTokens` | number | — | Total token limit for context |
-| `enabledSubagents` | string[] | all four | Which built-in subagents to use |
-| `customAgents` | CustomAgent[] | — | Additional custom agents |
-| `agentsDir` | string | `".qualops/agents"` | Directory for agent definition files |
-| `systemPrompt` | string | — | Custom system prompt for the review |
+| `maxTurns` | number | 100 | Maximum coordinator conversation turns |
+| `maxBudgetUsd` | number | 3.0 | Cost limit — aborts via AbortController when reached |
+| `model` | string | — | Coordinator model override |
+| `contextMode` | `"diff"` \| `"full"` \| `"auto"` | `"auto"` | How file context is provided to coordinator |
+| `maxTokensPerFile` | number | 8000 | Token limit per file in context |
+| `maxTotalTokens` | number | 50000 | Total token limit for all file context |
+| `enabledSubagents` | string[] | all four | Which built-in subagents to activate |
+| `coordinatorPrompt` | string | — | Path to markdown file that fully replaces the default coordinator prompt |
+| `systemPrompt` | string | — | Extra instructions appended to the default coordinator prompt (ignored if `coordinatorPrompt` is set) |
+| `subagentOverrides` | Record<string, SubagentOverride> | — | Per-subagent field patches (model, tools, maxTurns, etc.) |
+| `customAgents` | CustomAgent[] | — | Additional inline custom agents |
+| `agentsDir` | string | `".qualops/agents"` | Directory for agent definition markdown files |
 
-Built-in subagents: `"dependency-tracer"`, `"breaking-change-detector"`, `"security-analyzer"`, `"pattern-validator"`
+#### Built-in subagents
 
-Custom agent shape:
+| Name | Default Model | Default maxTurns | Tools |
+|------|--------------|-----------------|-------|
+| `dependency-tracer` | sonnet | 20 | Read, Grep, Glob |
+| `breaking-change-detector` | sonnet | 25 | Read, Grep, Glob, git_diff, git_show, list_changed_files |
+| `security-analyzer` | sonnet | 20 | Read, Grep, Glob |
+| `pattern-validator` | haiku | 10 | Read, Grep, Glob |
+
+#### MCP tools available to agents
+
+| Tool | Description |
+|------|-------------|
+| `mcp__qualops-agentic-tools__git_diff` | Git diff between refs, optional file filter and stat mode |
+| `mcp__qualops-agentic-tools__git_show` | Show file contents at a specific git ref |
+| `mcp__qualops-agentic-tools__list_changed_files` | List files changed between refs with A/M/D status |
+
+#### Prompt override tiers
+
+**Coordinator prompt** (3 tiers):
+1. No config → hardcoded default with dynamic agent list
+2. `"systemPrompt": "Focus on OWASP"` → default + appended instructions
+3. `"coordinatorPrompt": ".qualops/prompts/coordinator.md"` → file replaces everything
+
+**Subagent prompts** (3 tiers):
+1. No config → hardcoded defaults
+2. `"subagentOverrides": { "security-analyzer": { "model": "opus", "maxTurns": 15 } }` → patches fields, keeps default prompt
+3. Create `.qualops/agents/security-analyzer.md` → full replacement (custom agents override built-ins by name)
+
+#### SubagentOverride shape
+
+```json
+{
+  "security-analyzer": {
+    "prompt": ".qualops/prompts/owasp-security.md",
+    "model": "opus",
+    "maxTurns": 15,
+    "tools": ["Read", "Grep", "Glob"],
+    "disallowedTools": ["mcp__qualops-agentic-tools__git_diff"]
+  }
+}
+```
+
+All fields are optional — only specified fields override the default.
+
+#### Custom agent markdown format
+
+Place in `.qualops/agents/` directory (or custom `agentsDir`):
+
+```markdown
+---
+description: Analyzes Flask applications for OWASP vulnerabilities
+tools: [Read, Grep, Glob]
+model: sonnet
+---
+
+You are a Flask security specialist...
+```
+
+To override a built-in subagent, name the file the same as the built-in (e.g., `.qualops/agents/security-analyzer.md`).
+
+#### Inline custom agent shape
+
 ```json
 {
   "name": "migration-checker",
@@ -271,7 +334,7 @@ Custom agent shape:
 }
 ```
 
-Model options for custom agents: `"sonnet"`, `"opus"`, `"haiku"`
+Model options: `"sonnet"`, `"opus"`, `"haiku"`
 
 ## PROMPT AUTHORING
 
@@ -677,13 +740,14 @@ Use file-by-file mode for: simple code quality checks, single-file analysis, hig
         "enabled": true,
         "mode": "agentic",
         "agentic": {
-          "maxTurns": 15,
-          "maxBudgetUsd": 5.0,
+          "maxTurns": 30,
+          "maxBudgetUsd": 3.0,
           "contextMode": "auto",
-          "maxTokensPerFile": 8000,
-          "maxTotalTokens": 50000,
           "enabledSubagents": ["security-analyzer", "dependency-tracer"],
-          "systemPrompt": "You are a security-focused code reviewer. Focus on:\n1. Command injection vulnerabilities\n2. Path traversal in file operations\n3. Credential exposure in logs\n4. Unsafe deserialization\n5. Cross-file security implications"
+          "systemPrompt": "Focus on OWASP Top 10 and cross-file security implications",
+          "subagentOverrides": {
+            "security-analyzer": { "model": "opus", "maxTurns": 15 }
+          }
         },
         "validation": {
           "enabled": true,
@@ -716,10 +780,11 @@ You can run both modes in the same pipeline:
         "enabled": true,
         "mode": "agentic",
         "agentic": {
-          "maxTurns": 15,
+          "maxTurns": 30,
+          "maxBudgetUsd": 3.0,
           "contextMode": "auto",
           "enabledSubagents": ["security-analyzer", "dependency-tracer"],
-          "systemPrompt": "Focus on cross-file security implications..."
+          "systemPrompt": "Focus on cross-file security implications"
         }
       },
       {

--- a/src/shared/types/config.ts
+++ b/src/shared/types/config.ts
@@ -17,6 +17,7 @@ export interface CustomAgentDefinition {
 export interface AgenticConfig {
   maxTurns?: number;
   maxBudgetUsd?: number;
+  model?: string;
   enabledSubagents?: AgenticSubagentType[];
   customAgents?: CustomAgentDefinition[];
   agentsDir?: string;

--- a/src/shared/types/config.ts
+++ b/src/shared/types/config.ts
@@ -14,6 +14,15 @@ export interface CustomAgentDefinition {
   model?: 'sonnet' | 'opus' | 'haiku';
 }
 
+export interface SubagentOverride {
+  prompt?: string;
+  description?: string;
+  model?: string;
+  tools?: string[];
+  disallowedTools?: string[];
+  maxTurns?: number;
+}
+
 export interface AgenticConfig {
   maxTurns?: number;
   maxBudgetUsd?: number;
@@ -21,7 +30,9 @@ export interface AgenticConfig {
   enabledSubagents?: AgenticSubagentType[];
   customAgents?: CustomAgentDefinition[];
   agentsDir?: string;
+  coordinatorPrompt?: string;
   systemPrompt?: string;
+  subagentOverrides?: Record<string, SubagentOverride>;
   contextMode?: 'diff' | 'full' | 'auto';
   maxTokensPerFile?: number;
   maxTotalTokens?: number;

--- a/src/stages/review/agentic/agentic-executor.ts
+++ b/src/stages/review/agentic/agentic-executor.ts
@@ -1,3 +1,6 @@
+import { readFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+
 import {
   query,
   type AgentDefinition as SDKAgentDefinition,
@@ -95,6 +98,7 @@ export class AgenticExecutor {
 
     const toolServer = createAgenticTools(this.cwd);
     const builtInAgents = createSubagentDefinitions(this.config);
+    this.applySubagentOverrides(builtInAgents);
     const customAgents = this.agentLoader.loadCustomAgents(this.config);
     const allAgents: Record<string, AgentDefinition> = { ...builtInAgents, ...customAgents };
 
@@ -313,7 +317,41 @@ export class AgenticExecutor {
     }
   }
 
+  private applySubagentOverrides(agents: Record<string, AgentDefinition>): void {
+    const overrides = this.config.subagentOverrides;
+    if (!overrides) return;
+
+    for (const [name, override] of Object.entries(overrides)) {
+      if (!agents[name]) continue;
+
+      if (override.prompt) {
+        const promptPath = resolve(this.cwd, override.prompt);
+        if (existsSync(promptPath)) {
+          agents[name].prompt = readFileSync(promptPath, 'utf-8');
+          logger.info(`[Agentic] Overriding ${name} prompt from ${override.prompt}`);
+        } else {
+          logger.warn(`[Agentic] Prompt override not found: ${promptPath}`);
+        }
+      }
+
+      if (override.description) agents[name].description = override.description;
+      if (override.model) agents[name].model = override.model as AgentDefinition['model'];
+      if (override.tools) agents[name].tools = override.tools;
+      if (override.disallowedTools) agents[name].disallowedTools = override.disallowedTools;
+      if (override.maxTurns) agents[name].maxTurns = override.maxTurns;
+    }
+  }
+
   private buildSystemPrompt(allAgents: Record<string, AgentDefinition>): string {
+    if (this.config.coordinatorPrompt) {
+      const promptPath = resolve(this.cwd, this.config.coordinatorPrompt);
+      if (existsSync(promptPath)) {
+        logger.info(`[Agentic] Using coordinator prompt from ${this.config.coordinatorPrompt}`);
+        return readFileSync(promptPath, 'utf-8');
+      }
+      logger.warn(`[Agentic] Coordinator prompt not found: ${promptPath}, using default`);
+    }
+
     const customPrompt = this.config.systemPrompt || '';
     const agentList = Object.entries(allAgents)
       .map(([name, def]) => `- **${name}**: ${def.description}`)

--- a/src/stages/review/agentic/agentic-executor.ts
+++ b/src/stages/review/agentic/agentic-executor.ts
@@ -1,15 +1,23 @@
-import { query } from '@anthropic-ai/claude-agent-sdk';
+import {
+  query,
+  type AgentDefinition as SDKAgentDefinition,
+  type SDKMessage,
+  type SDKResultSuccess,
+  type SDKAssistantMessage,
+  type SDKTaskNotificationMessage,
+} from '@anthropic-ai/claude-agent-sdk';
 
 import { AgentLoader } from './loaders/agent-loader';
 import { createSubagentDefinitions, type AgentDefinition } from './subagents/definitions';
 import { createAgenticTools } from './tools';
+import { addStageTokenStats } from '../../../shared/runtime/session-context';
 import type { ReviewIssue } from '../../../shared/types';
 import type { FileInfo, PipelineJob, AgenticConfig } from '../../../shared/types/config';
 import { logger } from '../../../shared/utils/logger';
 
 const DEFAULT_CONFIG: AgenticConfig = {
   maxTurns: 100,
-  maxBudgetUsd: 10.0,
+  maxBudgetUsd: 3.0,
   enabledSubagents: [
     'dependency-tracer',
     'breaking-change-detector',
@@ -20,6 +28,49 @@ const DEFAULT_CONFIG: AgenticConfig = {
   agentsDir: '.qualops/agents',
   systemPrompt: '',
 };
+
+const ISSUE_SCHEMA = {
+  type: 'object',
+  properties: {
+    issues: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          type: { type: 'string', enum: ['security', 'bug', 'performance', 'maintainability'] },
+          severity: { type: 'string', enum: ['critical', 'high', 'medium', 'low'] },
+          description: { type: 'string' },
+          location: { type: 'string' },
+          reasoning: { type: 'string' },
+          suggestion: { type: 'string' },
+          confidence: { type: 'number' },
+        },
+        required: ['type', 'severity', 'description', 'location', 'confidence'],
+      },
+    },
+  },
+  required: ['issues'],
+};
+
+interface SubagentMetric {
+  agentName: string;
+  status?: string;
+  summary?: string;
+  totalTokens?: number;
+  toolUses?: number;
+  durationMs?: number;
+}
+
+interface RawIssue {
+  type?: string;
+  severity?: string;
+  description?: string;
+  location?: string;
+  reasoning?: string;
+  suggestion?: string;
+  confidence?: number;
+  context?: string;
+}
 
 export class AgenticExecutor {
   private config: AgenticConfig;
@@ -35,8 +86,7 @@ export class AgenticExecutor {
   }
 
   async execute(files: FileInfo[]): Promise<ReviewIssue[]> {
-    logger.info(`[Agentic] Starting agentic review for job: ${this.job.name}`);
-    logger.info(`[Agentic] Files to review: ${files.length}`);
+    logger.info(`[Agentic] Starting review for job: ${this.job.name} (${files.length} files)`);
 
     if (files.length === 0) {
       logger.info('[Agentic] No files to review');
@@ -44,128 +94,256 @@ export class AgenticExecutor {
     }
 
     const toolServer = createAgenticTools(this.cwd);
-
-    // Load built-in subagents
     const builtInAgents = createSubagentDefinitions(this.config);
-
-    // Load custom agents from config and files
     const customAgents = this.agentLoader.loadCustomAgents(this.config);
-
-    // Merge all agents (custom agents can override built-in)
     const allAgents: Record<string, AgentDefinition> = { ...builtInAgents, ...customAgents };
 
-    const agentNames = Object.keys(allAgents);
-    logger.info(`[Agentic] Available agents: ${agentNames.join(', ')}`);
-    logger.info(`[Agentic] Custom agents: ${Object.keys(customAgents).join(', ') || 'none'}`);
-
-    const _enabledSubagents = this.config.enabledSubagents || [];
+    logger.info(`[Agentic] Agents: ${Object.keys(allAgents).join(', ')}`);
 
     const systemPrompt = this.buildSystemPrompt(allAgents);
     const userPrompt = this.buildUserPrompt(files);
-
+    const abortController = new AbortController();
     const issues: ReviewIssue[] = [];
+    const subagentMetrics: Record<string, SubagentMetric> = {};
+    let budgetExhausted = false;
 
     try {
       const result = query({
         prompt: userPrompt,
         options: {
           systemPrompt,
+          agents: allAgents as Record<string, SDKAgentDefinition>,
           allowedTools: [
             'Read',
             'Grep',
             'Glob',
-            'mcp__qualops-agentic-tools__find_usages',
-            'mcp__qualops-agentic-tools__git_diff_analysis',
+            'mcp__qualops-agentic-tools__git_diff',
+            'mcp__qualops-agentic-tools__git_show',
             'mcp__qualops-agentic-tools__list_changed_files',
           ],
           mcpServers: {
             'qualops-agentic-tools': toolServer,
           },
-          agents: allAgents,
           maxTurns: this.config.maxTurns || 100,
           cwd: this.cwd,
           permissionMode: 'bypassPermissions',
+          allowDangerouslySkipPermissions: true,
+          abortController,
+          outputFormat: { type: 'json_schema', schema: ISSUE_SCHEMA },
         },
       });
 
       for await (const message of result) {
-        logger.info(
-          `[Agentic] Message: type=${message.type}, subtype=${'subtype' in message ? message.subtype : 'N/A'}`,
-        );
+        this.handleMessage(message, issues, subagentMetrics, files);
 
-        if (message.type === 'assistant') {
-          const content = 'message' in message ? message.message?.content : null;
-          if (content && Array.isArray(content)) {
-            for (const block of content) {
-              if (block.type === 'text') {
-                logger.info(
-                  `[Agentic] Assistant text (first 200 chars): ${block.text.substring(0, 200)}`,
-                );
-              } else if (block.type === 'tool_use') {
-                logger.info(`[Agentic] Tool call: ${block.name}`);
-              }
-            }
-          }
-        }
-
-        if (message.type === 'result') {
-          if (message.subtype === 'success' && message.result) {
-            logger.info(
-              `[Agentic] Success result (first 500 chars): ${message.result.substring(0, 500)}`,
-            );
-            const parsed = this.parseIssuesFromResult(message.result, files);
-            issues.push(...parsed);
-            logger.info(`[Agentic] Parsed ${parsed.length} issues from result`);
-          } else if (message.subtype !== 'success') {
-            logger.error(`[Agentic] Agent error: ${message.subtype}`);
-          }
+        if (this.checkBudget(message, abortController)) {
+          budgetExhausted = true;
+          break;
         }
       }
     } catch (error) {
-      logger.error(`[Agentic] Execution failed: ${(error as Error).message}`);
-      throw error;
+      if (budgetExhausted) {
+        logger.warn(`[Agentic] Budget exhausted, returning ${issues.length} partial results`);
+      } else {
+        logger.error(`[Agentic] Execution failed: ${(error as Error).message}`);
+        if (issues.length === 0) throw error;
+        logger.warn(`[Agentic] Returning ${issues.length} partial results from before failure`);
+      }
     }
 
-    logger.info(`[Agentic] Review completed: ${issues.length} total issues`);
+    this.logSubagentMetrics(subagentMetrics);
+    logger.info(`[Agentic] Review completed: ${issues.length} issues`);
     return issues;
   }
 
-  private buildSystemPrompt(_allAgents: Record<string, AgentDefinition>): string {
+  private handleMessage(
+    message: SDKMessage,
+    issues: ReviewIssue[],
+    metrics: Record<string, SubagentMetric>,
+    files: FileInfo[],
+  ): void {
+    if (message.type === 'assistant') {
+      this.handleAssistantMessage(message as SDKAssistantMessage);
+    }
+
+    if (message.type === 'system' && 'subtype' in message) {
+      if (message.subtype === 'task_started') {
+        const taskId = (message as any).task_id as string;
+        metrics[taskId] = { agentName: taskId };
+        logger.info(`[Agentic] Subagent started: ${taskId}`);
+      }
+
+      if (message.subtype === 'task_notification') {
+        const notif = message as SDKTaskNotificationMessage;
+        metrics[notif.task_id] = {
+          agentName: notif.task_id,
+          status: notif.status,
+          summary: notif.summary,
+          totalTokens: notif.usage?.total_tokens,
+          toolUses: notif.usage?.tool_uses,
+          durationMs: notif.usage?.duration_ms,
+        };
+        logger.info(
+          `[Agentic] Subagent ${notif.status}: ${notif.task_id} (${notif.usage?.total_tokens || 0} tokens)`,
+        );
+
+        if (notif.status === 'completed' && notif.summary) {
+          const parsed = this.parseIssuesFromText(notif.summary, files);
+          if (parsed.length > 0) {
+            issues.push(...parsed);
+            logger.info(
+              `[Agentic] Captured ${parsed.length} issues from subagent ${notif.task_id}`,
+            );
+          }
+        }
+      }
+    }
+
+    if (message.type === 'result') {
+      if (message.subtype === 'success') {
+        const success = message as SDKResultSuccess;
+        this.reportTokenUsage(success);
+
+        if (success.structured_output) {
+          const output = success.structured_output as { issues?: RawIssue[] };
+          if (output.issues) {
+            const parsed = output.issues
+              .filter((i) => (i.confidence || 0) >= 7)
+              .map((i, idx) => this.normalizeIssue(i, idx, files));
+            issues.length = 0;
+            issues.push(...parsed);
+            logger.info(`[Agentic] Structured output: ${parsed.length} issues`);
+          }
+        } else if (success.result) {
+          const parsed = this.parseIssuesFromText(success.result, files);
+          issues.length = 0;
+          issues.push(...parsed);
+          logger.info(`[Agentic] Parsed ${parsed.length} issues from result text`);
+        }
+      } else {
+        logger.error(`[Agentic] Agent error: ${message.subtype}`);
+      }
+    }
+  }
+
+  private handleAssistantMessage(message: SDKAssistantMessage): void {
+    const content = message.message?.content;
+    if (!content || !Array.isArray(content)) return;
+
+    for (const block of content) {
+      if (block.type === 'tool_use') {
+        logger.info(`[Agentic] Tool: ${block.name}`);
+      }
+    }
+  }
+
+  private checkBudget(message: SDKMessage, abortController: AbortController): boolean {
+    if (!this.config.maxBudgetUsd) return false;
+
+    if (message.type === 'result' && message.subtype === 'success') {
+      const cost = (message as SDKResultSuccess).total_cost_usd;
+      if (cost >= this.config.maxBudgetUsd) {
+        logger.warn(
+          `[Agentic] Budget limit reached: $${cost.toFixed(4)} >= $${this.config.maxBudgetUsd}`,
+        );
+        return true;
+      }
+    }
+
+    // Mid-run budget check from assistant message usage
+    if (message.type === 'assistant') {
+      const usage = (message as SDKAssistantMessage).message?.usage;
+      if (usage) {
+        const estimatedCost =
+          ((usage.input_tokens || 0) / 1_000_000) * 3.0 +
+          ((usage.output_tokens || 0) / 1_000_000) * 15.0;
+
+        if (estimatedCost >= this.config.maxBudgetUsd * 0.9) {
+          logger.warn(`[Agentic] Approaching budget limit (~$${estimatedCost.toFixed(4)})`);
+          abortController.abort();
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  private reportTokenUsage(result: SDKResultSuccess): void {
+    let totalInput = 0;
+    let totalOutput = 0;
+    let totalCached = 0;
+
+    for (const usage of Object.values(result.modelUsage)) {
+      totalInput += usage.inputTokens;
+      totalOutput += usage.outputTokens;
+      totalCached += usage.cacheReadInputTokens;
+    }
+
+    addStageTokenStats(
+      `review-agentic:${this.job.name}`,
+      result.num_turns,
+      totalInput,
+      totalOutput,
+      totalCached,
+      result.total_cost_usd,
+    );
+
+    logger.info(
+      `[Agentic] Cost: $${result.total_cost_usd.toFixed(4)} | Turns: ${result.num_turns} | ` +
+        `Input: ${totalInput} | Output: ${totalOutput} | Cached: ${totalCached}`,
+    );
+
+    for (const [model, usage] of Object.entries(result.modelUsage)) {
+      logger.info(
+        `[Agentic]   ${model}: $${usage.costUSD.toFixed(4)} (in: ${usage.inputTokens}, out: ${usage.outputTokens})`,
+      );
+    }
+  }
+
+  private logSubagentMetrics(metrics: Record<string, SubagentMetric>): void {
+    const entries = Object.values(metrics);
+    if (entries.length === 0) return;
+
+    logger.info(`[Agentic] Subagent summary:`);
+    for (const m of entries) {
+      logger.info(
+        `[Agentic]   ${m.agentName}: ${m.status || 'unknown'} | ${m.totalTokens || 0} tokens | ${m.toolUses || 0} tools | ${m.durationMs || 0}ms`,
+      );
+    }
+  }
+
+  private buildSystemPrompt(allAgents: Record<string, AgentDefinition>): string {
     const customPrompt = this.config.systemPrompt || '';
+    const agentList = Object.entries(allAgents)
+      .map(([name, def]) => `- **${name}**: ${def.description}`)
+      .join('\n');
 
-    return `You are a code reviewer. File contents and diffs are provided below.
+    return `You are a code review coordinator. Your job is to analyze changed files and delegate specialized analysis to subagents.
 
-${customPrompt}
+## Available Subagents
+
+You have access to specialized agents via the Agent tool:
+
+${agentList}
 
 ## Process
 
-1. Analyze the provided code/diffs
-2. Use Grep/Glob ONLY if checking external dependencies
-3. Output JSON findings
-
-## Output Format
-
-\`\`\`json
-[
-  {
-    "type": "security|bug|performance|maintainability",
-    "severity": "critical|high|medium|low",
-    "description": "What the issue is",
-    "location": "src/file.ts:42",
-    "reasoning": "Why this is a problem",
-    "suggestion": "How to fix it",
-    "confidence": 8
-  }
-]
-\`\`\`
-
-If no issues found, output: \`\`\`json\n[]\n\`\`\`
+1. **Analyze the diffs** — understand what changed and categorize the changes
+2. **Decide which agents are relevant** — skip agents that have nothing to review (e.g., skip security-analyzer for pure CSS/style changes, skip dependency-tracer for isolated single-file changes)
+3. **Delegate** — invoke each relevant agent via the Agent tool. Tell each agent which files to focus on and what to look for. Include the file diffs/content in your delegation prompt.
+4. **Synthesize** — collect all agent findings, remove obvious duplicates, rank by severity
 
 ## Rules
 
-- confidence >= 7
-- Focus on changed code
-- Max 10 tool calls`;
+- Only invoke agents that are relevant to the changes
+- Each agent returns issues as JSON — include their findings in your output
+- If agents find overlapping issues, keep the higher-confidence one
+- If no agents are relevant (trivial change), return an empty issues array
+- Focus on changed code, not pre-existing issues
+- Minimum confidence: 7
+
+${customPrompt ? `## Additional Instructions\n\n${customPrompt}` : ''}`;
   }
 
   private buildUserPrompt(files: FileInfo[]): string {
@@ -191,11 +369,9 @@ If no issues found, output: \`\`\`json\n[]\n\`\`\`
       if (totalTokens >= maxTotal) break;
     }
 
-    return `Review the following changed files for issues.
+    return `Review the following ${files.length} changed files. Delegate analysis to the appropriate subagents.
 
-${fileContexts.join('\n\n---\n\n')}
-
-Return issues as JSON. If checking dependencies, use Grep/Glob tools.`;
+${fileContexts.join('\n\n---\n\n')}`;
   }
 
   private buildFileContext(
@@ -241,38 +417,39 @@ Return issues as JSON. If checking dependencies, use Grep/Glob tools.`;
     return Math.ceil(text.length / 4);
   }
 
-  private parseIssuesFromResult(result: string, files: FileInfo[]): ReviewIssue[] {
-    const jsonMatch = result.match(/```(?:json)?\s*([\s\S]*?)```/) || result.match(/\[[\s\S]*\]/);
-
-    if (!jsonMatch) {
-      logger.warn('[Agentic] No JSON found in result');
-      return [];
-    }
+  private parseIssuesFromText(text: string, files: FileInfo[]): ReviewIssue[] {
+    const jsonMatch = text.match(/```(?:json)?\s*([\s\S]*?)```/) || text.match(/\[[\s\S]*\]/);
+    if (!jsonMatch) return [];
 
     const jsonStr = jsonMatch[1] || jsonMatch[0];
 
     try {
       const parsed = JSON.parse(jsonStr);
-      const issueArray = Array.isArray(parsed) ? parsed : [];
+      const issueArray = Array.isArray(parsed)
+        ? parsed
+        : Array.isArray(parsed?.issues)
+          ? parsed.issues
+          : [];
 
       return issueArray
-        .filter((issue: any) => issue.confidence >= 7)
-        .map((issue: any, index: number) => this.normalizeIssue(issue, index, files));
-    } catch (error) {
-      logger.warn(`[Agentic] Failed to parse issues: ${(error as Error).message}`);
+        .filter((issue: RawIssue) => (issue.confidence || 0) >= 7)
+        .map((issue: RawIssue, index: number) => this.normalizeIssue(issue, index, files));
+    } catch {
       return [];
     }
   }
 
-  private normalizeIssue(issue: any, index: number, files: FileInfo[]): ReviewIssue {
-    const location = this.parseLocation(issue.location || issue.file || '');
+  private normalizeIssue(issue: RawIssue, index: number, files: FileInfo[]): ReviewIssue {
+    const location = this.parseLocation(issue.location || '');
     const file = location.file || files[0]?.path || 'unknown';
+    type IssueType = ReviewIssue['type'];
+    type IssueSeverity = ReviewIssue['severity'];
 
     return {
       id: `agentic-${this.job.name}-${Date.now()}-${index}`,
       file,
-      type: issue.type || 'maintainability',
-      severity: issue.severity || 'medium',
+      type: (issue.type as IssueType) || 'maintainability',
+      severity: (issue.severity as IssueSeverity) || 'medium',
       description: issue.description || 'No description',
       location: location.line ? `${location.line}` : '1',
       reasoning: issue.reasoning || '',
@@ -289,13 +466,11 @@ Return issues as JSON. If checking dependencies, use Grep/Glob tools.`;
   private parseLocation(location: string): { file?: string; line?: number } {
     if (!location) return {};
 
-    // Handle "file:line" format
     const match = location.match(/^(.+?):(\d+)/);
     if (match) {
       return { file: match[1], line: parseInt(match[2], 10) };
     }
 
-    // Handle "line:N" format
     const lineMatch = location.match(/line:?\s*(\d+)/i);
     if (lineMatch) {
       return { line: parseInt(lineMatch[1], 10) };
@@ -304,13 +479,13 @@ Return issues as JSON. If checking dependencies, use Grep/Glob tools.`;
     return {};
   }
 
-  private calculatePriority(severity: string): number {
+  private calculatePriority(severity?: string): number {
     const priorities: Record<string, number> = {
       critical: 1,
       high: 2,
       medium: 3,
       low: 4,
     };
-    return priorities[severity] || 3;
+    return priorities[severity || 'medium'] || 3;
   }
 }

--- a/src/stages/review/agentic/subagents/definitions.ts
+++ b/src/stages/review/agentic/subagents/definitions.ts
@@ -11,18 +11,19 @@ const SUBAGENT_DEFINITIONS: Record<AgenticSubagentType, AgentDefinition> = {
   'dependency-tracer': {
     description:
       'Traces cross-file dependencies and identifies coupling issues, circular dependencies, and import chains that may be affected by changes',
-    prompt: `You are a dependency analysis expert for TypeScript/JavaScript codebases.
+    prompt: `You are a dependency analysis expert.
 
 Your job is to:
-1. Trace import/export relationships between changed files and the rest of the codebase
+1. Trace import/dependency relationships between changed files and the rest of the codebase
 2. Identify which other files might be affected by the changes
 3. Detect circular dependencies that could cause issues
 4. Find tightly coupled modules that violate separation of concerns
 
 When analyzing dependencies:
-- Use trace_imports to understand what each changed file imports and what imports it
-- Use find_usages to find all places where exported symbols are used
-- Look for patterns indicating tight coupling (many bidirectional imports, god modules)
+- Read the changed files to understand their imports and exports
+- Use Grep to find all files that import/reference symbols from the changed files
+- Use Glob to discover related files in the same module/package
+- Look for bidirectional imports, god modules, and excessive coupling
 
 Return issues in this JSON format:
 [{
@@ -36,19 +37,13 @@ Return issues in this JSON format:
 }]
 
 If no dependency issues are found, return an empty array: []`,
-    tools: [
-      'Read',
-      'Grep',
-      'Glob',
-      'mcp__qualops-agentic-tools__trace_imports',
-      'mcp__qualops-agentic-tools__find_usages',
-    ],
+    tools: ['Read', 'Grep', 'Glob'],
     model: 'sonnet',
   },
 
   'breaking-change-detector': {
     description:
-      'Detects breaking API changes, interface modifications, export removals, and function signature changes that could affect consumers',
+      'Detects breaking API changes, export removals, signature changes, and interface modifications that could affect consumers',
     prompt: `You are a breaking change detection expert.
 
 Your job is to identify changes that could break consumers of this code:
@@ -59,12 +54,10 @@ Your job is to identify changes that could break consumers of this code:
 5. Behavioral changes that could break existing usage patterns
 
 When analyzing:
-- Use git_diff_analysis to see what changed
-- Use analyze_exports to compare exports between versions
-- Use find_interface_changes to detect interface modifications
-- Use find_usages to understand the impact scope
-
-Focus on PUBLIC API changes - internal implementation changes are fine.
+- Use git_diff to see what changed between versions
+- Use git_show to compare the previous version of a file with the current one
+- Read the current files and use Grep to find all consumers of changed exports
+- Focus on PUBLIC API changes — internal implementation changes are fine
 
 Return issues in this JSON format:
 [{
@@ -81,10 +74,10 @@ If no breaking changes are found, return an empty array: []`,
     tools: [
       'Read',
       'Grep',
-      'mcp__qualops-agentic-tools__git_diff_analysis',
-      'mcp__qualops-agentic-tools__analyze_exports',
-      'mcp__qualops-agentic-tools__find_interface_changes',
-      'mcp__qualops-agentic-tools__find_usages',
+      'Glob',
+      'mcp__qualops-agentic-tools__git_diff',
+      'mcp__qualops-agentic-tools__git_show',
+      'mcp__qualops-agentic-tools__list_changed_files',
     ],
     model: 'sonnet',
   },
@@ -104,10 +97,10 @@ Your job is to identify security issues:
 7. Missing input validation at trust boundaries
 
 When analyzing:
-- Trace data flow from user input to dangerous sinks
-- Use find_usages to track how user-controlled data propagates
-- Look for patterns like eval(), exec(), shell commands with user input
-- Check for hardcoded API keys, passwords, or tokens
+- Read the changed files carefully, tracing data flow from user input to dangerous sinks
+- Use Grep to find patterns like eval(), exec(), shell commands, raw SQL across the codebase
+- Use Grep to check for hardcoded API keys, passwords, or tokens
+- Read related files to understand how user-controlled data propagates
 
 IMPORTANT: Only report issues with HIGH confidence. Verify by tracing actual data flow.
 
@@ -124,13 +117,7 @@ Return issues in this JSON format:
 }]
 
 If no security issues are found, return an empty array: []`,
-    tools: [
-      'Read',
-      'Grep',
-      'Glob',
-      'mcp__qualops-agentic-tools__find_usages',
-      'mcp__qualops-agentic-tools__trace_imports',
-    ],
+    tools: ['Read', 'Grep', 'Glob'],
     model: 'sonnet',
   },
 

--- a/src/stages/review/agentic/subagents/definitions.ts
+++ b/src/stages/review/agentic/subagents/definitions.ts
@@ -5,6 +5,8 @@ export interface AgentDefinition {
   prompt: string;
   tools: string[];
   model?: 'sonnet' | 'opus' | 'haiku';
+  maxTurns?: number;
+  disallowedTools?: string[];
 }
 
 const SUBAGENT_DEFINITIONS: Record<AgenticSubagentType, AgentDefinition> = {
@@ -39,6 +41,7 @@ Return issues in this JSON format:
 If no dependency issues are found, return an empty array: []`,
     tools: ['Read', 'Grep', 'Glob'],
     model: 'sonnet',
+    maxTurns: 20,
   },
 
   'breaking-change-detector': {
@@ -80,6 +83,7 @@ If no breaking changes are found, return an empty array: []`,
       'mcp__qualops-agentic-tools__list_changed_files',
     ],
     model: 'sonnet',
+    maxTurns: 25,
   },
 
   'security-analyzer': {
@@ -119,6 +123,7 @@ Return issues in this JSON format:
 If no security issues are found, return an empty array: []`,
     tools: ['Read', 'Grep', 'Glob'],
     model: 'sonnet',
+    maxTurns: 20,
   },
 
   'pattern-validator': {
@@ -155,6 +160,7 @@ Return issues in this JSON format:
 If no pattern violations are found, return an empty array: []`,
     tools: ['Read', 'Grep', 'Glob'],
     model: 'haiku',
+    maxTurns: 10,
   },
 };
 

--- a/src/stages/review/agentic/tools/index.ts
+++ b/src/stages/review/agentic/tools/index.ts
@@ -1,10 +1,7 @@
 import { execSync } from 'node:child_process';
-import { readFileSync, existsSync } from 'node:fs';
 
 import { tool, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
-
-import type { DependencyTrace, ExportComparison } from '../types';
 
 export function createAgenticTools(cwd: string) {
   return createSdkMcpServer({
@@ -12,68 +9,8 @@ export function createAgenticTools(cwd: string) {
     version: '1.0.0',
     tools: [
       tool(
-        'find_usages',
-        'Find all usages of a symbol (function, class, variable, type) across the codebase using ripgrep',
-        {
-          symbol: z.string().describe('The symbol name to search for (exact word match)'),
-          scope: z.string().optional().describe('Limit search to this directory path'),
-          fileType: z.string().optional().describe('File type filter (e.g., ts, js, tsx)'),
-        },
-        async ({ symbol, scope, fileType }) => {
-          const searchPath = scope || cwd;
-          const typeArg = fileType ? `--type ${fileType}` : '--type ts --type tsx';
-
-          try {
-            const result = execSync(`rg -n --word-regexp "${symbol}" ${searchPath} ${typeArg}`, {
-              encoding: 'utf-8',
-              cwd,
-              maxBuffer: 10 * 1024 * 1024,
-            });
-            return { content: [{ type: 'text', text: result || 'No usages found' }] };
-          } catch (error) {
-            const execError = error as { status?: number; message?: string };
-            if (execError.status === 1) {
-              return { content: [{ type: 'text', text: 'No usages found' }] };
-            }
-            return {
-              content: [{ type: 'text', text: `Error: ${execError.message || 'Unknown error'}` }],
-            };
-          }
-        },
-      ),
-
-      tool(
-        'trace_imports',
-        'Trace import/export dependencies for a TypeScript file. Returns what the file imports and which files import it.',
-        {
-          filePath: z.string().describe('Path to the file to analyze (relative to cwd)'),
-        },
-        async ({ filePath }) => {
-          const fullPath = filePath.startsWith('/') ? filePath : `${cwd}/${filePath}`;
-
-          if (!existsSync(fullPath)) {
-            return { content: [{ type: 'text', text: `File not found: ${filePath}` }] };
-          }
-
-          const content = readFileSync(fullPath, 'utf-8');
-          const imports = extractImports(content);
-          const exports = extractExports(content);
-          const importedBy = findImportingFiles(filePath, cwd);
-
-          const result: DependencyTrace = {
-            filePath,
-            imports,
-            importedBy,
-            exports,
-          };
-
-          return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-        },
-      ),
-
-      tool(
-        'git_diff_analysis',
-        'Get detailed git diff for a commit range or specific file. Shows added/removed/modified lines.',
+        'git_diff',
+        'Get git diff for a commit range or specific file. Shows added/removed/modified lines.',
         {
           base: z.string().describe('Base commit or branch (e.g., main, HEAD~1)'),
           head: z.string().optional().describe('Head commit or branch (defaults to HEAD)'),
@@ -99,70 +36,20 @@ export function createAgenticTools(cwd: string) {
       ),
 
       tool(
-        'analyze_exports',
-        'Analyze public exports from a TypeScript file and optionally compare with a previous version to detect breaking changes.',
+        'git_show',
+        'Show a file at a specific git ref. Useful for comparing current vs previous versions.',
         {
-          filePath: z.string().describe('Path to the file to analyze'),
-          compareWithRef: z
-            .string()
-            .optional()
-            .describe('Git ref to compare with (e.g., main, HEAD~1)'),
+          ref: z.string().describe('Git ref (e.g., main, HEAD~1, abc123)'),
+          file: z.string().describe('File path relative to repo root'),
         },
-        async ({ filePath, compareWithRef }) => {
-          const fullPath = filePath.startsWith('/') ? filePath : `${cwd}/${filePath}`;
-
-          if (!existsSync(fullPath)) {
-            return { content: [{ type: 'text', text: `File not found: ${filePath}` }] };
-          }
-
-          const currentContent = readFileSync(fullPath, 'utf-8');
-          const currentExports = extractExports(currentContent);
-
-          let comparison: ExportComparison | null = null;
-
-          if (compareWithRef) {
-            try {
-              const oldContent = execSync(`git show ${compareWithRef}:${filePath}`, {
-                encoding: 'utf-8',
-                cwd,
-              });
-              const oldExports = extractExports(oldContent);
-              comparison = compareExports(oldExports, currentExports);
-            } catch {
-              comparison = { added: currentExports, removed: [], modified: [] };
-            }
-          }
-
-          const result = {
-            filePath,
-            exports: currentExports,
-            comparison,
-          };
-
-          return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-        },
-      ),
-
-      tool(
-        'find_interface_changes',
-        'Find changes to TypeScript interfaces or types between two git refs',
-        {
-          base: z.string().describe('Base git ref'),
-          head: z.string().optional().describe('Head git ref (defaults to HEAD)'),
-          interfaceName: z.string().optional().describe('Specific interface to check'),
-        },
-        async ({ base, head, interfaceName }) => {
-          const headRef = head || 'HEAD';
-          const grepPattern = interfaceName
-            ? `"(interface|type)\\s+${interfaceName}"`
-            : '"(interface|type)\\s+\\w+"';
-
+        async ({ ref, file }) => {
           try {
-            const diff = execSync(
-              `git diff ${base}...${headRef} --unified=5 -G ${grepPattern} -- "*.ts" "*.tsx"`,
-              { encoding: 'utf-8', cwd, maxBuffer: 10 * 1024 * 1024 },
-            );
-            return { content: [{ type: 'text', text: diff || 'No interface changes found' }] };
+            const content = execSync(`git show ${ref}:${file}`, {
+              encoding: 'utf-8',
+              cwd,
+              maxBuffer: 10 * 1024 * 1024,
+            });
+            return { content: [{ type: 'text', text: content }] };
           } catch (error) {
             return { content: [{ type: 'text', text: `Error: ${(error as Error).message}` }] };
           }
@@ -197,78 +84,4 @@ export function createAgenticTools(cwd: string) {
       ),
     ],
   });
-}
-
-function extractImports(content: string): string[] {
-  const importRegex = /import\s+(?:(?:\{[^}]*\}|\*\s+as\s+\w+|\w+)\s+from\s+)?['"]([^'"]+)['"]/g;
-  const imports: string[] = [];
-  let match;
-  while ((match = importRegex.exec(content)) !== null) {
-    imports.push(match[1]);
-  }
-  return imports;
-}
-
-function extractExports(content: string): string[] {
-  const exports: string[] = [];
-
-  // Named exports: export { name } or export { name as alias }
-  const namedExportRegex = /export\s*\{([^}]+)\}/g;
-  let match;
-  while ((match = namedExportRegex.exec(content)) !== null) {
-    const names = match[1].split(',').map((n) =>
-      n
-        .trim()
-        .split(/\s+as\s+/)[0]
-        .trim(),
-    );
-    exports.push(...names);
-  }
-
-  // Direct exports: export const/let/var/function/class/interface/type
-  const directExportRegex =
-    /export\s+(?:const|let|var|function|class|interface|type|enum)\s+(\w+)/g;
-  while ((match = directExportRegex.exec(content)) !== null) {
-    exports.push(match[1]);
-  }
-
-  // Default export
-  if (/export\s+default/.test(content)) {
-    exports.push('default');
-  }
-
-  return [...new Set(exports)];
-}
-
-function findImportingFiles(targetPath: string, cwd: string): string[] {
-  const fileName =
-    targetPath
-      .split('/')
-      .pop()
-      ?.replace(/\.[^.]+$/, '') || '';
-
-  try {
-    const result = execSync(`rg -l "${fileName}" --type ts ${cwd} 2>/dev/null || true`, {
-      encoding: 'utf-8',
-      cwd,
-      shell: '/bin/bash',
-    });
-    return result
-      .trim()
-      .split('\n')
-      .filter((f) => f && f !== targetPath);
-  } catch {
-    return [];
-  }
-}
-
-function compareExports(oldExports: string[], newExports: string[]): ExportComparison {
-  const oldSet = new Set(oldExports);
-  const newSet = new Set(newExports);
-
-  return {
-    added: newExports.filter((e) => !oldSet.has(e)),
-    removed: oldExports.filter((e) => !newSet.has(e)),
-    modified: [], // Would need AST analysis for signature changes
-  };
 }

--- a/src/stages/review/agentic/types.ts
+++ b/src/stages/review/agentic/types.ts
@@ -17,30 +17,3 @@ export interface SubagentResult {
     tokensUsed: number;
   };
 }
-
-export interface DependencyTrace {
-  filePath: string;
-  imports: string[];
-  importedBy: string[];
-  exports: string[];
-}
-
-export interface BreakingChangeResult {
-  file: string;
-  changeType: 'api-signature' | 'interface-change' | 'export-removal' | 'behavior-change';
-  description: string;
-  affectedFiles: string[];
-  severity: 'critical' | 'high' | 'medium';
-}
-
-export interface ExportComparison {
-  added: string[];
-  removed: string[];
-  modified: string[];
-}
-
-export interface ToolResult {
-  success: boolean;
-  data?: unknown;
-  error?: string;
-}


### PR DESCRIPTION
## Summary

- Rewrites `AgenticExecutor` to properly leverage Claude Agent SDK for multi-agent orchestration
- Coordinator prompt now instructs delegation to subagents via the SDK's built-in `Agent` tool (previously subagents were defined but never invoked)
- Structured output (`outputFormat: json_schema`) replaces fragile regex JSON parsing
- Budget enforcement via `AbortController` with mid-run cost monitoring from `SDKAssistantMessage.usage`
- Token tracking wired to `SessionContext` (`total_cost_usd`, per-model `modelUsage` breakdown)
- Per-subagent metrics captured from `SDKTaskNotificationMessage` (tokens, tool uses, duration)
- Partial results preserved on budget exhaustion or failure
- `allowDangerouslySkipPermissions: true` added (required for `bypassPermissions` mode)
- MCP tools trimmed from 6 to 3 — removed `find_usages`, `trace_imports`, `analyze_exports` (redundant with Read/Grep); kept `git_diff`, `git_show`, `list_changed_files` (agents can't run git)
- Subagent prompts made language-agnostic (previously TypeScript-specific)
- Includes `docs/RFC-001-agentic-mode.md` documenting architecture and roadmap

## E2E Validation

Tested against 3 real codebases with actual Claude API calls:

| Test | Language | Files | Agents | Issues | Cost |
|------|----------|-------|--------|--------|------|
| Security audit | TypeScript | 3 | security-analyzer, dependency-tracer, pattern-validator | 21 | $0.54 |
| Full scan + custom `flask-security` agent | Python | 3 | security-analyzer, pattern-validator, flask-security | 22 | $0.45 |
| Diff review + custom `go-concurrency` agent | Go | 4 | security-analyzer, breaking-change-detector, go-concurrency | 23 | $0.55 |
| Cross-file context (false positive elimination) | TypeScript | 3 | security-analyzer, pattern-validator | 14 | $0.43 |

Cross-file test validated the core thesis: agent reads validator.ts and database.ts to determine that api-handler.ts is safe (parameterized queries + input sanitization), avoiding ~5 false positives that a file-by-file reviewer would flag.

## Test plan

- [x] `npx tsc --noEmit` — zero type errors
- [x] `npm run lint` — clean
- [x] `npm test` — 1926 tests pass (52 suites)
- [x] `npm run build` — clean
- [x] E2E: TypeScript codebase with 3 built-in subagents
- [x] E2E: Python codebase with custom markdown agent
- [x] E2E: Go codebase with custom markdown agent
- [x] E2E: Cross-file false positive elimination
- [x] SDK type validation script confirmed all 13 API surface claims