### PR TITLE
validate .qualopsrc.json config with Zod

### DIFF
--- a/.qualops/examples/github/README.md
+++ b/.qualops/examples/github/README.md
@@ -5,8 +5,9 @@ This directory contains example configurations and workflows for using QualOps w
 ## Files
 
 - **`.qualopsrc.json`** - Full-featured configuration example
-- **`workflows/qualops-basic.yml`** - Minimal workflow setup
+- **`workflows/qualops-basic.yml`** - Minimal workflow using the GitHub Action
 - **`workflows/qualops-advanced.yml`** - Advanced workflow with output handling
+- **`workflows/qualops-npm.yml`** - npm-based workflow with pinned version and artifact upload
 
 ## Quick Setup
 

--- a/.qualops/examples/github/workflows/qualops-npm.yml
+++ b/.qualops/examples/github/workflows/qualops-npm.yml
@@ -1,0 +1,46 @@
+# npm-based QualOps workflow
+# Use this instead of the GitHub Action when you need:
+#   - A pinned qualops version
+#   - Control over the Node.js version
+#   - npm caching for faster runs
+#   - The HTML report as a downloadable artifact
+
+name: QualOps Code Quality
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  qualops:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      checks: write
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # Full history for accurate git diff
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '24'
+
+      - name: Install QualOps
+        run: npm install -g @eggai/qualops@~0.2
+
+      - name: Run QualOps
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: qualops --base=${{ github.base_ref }} --head=${{ github.sha }}
+
+      - name: Upload QualOps report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: qualops-report
+          path: .qualops/reports/
+          retention-days: 30

--- a/.qualops/examples/github/workflows/qualops-npm.yml
+++ b/.qualops/examples/github/workflows/qualops-npm.yml
@@ -1,9 +1,6 @@
 # npm-based QualOps workflow
-# Use this instead of the GitHub Action when you need:
-#   - A pinned qualops version
-#   - Control over the Node.js version
-#   - npm caching for faster runs
-#   - The HTML report as a downloadable artifact
+# Alternative to the GitHub Action for teams that prefer
+# installing QualOps via npm in their own CI steps.
 
 name: QualOps Code Quality
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - GitHub Models AI provider (`provider: "github"`) via `https://models.github.ai/inference`
-- Add JSON Schema for QualOps configuration file with comprehensive integration tests
+- Zod-based runtime validation for `.qualopsrc.json` with deprecation warnings for legacy fields
+- JSON Schema generated from Zod schemas (`npm run generate:schema`) replacing hand-maintained schema
 - Eval `--severity` filter to run only CRB cases with matching golden comment severity
 - Report on eval flakiness for Code Review Benchmark `npm run eval:recall-report` with filtering options `-- --severity=critical`
 

--- a/docs/qualops-config.schema.json
+++ b/docs/qualops-config.schema.json
@@ -5,7 +5,10 @@
   "description": "Schema for QualOps project configuration.",
   "type": "object",
   "additionalProperties": false,
-  "required": ["ai", "review"],
+  "required": [
+    "ai",
+    "review"
+  ],
   "properties": {
     "$schema": {
       "description": "Optional JSON Schema reference for editor/validator tooling.",
@@ -13,27 +16,9 @@
       "format": "uri-reference"
     },
     "ai": {
-      "description": "AI provider and model settings for each stage.",
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["reviewStage"],
-      "properties": {
-        "reviewStage": {
-          "description": "Settings for the review stage runtime. Although stages can be skipped, a previous review is always required for a fix stage, therefore this setting is required.",
-          "$ref": "#/$defs/aiStageConfig"
-        },
-        "fixStage": {
-          "description": "Settings for the fix stage runtime.",
-          "$ref": "#/$defs/aiStageConfig"
-        },
-        "judgeStage": {
-          "description": "Planned settings (currently unused) for configuring the judge stage (not yet implemented).",
-          "$ref": "#/$defs/aiStageConfig"
-        }
-      }
+      "$ref": "#/$defs/aiConfig"
     },
     "review": {
-      "description": "Review pipeline configuration. Must include at least one pipeline job.",
       "$ref": "#/$defs/reviewConfig"
     },
     "performance": {
@@ -69,7 +54,13 @@
       "description": "Legacy compatibility field. Values from config files are currently ignored.",
       "deprecated": true,
       "$ref": "#/$defs/nonEmptyStringArray",
-      "default": ["node_modules/**", ".git/**", "dist/**", "build/**", "coverage/**"]
+      "default": [
+        "node_modules/**",
+        ".git/**",
+        "dist/**",
+        "build/**",
+        "coverage/**"
+      ]
     },
     "includePatterns": {
       "description": "Legacy compatibility field. Values from config files are currently ignored.",
@@ -106,15 +97,13 @@
     "outputFormat": {
       "description": "Legacy compatibility field. Values from config files are currently ignored.",
       "deprecated": true,
-      "type": "string",
-      "enum": ["json", "html", "markdown"],
+      "$ref": "#/$defs/outputFormat",
       "default": "html"
     },
     "outputPath": {
       "description": "Legacy top-level override currently unused by runtime stage implementations.",
       "deprecated": true,
-      "type": "string",
-      "minLength": 1
+      "$ref": "#/$defs/nonEmptyString"
     },
     "verbose": {
       "description": "Legacy compatibility field. Values from config files are currently ignored (environment variables still apply).",
@@ -151,344 +140,60 @@
     }
   },
   "$defs": {
-    "nonEmptyString": {
-      "type": "string",
-      "minLength": 1
-    },
-    "nonEmptyStringArray": {
-      "type": "array",
-      "items": { "$ref": "#/$defs/nonEmptyString" }
-    },
-    "confidenceScore": {
-      "type": "integer",
-      "minimum": 1,
-      "maximum": 10
-    },
-    "severityList": {
-      "type": "array",
-      "items": { "$ref": "#/$defs/severity" },
-      "minItems": 1,
-      "uniqueItems": true
-    },
-    "severity": {
-      "description": "Standard issue severity levels used across review, fix, and reporting.",
-      "type": "string",
-      "enum": ["critical", "high", "medium", "low"]
-    },
-    "issueType": {
-      "description": "Canonical issue categories emitted by review stages.",
-      "type": "string",
-      "enum": ["bug", "security", "performance", "maintainability"]
-    },
-    "aiProvider": {
-      "description": "Supported AI provider names.",
-      "type": "string",
-      "enum": ["anthropic", "openai", "bedrock"]
-    },
-    "aiStageConfig": {
-      "description": "AI configuration for a specific stage.",
-      "type": "object",
-      "additionalProperties": true,
-      "required": ["provider", "model", "inputPerMillion", "outputPerMillion"],
-      "properties": {
-        "provider": {
-          "description": "AI provider for this stage.",
-          "$ref": "#/$defs/aiProvider"
-        },
-        "model": {
-          "description": "Model name passed to the selected provider.",
-          "type": "string",
-          "minLength": 1
-        },
-        "inputPerMillion": {
-          "description": "Estimated input token cost per million tokens.",
-          "type": "number",
-          "minimum": 0
-        },
-        "outputPerMillion": {
-          "description": "Estimated output token cost per million tokens.",
-          "type": "number",
-          "minimum": 0
-        },
-        "temperature": {
-          "description": "Sampling temperature used by compatible providers.",
-          "type": "number",
-          "minimum": 0
-        },
-        "maxTokens": {
-          "description": "Optional model output token cap.",
-          "type": "integer",
-          "minimum": 1
-        }
-      }
-    },
-    "promptConfig": {
-      "description": "Prompt reference object with optional metadata.",
+    "aiConfig": {
+      "description": "AI provider and model settings for each stage.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["file"],
+      "required": [
+        "reviewStage"
+      ],
       "properties": {
-        "file": {
-          "description": "Prompt file path relative to .qualops/prompts.",
-          "type": "string",
-          "minLength": 1
+        "reviewStage": {
+          "description": "Settings for the review stage runtime. Although stages can be skipped, a previous review is always required for a fix stage, therefore this setting is required.",
+          "$ref": "#/$defs/aiStageConfig"
         },
-        "meta": {
-          "description": "Optional metadata that can be used by prompt templates.",
-          "type": "object",
-          "additionalProperties": true
+        "fixStage": {
+          "description": "Settings for the fix stage runtime.",
+          "$ref": "#/$defs/aiStageConfig"
+        },
+        "judgeStage": {
+          "description": "Planned settings (currently unused) for configuring the judge stage (not yet implemented).",
+          "$ref": "#/$defs/aiStageConfig"
         }
       }
-    },
-    "promptRef": {
-      "description": "Prompt reference as a relative path string or { file, meta } object.",
-      "anyOf": [{ "type": "string", "minLength": 1 }, { "$ref": "#/$defs/promptConfig" }]
-    },
-    "validationConfig": {
-      "description": "Validation stage settings used to filter/adjust detected issues.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "enabled": {
-          "description": "Enable validation pass for this scope.",
-          "type": "boolean"
-        },
-        "minConfidence": {
-          "description": "Minimum confidence required before/after validation.",
-          "$ref": "#/$defs/confidenceScore"
-        },
-        "prompt": {
-          "description": "Prompt used for AI-assisted validation.",
-          "$ref": "#/$defs/promptRef"
-        }
-      }
-    },
-    "deduplicationConfig": {
-      "description": "Deduplication settings used to remove repeated issues per file.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "enabled": {
-          "description": "Enable deduplication for this scope.",
-          "type": "boolean"
-        },
-        "prompt": {
-          "description": "Prompt used for AI-assisted deduplication.",
-          "$ref": "#/$defs/promptRef"
-        }
-      }
-    },
-    "reviewPassFilters": {
-      "description": "File/content filters used to decide whether a pass should review a file.",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "detectionTriggers": {
-          "description": "Regex patterns tested against file content; at least one match is required.",
-          "$ref": "#/$defs/nonEmptyStringArray"
-        },
-        "filePatterns": {
-          "description": "Glob patterns a file path must match to be reviewed.",
-          "$ref": "#/$defs/nonEmptyStringArray"
-        },
-        "excludePatterns": {
-          "description": "Glob patterns that exclude matching files from the pass.",
-          "$ref": "#/$defs/nonEmptyStringArray"
-        }
-      }
-    },
-    "reviewPass": {
-      "description": "Single review pass executed within a file-by-file pipeline job.",
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["name", "enabled", "prompt"],
-      "properties": {
-        "name": {
-          "description": "Display name for logging and report grouping.",
-          "type": "string",
-          "minLength": 1
-        },
-        "enabled": {
-          "description": "Set false to disable this pass without removing it.",
-          "type": "boolean"
-        },
-        "docs": {
-          "description": "Optional docs reference used to build doc-aware review prompts.",
-          "type": "string",
-          "minLength": 1
-        },
-        "prompt": {
-          "description": "Prompt reference used by this review pass.",
-          "$ref": "#/$defs/promptRef"
-        },
-        "filters": {
-          "description": "Optional filters to limit this pass to relevant files/content.",
-          "$ref": "#/$defs/reviewPassFilters"
-        }
-      }
-    },
-    "agenticSubagentType": {
-      "description": "Built-in subagent identifiers supported in agentic mode.",
-      "type": "string",
-      "enum": [
-        "dependency-tracer",
-        "breaking-change-detector",
-        "security-analyzer",
-        "pattern-validator"
-      ]
-    },
-    "customAgentDefinition": {
-      "description": "Custom subagent definition merged with built-in agentic subagents.",
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["name", "description", "prompt"],
-      "properties": {
-        "name": {
-          "description": "Unique custom agent name.",
-          "type": "string",
-          "minLength": 1
-        },
-        "description": {
-          "description": "Human-readable purpose of the custom agent.",
-          "type": "string",
-          "minLength": 1
-        },
-        "prompt": {
-          "description": "System instructions for the custom agent.",
-          "type": "string",
-          "minLength": 1
-        },
-        "tools": {
-          "description": "Allowed tool names for the custom agent.",
-          "$ref": "#/$defs/nonEmptyStringArray"
-        },
-        "model": {
-          "description": "Optional model tier override for this custom agent.",
-          "type": "string",
-          "enum": ["sonnet", "opus", "haiku"]
-        }
-      }
-    },
-    "agenticConfig": {
-      "description": "Settings for agentic review execution (cross-file analysis with tools/subagents).",
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "maxTurns": {
-          "description": "Maximum message/tool-call turns for the agentic run.",
-          "type": "integer",
-          "minimum": 1
-        },
-        "maxBudgetUsd": {
-          "description": "Optional budget guardrail for agentic execution.",
-          "type": "number",
-          "minimum": 0
-        },
-        "enabledSubagents": {
-          "description": "Subset of built-in subagents to enable.",
-          "type": "array",
-          "items": { "$ref": "#/$defs/agenticSubagentType" }
-        },
-        "customAgents": {
-          "description": "Custom agents loaded from config and optional agents directory.",
-          "type": "array",
-          "items": { "$ref": "#/$defs/customAgentDefinition" }
-        },
-        "agentsDir": {
-          "description": "Directory containing external custom agent files.",
-          "type": "string",
-          "minLength": 1
-        },
-        "systemPrompt": {
-          "description": "Additional system instructions appended to the default agentic prompt.",
-          "type": "string"
-        },
-        "contextMode": {
-          "description": "How file context is sent: diff, full file content, or auto mode.",
-          "type": "string",
-          "enum": ["diff", "full", "auto"]
-        },
-        "maxTokensPerFile": {
-          "description": "Per-file token budget when building agentic context.",
-          "type": "integer",
-          "minimum": 1
-        },
-        "maxTotalTokens": {
-          "description": "Total token budget for all file contexts in one agentic run.",
-          "type": "integer",
-          "minimum": 1
-        }
-      }
-    },
-    "pipelineJobFileByFile": {
-      "description": "Pipeline job in file-by-file mode. Requires at least one pass.",
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["name", "enabled", "passes"],
-      "properties": {
-        "name": {
-          "type": "string",
-          "minLength": 1
-        },
-        "enabled": {
-          "type": "boolean"
-        },
-        "mode": {
-          "type": "string",
-          "enum": ["file-by-file"]
-        },
-        "agentic": { "$ref": "#/$defs/agenticConfig" },
-        "validation": { "$ref": "#/$defs/validationConfig" },
-        "deduplication": { "$ref": "#/$defs/deduplicationConfig" },
-        "passes": {
-          "type": "array",
-          "minItems": 1,
-          "items": { "$ref": "#/$defs/reviewPass" }
-        }
-      }
-    },
-    "pipelineJobAgentic": {
-      "description": "Pipeline job in agentic mode. Passes are optional in this mode.",
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["name", "enabled", "mode"],
-      "properties": {
-        "name": {
-          "type": "string",
-          "minLength": 1
-        },
-        "enabled": {
-          "type": "boolean"
-        },
-        "mode": {
-          "type": "string",
-          "enum": ["agentic"]
-        },
-        "agentic": { "$ref": "#/$defs/agenticConfig" },
-        "validation": { "$ref": "#/$defs/validationConfig" },
-        "deduplication": { "$ref": "#/$defs/deduplicationConfig" },
-        "passes": {
-          "type": "array",
-          "items": { "$ref": "#/$defs/reviewPass" }
-        }
-      }
-    },
-    "pipelineJob": {
-      "description": "Union type for supported pipeline job modes.",
-      "oneOf": [
-        { "$ref": "#/$defs/pipelineJobAgentic" },
-        { "$ref": "#/$defs/pipelineJobFileByFile" }
-      ]
     },
     "reviewConfig": {
-      "description": "Top-level review stage configuration and job pipeline.",
+      "description": "Review pipeline configuration. Must include at least one pipeline job.",
       "type": "object",
       "additionalProperties": false,
-      "required": ["pipeline"],
+      "required": [
+        "pipeline"
+      ],
       "properties": {
         "minConfidence": {
           "description": "Base confidence threshold used by review and template rendering contexts.",
           "$ref": "#/$defs/confidenceScore"
+        },
+        "maxConcurrentFiles": {
+          "description": "Concurrent file reviews for file-by-file pass execution.",
+          "type": "integer",
+          "minimum": 1
+        },
+        "validation": {
+          "description": "Global validation settings applied to all pipeline jobs.",
+          "$ref": "#/$defs/validationConfig"
+        },
+        "deduplication": {
+          "description": "Global deduplication settings applied to all pipeline jobs.",
+          "$ref": "#/$defs/deduplicationConfig"
+        },
+        "pipeline": {
+          "description": "Ordered list of review jobs to execute.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/pipelineJob"
+          }
         },
         "sessionBased": {
           "description": "Legacy compatibility setting currently ignored by the active review pipeline.",
@@ -516,42 +221,388 @@
           "description": "Legacy compatibility alias for review.deduplication.enabled.",
           "deprecated": true,
           "type": "boolean"
-        },
-        "maxConcurrentFiles": {
-          "description": "Concurrent file reviews for file-by-file pass execution.",
-          "type": "integer",
-          "minimum": 1
-        },
-        "validation": { "$ref": "#/$defs/validationConfig" },
-        "deduplication": { "$ref": "#/$defs/deduplicationConfig" },
-        "pipeline": {
-          "description": "Ordered list of review jobs to execute.",
-          "type": "array",
-          "minItems": 1,
-          "items": { "$ref": "#/$defs/pipelineJob" }
         }
       }
     },
-    "throttlingConfig": {
-      "description": "API rate-limit settings for review-time AI calls.",
+    "aiProvider": {
+      "description": "Supported AI provider names.",
+      "type": "string",
+      "enum": [
+        "anthropic",
+        "openai",
+        "bedrock",
+        "github"
+      ]
+    },
+    "nonEmptyString": {
+      "type": "string",
+      "minLength": 1
+    },
+    "aiStageConfig": {
+      "description": "AI configuration for a specific stage.",
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "provider",
+        "model",
+        "inputPerMillion",
+        "outputPerMillion"
+      ],
+      "properties": {
+        "provider": {
+          "$ref": "#/$defs/aiProvider"
+        },
+        "model": {
+          "description": "Model name passed to the selected provider.",
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "inputPerMillion": {
+          "description": "Estimated input token cost per million tokens.",
+          "type": "number",
+          "minimum": 0
+        },
+        "outputPerMillion": {
+          "description": "Estimated output token cost per million tokens.",
+          "type": "number",
+          "minimum": 0
+        },
+        "temperature": {
+          "description": "Sampling temperature used by compatible providers.",
+          "type": "number",
+          "minimum": 0
+        },
+        "maxTokens": {
+          "description": "Optional model output token cap.",
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "confidenceScore": {
+      "description": "Integer confidence score from 1 (lowest) to 10 (highest).",
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 10
+    },
+    "validationConfig": {
+      "description": "Validation stage settings used to filter/adjust detected issues.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "enabled": {
-          "description": "Legacy compatibility field currently ignored.",
-          "deprecated": true,
+          "description": "Enable validation pass for this scope.",
           "type": "boolean"
         },
-        "apiCallsPerMinute": {
-          "description": "Maximum review-time AI calls per minute. If omitted, runtime defaults to 2.",
+        "minConfidence": {
+          "description": "Minimum confidence required before/after validation.",
+          "$ref": "#/$defs/confidenceScore"
+        },
+        "prompt": {
+          "description": "Prompt used for AI-assisted validation.",
+          "$ref": "#/$defs/promptRef"
+        }
+      }
+    },
+    "promptRef": {
+      "description": "Prompt reference as a relative path string or { file, meta } object.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        {
+          "$ref": "#/$defs/promptConfig"
+        }
+      ]
+    },
+    "promptConfig": {
+      "description": "Prompt reference object with optional metadata.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "file"
+      ],
+      "properties": {
+        "file": {
+          "description": "Prompt file path relative to .qualops/prompts.",
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "meta": {
+          "description": "Optional metadata that can be used by prompt templates.",
+          "type": "object",
+          "additionalProperties": true
+        }
+      }
+    },
+    "deduplicationConfig": {
+      "description": "Deduplication settings used to remove repeated issues per file.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "description": "Enable deduplication for this scope.",
+          "type": "boolean"
+        },
+        "prompt": {
+          "description": "Prompt used for AI-assisted deduplication.",
+          "$ref": "#/$defs/promptRef"
+        }
+      }
+    },
+    "pipelineJob": {
+      "description": "Union type for supported pipeline job modes.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/pipelineJobAgentic"
+        },
+        {
+          "$ref": "#/$defs/pipelineJobFileByFile"
+        }
+      ]
+    },
+    "pipelineJobAgentic": {
+      "description": "Pipeline job in agentic mode. Passes are optional in this mode.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "enabled",
+        "mode"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "agentic": {
+          "$ref": "#/$defs/agenticConfig"
+        },
+        "validation": {
+          "$ref": "#/$defs/validationConfig"
+        },
+        "deduplication": {
+          "$ref": "#/$defs/deduplicationConfig"
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "agentic"
+          ]
+        },
+        "passes": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/reviewPass"
+          }
+        }
+      }
+    },
+    "agenticConfig": {
+      "description": "Settings for agentic review execution (cross-file analysis with tools/subagents).",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "maxTurns": {
+          "description": "Maximum message/tool-call turns for the agentic run.",
           "type": "integer",
           "minimum": 1
         },
-        "maxRequestsPerMinute": {
-          "description": "Legacy compatibility alias currently ignored at runtime.",
-          "deprecated": true,
+        "maxBudgetUsd": {
+          "description": "Optional budget guardrail for agentic execution.",
+          "type": "number",
+          "minimum": 0
+        },
+        "enabledSubagents": {
+          "description": "Subset of built-in subagents to enable.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/agenticSubagentType"
+          }
+        },
+        "customAgents": {
+          "description": "Custom agents loaded from config and optional agents directory.",
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/customAgentDefinition"
+          }
+        },
+        "agentsDir": {
+          "description": "Directory containing external custom agent files.",
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "systemPrompt": {
+          "description": "Additional system instructions appended to the default agentic prompt.",
+          "type": "string"
+        },
+        "contextMode": {
+          "$ref": "#/$defs/contextMode"
+        },
+        "maxTokensPerFile": {
+          "description": "Per-file token budget when building agentic context.",
           "type": "integer",
           "minimum": 1
+        },
+        "maxTotalTokens": {
+          "description": "Total token budget for all file contexts in one agentic run.",
+          "type": "integer",
+          "minimum": 1
+        }
+      }
+    },
+    "agenticSubagentType": {
+      "description": "Built-in subagent identifiers supported in agentic mode.",
+      "type": "string",
+      "enum": [
+        "dependency-tracer",
+        "breaking-change-detector",
+        "security-analyzer",
+        "pattern-validator"
+      ]
+    },
+    "customAgentDefinition": {
+      "description": "Custom subagent definition merged with built-in agentic subagents.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "description",
+        "prompt"
+      ],
+      "properties": {
+        "description": {
+          "description": "Human-readable purpose of the custom agent.",
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "name": {
+          "description": "Unique custom agent name.",
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "prompt": {
+          "description": "System instructions for the custom agent.",
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "tools": {
+          "description": "Allowed tool names for the custom agent.",
+          "$ref": "#/$defs/nonEmptyStringArray"
+        },
+        "model": {
+          "$ref": "#/$defs/agentModel"
+        }
+      }
+    },
+    "nonEmptyStringArray": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/nonEmptyString"
+      }
+    },
+    "agentModel": {
+      "description": "Optional model tier override for this custom agent.",
+      "type": "string",
+      "enum": [
+        "sonnet",
+        "opus",
+        "haiku"
+      ]
+    },
+    "contextMode": {
+      "description": "How file context is sent: diff, full file content, or auto mode.",
+      "type": "string",
+      "enum": [
+        "diff",
+        "full",
+        "auto"
+      ]
+    },
+    "reviewPass": {
+      "description": "Single review pass executed within a file-by-file pipeline job.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "enabled",
+        "prompt"
+      ],
+      "properties": {
+        "name": {
+          "description": "Display name for logging and report grouping.",
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "enabled": {
+          "description": "Set false to disable this pass without removing it.",
+          "type": "boolean"
+        },
+        "docs": {
+          "description": "Optional docs reference used to build doc-aware review prompts.",
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "prompt": {
+          "description": "Prompt reference used by this review pass.",
+          "$ref": "#/$defs/promptRef"
+        },
+        "filters": {
+          "description": "Optional filters to limit this pass to relevant files/content.",
+          "$ref": "#/$defs/reviewPassFilters"
+        }
+      }
+    },
+    "reviewPassFilters": {
+      "description": "File/content filters used to decide whether a pass should review a file.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "detectionTriggers": {
+          "description": "Regex patterns tested against file content; at least one match is required.",
+          "$ref": "#/$defs/nonEmptyStringArray"
+        },
+        "filePatterns": {
+          "description": "Glob patterns a file path must match to be reviewed.",
+          "$ref": "#/$defs/nonEmptyStringArray"
+        },
+        "excludePatterns": {
+          "description": "Glob patterns that exclude matching files from the pass.",
+          "$ref": "#/$defs/nonEmptyStringArray"
+        }
+      }
+    },
+    "pipelineJobFileByFile": {
+      "description": "Pipeline job in file-by-file mode. Requires at least one pass.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "enabled",
+        "passes"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "agentic": {
+          "$ref": "#/$defs/agenticConfig"
+        },
+        "validation": {
+          "$ref": "#/$defs/validationConfig"
+        },
+        "deduplication": {
+          "$ref": "#/$defs/deduplicationConfig"
+        },
+        "mode": {
+          "type": "string",
+          "enum": [
+            "file-by-file"
+          ]
+        },
+        "passes": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "$ref": "#/$defs/reviewPass"
+          }
         }
       }
     },
@@ -560,6 +611,9 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "throttling": {
+          "$ref": "#/$defs/throttlingConfig"
+        },
         "maxFileSizeKB": {
           "description": "Legacy compatibility field currently not applied by active stages.",
           "deprecated": true,
@@ -601,9 +655,29 @@
           "deprecated": true,
           "type": "integer",
           "minimum": 1
+        }
+      }
+    },
+    "throttlingConfig": {
+      "description": "API rate-limit settings for review-time AI calls.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "apiCallsPerMinute": {
+          "description": "Maximum review-time AI calls per minute. If omitted, runtime defaults to 2.",
+          "type": "integer",
+          "minimum": 1
         },
-        "throttling": {
-          "$ref": "#/$defs/throttlingConfig"
+        "enabled": {
+          "description": "Legacy compatibility field currently ignored.",
+          "deprecated": true,
+          "type": "boolean"
+        },
+        "maxRequestsPerMinute": {
+          "description": "Legacy compatibility alias currently ignored at runtime.",
+          "deprecated": true,
+          "type": "integer",
+          "minimum": 1
         }
       }
     },
@@ -612,6 +686,11 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "maxConcurrentFixes": {
+          "description": "Maximum number of fixes generated concurrently.",
+          "type": "integer",
+          "minimum": 1
+        },
         "enabled": {
           "description": "Enable fix stage behaviours.",
           "deprecated": true,
@@ -620,8 +699,7 @@
         "prompt": {
           "description": "Optional fix prompt override used by fix generation workflows.",
           "deprecated": true,
-          "type": "string",
-          "minLength": 1
+          "$ref": "#/$defs/nonEmptyString"
         },
         "severities": {
           "description": "Severities eligible for fix generation.",
@@ -633,11 +711,6 @@
           "deprecated": true,
           "$ref": "#/$defs/confidenceScore"
         },
-        "maxConcurrentFixes": {
-          "description": "Maximum number of fixes generated concurrently.",
-          "type": "integer",
-          "minimum": 1
-        },
         "autoApply": {
           "description": "If true, enables automatic application of generated fixes when requested by stage options.",
           "deprecated": true,
@@ -645,17 +718,30 @@
         }
       }
     },
+    "severityList": {
+      "description": "Non-empty array of severity levels.",
+      "type": "array",
+      "minItems": 1,
+      "uniqueItems": true,
+      "items": {
+        "$ref": "#/$defs/severity"
+      }
+    },
+    "severity": {
+      "description": "Standard issue severity levels used across review, fix, and reporting.",
+      "type": "string",
+      "enum": [
+        "critical",
+        "high",
+        "medium",
+        "low"
+      ]
+    },
     "reportConfig": {
       "description": "Report rendering and severity filtering settings used by report and CI outputs.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "outputFormat": {
-          "description": "Preferred report format.",
-          "deprecated": true,
-          "type": "string",
-          "enum": ["json", "html", "markdown"]
-        },
         "includedSeverities": {
           "description": "Only issues with these severities are included in report outputs.",
           "$ref": "#/$defs/severityList"
@@ -667,19 +753,28 @@
         "enableRootCauseExtraction": {
           "description": "Enable post-processing that classifies issues into root-cause buckets.",
           "type": "boolean"
+        },
+        "outputFormat": {
+          "description": "Preferred report format.",
+          "deprecated": true,
+          "$ref": "#/$defs/outputFormat"
         }
       }
+    },
+    "outputFormat": {
+      "description": "Output format for reports and generated files.",
+      "type": "string",
+      "enum": [
+        "json",
+        "html",
+        "markdown"
+      ]
     },
     "githubConfig": {
       "description": "GitHub pull request integration settings.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "enabled": {
-          "description": "Enable GitHub integration behaviour.",
-          "deprecated": true,
-          "type": "boolean"
-        },
         "postComments": {
           "description": "Post or update a QualOps PR comment.",
           "type": "boolean"
@@ -696,6 +791,11 @@
           "description": "Maximum number of inline annotations/comments created per run.",
           "type": "integer",
           "minimum": 1
+        },
+        "enabled": {
+          "description": "Enable GitHub integration behaviour.",
+          "deprecated": true,
+          "type": "boolean"
         }
       }
     },
@@ -704,6 +804,10 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
+        "blockPipeline": {
+          "description": "Fail CI pipeline when configured quality conditions are not met.",
+          "type": "boolean"
+        },
         "enabled": {
           "description": "Enable GitLab integration behaviour.",
           "deprecated": true,
@@ -718,10 +822,6 @@
           "description": "Skip MR updates for draft merge requests when supported.",
           "deprecated": true,
           "type": "boolean"
-        },
-        "blockPipeline": {
-          "description": "Fail CI pipeline when configured quality conditions are not met.",
-          "type": "boolean"
         }
       }
     },
@@ -732,18 +832,15 @@
       "properties": {
         "sessionsDir": {
           "description": "Custom sessions directory path.",
-          "type": "string",
-          "minLength": 1
+          "$ref": "#/$defs/nonEmptyString"
         },
         "cacheDir": {
           "description": "Custom cache directory path.",
-          "type": "string",
-          "minLength": 1
+          "$ref": "#/$defs/nonEmptyString"
         },
         "outputDir": {
           "description": "Custom output directory path.",
-          "type": "string",
-          "minLength": 1
+          "$ref": "#/$defs/nonEmptyString"
         }
       }
     },
@@ -753,9 +850,7 @@
       "additionalProperties": false,
       "properties": {
         "level": {
-          "description": "Minimum log level to emit.",
-          "type": "string",
-          "enum": ["debug", "info", "warn", "error"]
+          "$ref": "#/$defs/logLevel"
         },
         "enableColors": {
           "description": "Enable ANSI colorized logs.",
@@ -770,6 +865,16 @@
           "type": "string"
         }
       }
+    },
+    "logLevel": {
+      "description": "Minimum log level to emit.",
+      "type": "string",
+      "enum": [
+        "debug",
+        "info",
+        "warn",
+        "error"
+      ]
     }
   }
 }

--- a/docs/qualops-config.schema.json
+++ b/docs/qualops-config.schema.json
@@ -308,7 +308,7 @@
       "description": "Prompt reference as a relative path string or { file, meta } object.",
       "oneOf": [
         {
-          "$ref": "#/$defs/nonEmptyString"
+          "$ref": "#/$defs/relativePath"
         },
         {
           "$ref": "#/$defs/promptConfig"
@@ -325,7 +325,7 @@
       "properties": {
         "file": {
           "description": "Prompt file path relative to .qualops/prompts.",
-          "$ref": "#/$defs/nonEmptyString"
+          "$ref": "#/$defs/relativePath"
         },
         "meta": {
           "description": "Optional metadata that can be used by prompt templates.",
@@ -430,7 +430,7 @@
         },
         "agentsDir": {
           "description": "Directory containing external custom agent files.",
-          "$ref": "#/$defs/nonEmptyString"
+          "$ref": "#/$defs/relativePath"
         },
         "systemPrompt": {
           "description": "Additional system instructions appended to the default agentic prompt.",
@@ -876,6 +876,11 @@
         "warn",
         "error"
       ]
+    },
+    "relativePath": {
+      "$ref": "#/$defs/nonEmptyString",
+      "type": "string",
+      "minLength": 1
     }
   }
 }

--- a/docs/qualops-config.schema.json
+++ b/docs/qualops-config.schema.json
@@ -276,7 +276,8 @@
           "type": "integer",
           "minimum": 1
         }
-      }
+      },
+      "passthrough": true
     },
     "confidenceScore": {
       "description": "Integer confidence score from 1 (lowest) to 10 (highest).",

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "eval:upload:all": "node evals/src/upload-datasets.js --source=all",
     "eval:upload:qualops": "node evals/src/upload-datasets.js --source=qualops",
     "eval:upload:crb:all": "node evals/src/upload-datasets.js --source=crb",
-    "eval:recall-report": "node evals/src/recall-report.js"
+    "eval:recall-report": "node evals/src/recall-report.js",
+    "generate:schema": "tsx scripts/generate-config-schema.ts"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.75",

--- a/scripts/config-schema/post-process.ts
+++ b/scripts/config-schema/post-process.ts
@@ -1,0 +1,399 @@
+/**
+ * Post-processing utilities for Zod-generated JSON Schemas.
+ *
+ * Zod's toJSONSchema generates auto-named $defs (__schema0, __schema1, ...).
+ * Each Zod schema tagged with `.meta({ defName: '...' })` gets that name
+ * propagated into the JSON Schema output as a `defName` property.
+ *
+ * These functions:
+ * 1. Rename $defs using the `defName` metadata from each definition
+ * 2. Inline unnamed trivial $defs (bare booleans, simple integers, $ref indirections)
+ * 3. Strip `defName` properties from the final output
+ * 4. Reorder properties for readable, predictable output
+ */
+
+type Defs = Record<string, Record<string, unknown>>;
+
+export interface RefContext {
+  renameMap: Record<string, string>;
+  inlineSet: Set<string>;
+  defs: Defs;
+}
+
+const DEFS_REF_RE = /^#\/\$defs\/(.+)$/;
+
+export function postProcessDefs(schema: Record<string, unknown>): void {
+  const defs = schema.$defs as Defs | undefined;
+  if (!defs) return;
+
+  extractNamedInlineDefs(schema, defs);
+
+  const ctx: RefContext = {
+    renameMap: buildRenameMap(defs),
+    inlineSet: buildInlineSet(defs),
+    defs,
+  };
+
+  rewriteRefs(schema, ctx);
+  normalizeZodOutput(schema);
+  applyRenamesAndPrune(defs, ctx);
+  deduplicateRefDescriptions(schema, defs);
+}
+
+function applyRenamesAndPrune(defs: Defs, { renameMap, inlineSet }: RefContext): void {
+  for (const key of inlineSet) {
+    delete defs[key];
+  }
+
+  const kept = new Set<string>();
+  for (const [oldName, newName] of Object.entries(renameMap)) {
+    if (inlineSet.has(oldName)) continue;
+    if (kept.has(newName)) {
+      delete defs[oldName];
+      continue;
+    }
+    kept.add(newName);
+    if (oldName !== newName) {
+      defs[newName] = defs[oldName];
+      delete defs[oldName];
+    }
+  }
+}
+
+/**
+ * If the child object has a `defName` and no existing `$ref`, extract it into
+ * `$defs` and return a `$ref` + sibling properties replacement. Returns null
+ * if the child should not be extracted.
+ */
+function liftToDef(child: Record<string, unknown>, defs: Defs): Record<string, unknown> | null {
+  const defName = child.defName as string | undefined;
+  if (!defName || child.$ref) return null;
+  if (defs[defName]) return null;
+
+  const extracted: Record<string, unknown> = {};
+  const sibling: Record<string, unknown> = { $ref: `#/$defs/${defName}` };
+
+  for (const [k, v] of Object.entries(child)) {
+    if (k === 'defName') continue;
+    if (k === 'description') {
+      sibling[k] = v;
+      extracted[k] = v;
+    } else if (k === 'deprecated') {
+      sibling[k] = v;
+    } else {
+      extracted[k] = v;
+    }
+  }
+
+  extracted.defName = defName;
+  defs[defName] = extracted;
+  return sibling;
+}
+
+export function extractNamedInlineDefs(node: unknown, defs: Defs): void {
+  if (node === null || typeof node !== 'object') return;
+
+  if (Array.isArray(node)) {
+    for (let i = 0; i < node.length; i++) {
+      extractNamedInlineDefs(node[i], defs);
+      if (node[i] !== null && typeof node[i] === 'object' && !Array.isArray(node[i])) {
+        const replacement = liftToDef(node[i] as Record<string, unknown>, defs);
+        if (replacement) node[i] = replacement;
+      }
+    }
+    return;
+  }
+
+  const obj = node as Record<string, unknown>;
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+      extractNamedInlineDefs(value, defs);
+      continue;
+    }
+
+    const child = value as Record<string, unknown>;
+    extractNamedInlineDefs(child, defs);
+
+    const replacement = liftToDef(child, defs);
+    if (replacement) obj[key] = replacement;
+  }
+}
+
+export function buildRenameMap(defs: Defs): Record<string, string> {
+  const map: Record<string, string> = {};
+
+  for (const [key, def] of Object.entries(defs)) {
+    const name = (def.defName as string) ?? null;
+    map[key] = name ?? key;
+  }
+
+  return map;
+}
+
+/**
+ * $defs without a defName that are trivial primitives get inlined at usage sites.
+ */
+export function buildInlineSet(defs: Defs): Set<string> {
+  const inlinable = new Set<string>();
+
+  for (const [key, def] of Object.entries(defs)) {
+    if (def.defName) continue;
+    if (def.$ref) {
+      inlinable.add(key);
+      continue;
+    }
+    const type = def.type as string | undefined;
+    const isPrimitive = type === 'boolean' || type === 'number' || type === 'string';
+    const isConstrainedInt = type === 'integer' && !def.enum;
+    if (isPrimitive || isConstrainedInt) {
+      inlinable.add(key);
+    }
+    if (type === 'object' && !def.properties) {
+      inlinable.add(key);
+    }
+    if (type === 'array') {
+      inlinable.add(key);
+    }
+    if (Object.keys(def).length === 0) {
+      inlinable.add(key);
+    }
+  }
+
+  return inlinable;
+}
+
+export function rewriteRefs(node: unknown, ctx: RefContext): void {
+  if (node === null || typeof node !== 'object') return;
+
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      rewriteRefs(item, ctx);
+    }
+    return;
+  }
+
+  const obj = node as Record<string, unknown>;
+
+  for (const [prop, value] of Object.entries(obj)) {
+    if (prop === '$ref' && typeof value === 'string') {
+      rewriteRefProperty(obj, value, ctx);
+      return;
+    }
+    rewriteRefs(value, ctx);
+  }
+}
+
+function rewriteRefProperty(obj: Record<string, unknown>, ref: string, ctx: RefContext): void {
+  const match = ref.match(DEFS_REF_RE);
+  if (!match) return;
+
+  const refName = match[1];
+  const { renameMap, inlineSet, defs } = ctx;
+
+  if (inlineSet.has(refName)) {
+    const merged = resolveRefChain(defs, refName, ctx);
+    delete obj.$ref;
+    if (merged) {
+      for (const [k, v] of Object.entries(merged)) {
+        if (!(k in obj)) obj[k] = v;
+      }
+    }
+    rewriteRefs(obj, ctx);
+  } else if (renameMap[refName] && renameMap[refName] !== refName) {
+    obj.$ref = `#/$defs/${renameMap[refName]}`;
+  }
+}
+
+/**
+ * Follow a $ref chain, collecting non-$ref properties from each node.
+ * Stops at named defs (those not in inlineSet) — preserving the $ref so the
+ * named def stays referenced rather than being fully flattened.
+ *
+ * E.g. { deprecated: true, $ref: "#/$defs/__s0" } where __s0 = { type: "boolean" }
+ * yields { deprecated: true, type: "boolean" }.
+ *
+ * But { description: "...", $ref: "#/$defs/__s0" } where __s0 refs a named def
+ * yields { description: "...", $ref: "#/$defs/namedDef" }.
+ */
+export function resolveRefChain(
+  defs: Defs,
+  startName: string,
+  ctx: RefContext,
+): Record<string, unknown> | null {
+  const merged: Record<string, unknown> = {};
+  let current = defs[startName];
+
+  while (current) {
+    for (const [k, v] of Object.entries(current)) {
+      if (k !== '$ref' && !(k in merged)) {
+        merged[k] = v;
+      }
+    }
+    const ref = current.$ref as string | undefined;
+    if (!ref) break;
+
+    const innerMatch = ref.match(DEFS_REF_RE);
+    if (!innerMatch) break;
+
+    const targetName = innerMatch[1];
+    if (!ctx.inlineSet.has(targetName)) {
+      merged.$ref = `#/$defs/${ctx.renameMap[targetName] ?? targetName}`;
+      break;
+    }
+    current = defs[targetName];
+  }
+
+  return Object.keys(merged).length > 0 ? merged : null;
+}
+
+/**
+ * Normalize Zod-specific JSON Schema output quirks into conventional JSON Schema.
+ * Applied recursively to every node in the schema tree.
+ */
+export function normalizeZodOutput(node: unknown): void {
+  if (node === null || typeof node !== 'object') return;
+
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      normalizeZodOutput(item);
+    }
+    return;
+  }
+
+  const obj = node as Record<string, unknown>;
+  normalizeNode(obj);
+
+  for (const value of Object.values(obj)) {
+    normalizeZodOutput(value);
+  }
+}
+
+function normalizeNode(obj: Record<string, unknown>): void {
+  delete obj.defName;
+
+  if ('const' in obj && typeof obj.const === 'string') {
+    obj.enum = [obj.const];
+    delete obj.const;
+  }
+
+  if (
+    'additionalProperties' in obj &&
+    typeof obj.additionalProperties === 'object' &&
+    obj.additionalProperties !== null &&
+    Object.keys(obj.additionalProperties as object).length === 0
+  ) {
+    obj.additionalProperties = true;
+  }
+
+  if (obj.type === 'integer' && obj.maximum === Number.MAX_SAFE_INTEGER) {
+    delete obj.maximum;
+  }
+
+  if (Array.isArray(obj.anyOf) && !obj.oneOf) {
+    obj.oneOf = obj.anyOf;
+    delete obj.anyOf;
+  }
+
+  if (
+    'propertyNames' in obj &&
+    typeof obj.propertyNames === 'object' &&
+    obj.propertyNames !== null
+  ) {
+    const pn = obj.propertyNames as Record<string, unknown>;
+    if (Object.keys(pn).length === 1 && pn.type === 'string') {
+      delete obj.propertyNames;
+    }
+  }
+}
+
+/**
+ * Remove description siblings on $ref nodes when they duplicate the
+ * referenced def's own description — avoids redundant text in the output.
+ */
+export function deduplicateRefDescriptions(node: unknown, defs: Defs): void {
+  if (node === null || typeof node !== 'object') return;
+
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      deduplicateRefDescriptions(item, defs);
+    }
+    return;
+  }
+
+  const obj = node as Record<string, unknown>;
+
+  if (typeof obj.$ref === 'string' && typeof obj.description === 'string') {
+    const match = (obj.$ref as string).match(DEFS_REF_RE);
+    if (match) {
+      const def = defs[match[1]];
+      if (def && def.description === obj.description) {
+        delete obj.description;
+      }
+    }
+  }
+
+  for (const value of Object.values(obj)) {
+    deduplicateRefDescriptions(value, defs);
+  }
+}
+
+/**
+ * Reorder JSON Schema properties so metadata comes first, data structures last.
+ * Applied recursively to produce readable, predictable output.
+ */
+const KNOWN_ORDER = [
+  '$schema',
+  '$id',
+  'title',
+  'description',
+  'deprecated',
+  '$ref',
+  'type',
+  'additionalProperties',
+  'enum',
+  'const',
+  'minimum',
+  'maximum',
+  'minLength',
+  'maxLength',
+  'minItems',
+  'maxItems',
+  'uniqueItems',
+  'format',
+  'default',
+  'required',
+  'properties',
+  'items',
+  'anyOf',
+  'oneOf',
+  'allOf',
+  'if',
+  'then',
+  'else',
+  '$defs',
+];
+
+export function orderProperties(node: unknown): unknown {
+  if (node === null || typeof node !== 'object') return node;
+
+  if (Array.isArray(node)) {
+    return node.map(orderProperties);
+  }
+
+  const obj = node as Record<string, unknown>;
+  const ordered: Record<string, unknown> = {};
+
+  for (const key of KNOWN_ORDER) {
+    if (key in obj) {
+      ordered[key] = orderProperties(obj[key]);
+    }
+  }
+  for (const key of Object.keys(obj)) {
+    if (!(key in ordered)) {
+      ordered[key] = orderProperties(obj[key]);
+    }
+  }
+
+  return ordered;
+}

--- a/scripts/config-schema/post-process.ts
+++ b/scripts/config-schema/post-process.ts
@@ -3,13 +3,8 @@
  *
  * Zod's toJSONSchema generates auto-named $defs (__schema0, __schema1, ...).
  * Each Zod schema tagged with `.meta({ defName: '...' })` gets that name
- * propagated into the JSON Schema output as a `defName` property.
- *
- * These functions:
- * 1. Rename $defs using the `defName` metadata from each definition
- * 2. Inline unnamed trivial $defs (bare booleans, simple integers, $ref indirections)
- * 3. Strip `defName` properties from the final output
- * 4. Reorder properties for readable, predictable output
+ * propagated into the JSON Schema output as a `defName` property, which these
+ * utilities then use to rename, inline, and clean up the generated schema.
  */
 
 type Defs = Record<string, Record<string, unknown>>;
@@ -90,34 +85,63 @@ function liftToDef(child: Record<string, unknown>, defs: Defs): Record<string, u
   return sibling;
 }
 
-export function extractNamedInlineDefs(node: unknown, defs: Defs): void {
-  if (node === null || typeof node !== 'object') return;
+type NodeObject = Record<string, unknown>;
+type NodeArray = unknown[];
+type WalkNode = NodeObject | NodeArray;
 
-  if (Array.isArray(node)) {
-    for (let i = 0; i < node.length; i++) {
-      extractNamedInlineDefs(node[i], defs);
-      if (node[i] !== null && typeof node[i] === 'object' && !Array.isArray(node[i])) {
-        const replacement = liftToDef(node[i] as Record<string, unknown>, defs);
-        if (replacement) node[i] = replacement;
+/**
+ * Visitor called once per object/array node during a walk. May mutate the
+ * node in place. Returning a new object/array replaces the node at its
+ * parent (the walker handles the reassignment). Returning void/undefined
+ * keeps the original node.
+ */
+type Visitor = (node: WalkNode) => WalkNode | void;
+
+/**
+ * Depth-first tree walker for JSON Schema nodes. Recurses into every object
+ * property and every array element. Primitives are returned as-is.
+ *
+ * - `order: 'pre'` (default) — visit parent, then recurse into children.
+ * - `order: 'post'` — recurse into children, then visit parent.
+ */
+function walk(node: unknown, visit: Visitor, order: 'pre' | 'post' = 'pre'): unknown {
+  if (node === null || typeof node !== 'object') return node;
+
+  const recurseChildren = (current: WalkNode): void => {
+    if (Array.isArray(current)) {
+      for (let i = 0; i < current.length; i++) {
+        current[i] = walk(current[i], visit, order);
+      }
+    } else {
+      for (const key of Object.keys(current)) {
+        current[key] = walk(current[key], visit, order);
       }
     }
-    return;
+  };
+
+  let current = node as WalkNode;
+
+  if (order === 'pre') {
+    const replaced = visit(current);
+    if (replaced !== undefined) current = replaced;
+    recurseChildren(current);
+    return current;
   }
 
-  const obj = node as Record<string, unknown>;
+  recurseChildren(current);
+  const replaced = visit(current);
+  return replaced ?? current;
+}
 
-  for (const [key, value] of Object.entries(obj)) {
-    if (value === null || typeof value !== 'object' || Array.isArray(value)) {
-      extractNamedInlineDefs(value, defs);
-      continue;
-    }
-
-    const child = value as Record<string, unknown>;
-    extractNamedInlineDefs(child, defs);
-
-    const replacement = liftToDef(child, defs);
-    if (replacement) obj[key] = replacement;
-  }
+export function extractNamedInlineDefs(node: unknown, defs: Defs): void {
+  walk(
+    node,
+    (n) => {
+      if (Array.isArray(n)) return;
+      return liftToDef(n, defs) ?? undefined;
+    },
+    'post',
+  );
 }
 
 export function buildRenameMap(defs: Defs): Record<string, string> {
@@ -164,24 +188,17 @@ export function buildInlineSet(defs: Defs): Set<string> {
 }
 
 export function rewriteRefs(node: unknown, ctx: RefContext): void {
-  if (node === null || typeof node !== 'object') return;
-
-  if (Array.isArray(node)) {
-    for (const item of node) {
-      rewriteRefs(item, ctx);
+  walk(node, (n) => {
+    if (Array.isArray(n)) return;
+    // Loop handles the case where inlining merges in a new $ref
+    // (e.g., chain resolution stops at a named def). After at most one
+    // additional pass the ref is either fully inlined or canonicalized.
+    while (typeof n.$ref === 'string') {
+      const before = n.$ref;
+      rewriteRefProperty(n, before, ctx);
+      if (n.$ref === before) break;
     }
-    return;
-  }
-
-  const obj = node as Record<string, unknown>;
-
-  for (const [prop, value] of Object.entries(obj)) {
-    if (prop === '$ref' && typeof value === 'string') {
-      rewriteRefProperty(obj, value, ctx);
-      return;
-    }
-    rewriteRefs(value, ctx);
-  }
+  });
 }
 
 function rewriteRefProperty(obj: Record<string, unknown>, ref: string, ctx: RefContext): void {
@@ -199,7 +216,6 @@ function rewriteRefProperty(obj: Record<string, unknown>, ref: string, ctx: RefC
         if (!(k in obj)) obj[k] = v;
       }
     }
-    rewriteRefs(obj, ctx);
   } else if (renameMap[refName] && renameMap[refName] !== refName) {
     obj.$ref = `#/$defs/${renameMap[refName]}`;
   }
@@ -249,24 +265,11 @@ export function resolveRefChain(
 
 /**
  * Normalize Zod-specific JSON Schema output quirks into conventional JSON Schema.
- * Applied recursively to every node in the schema tree.
  */
 export function normalizeZodOutput(node: unknown): void {
-  if (node === null || typeof node !== 'object') return;
-
-  if (Array.isArray(node)) {
-    for (const item of node) {
-      normalizeZodOutput(item);
-    }
-    return;
-  }
-
-  const obj = node as Record<string, unknown>;
-  normalizeNode(obj);
-
-  for (const value of Object.values(obj)) {
-    normalizeZodOutput(value);
-  }
+  walk(node, (n) => {
+    if (!Array.isArray(n)) normalizeNode(n);
+  });
 }
 
 function normalizeNode(obj: Record<string, unknown>): void {
@@ -312,36 +315,19 @@ function normalizeNode(obj: Record<string, unknown>): void {
  * referenced def's own description — avoids redundant text in the output.
  */
 export function deduplicateRefDescriptions(node: unknown, defs: Defs): void {
-  if (node === null || typeof node !== 'object') return;
-
-  if (Array.isArray(node)) {
-    for (const item of node) {
-      deduplicateRefDescriptions(item, defs);
+  walk(node, (n) => {
+    if (Array.isArray(n)) return;
+    if (typeof n.$ref !== 'string' || typeof n.description !== 'string') return;
+    const match = n.$ref.match(DEFS_REF_RE);
+    if (!match) return;
+    const def = defs[match[1]];
+    if (def && def.description === n.description) {
+      delete n.description;
     }
-    return;
-  }
-
-  const obj = node as Record<string, unknown>;
-
-  if (typeof obj.$ref === 'string' && typeof obj.description === 'string') {
-    const match = (obj.$ref as string).match(DEFS_REF_RE);
-    if (match) {
-      const def = defs[match[1]];
-      if (def && def.description === obj.description) {
-        delete obj.description;
-      }
-    }
-  }
-
-  for (const value of Object.values(obj)) {
-    deduplicateRefDescriptions(value, defs);
-  }
+  });
 }
 
-/**
- * Reorder JSON Schema properties so metadata comes first, data structures last.
- * Applied recursively to produce readable, predictable output.
- */
+/** Reorder JSON Schema properties so metadata comes first, data structures last. */
 const KNOWN_ORDER = [
   '$schema',
   '$id',
@@ -375,25 +361,15 @@ const KNOWN_ORDER = [
 ];
 
 export function orderProperties(node: unknown): unknown {
-  if (node === null || typeof node !== 'object') return node;
-
-  if (Array.isArray(node)) {
-    return node.map(orderProperties);
-  }
-
-  const obj = node as Record<string, unknown>;
-  const ordered: Record<string, unknown> = {};
-
-  for (const key of KNOWN_ORDER) {
-    if (key in obj) {
-      ordered[key] = orderProperties(obj[key]);
+  return walk(node, (n) => {
+    if (Array.isArray(n)) return;
+    const ordered: Record<string, unknown> = {};
+    for (const key of KNOWN_ORDER) {
+      if (key in n) ordered[key] = n[key];
     }
-  }
-  for (const key of Object.keys(obj)) {
-    if (!(key in ordered)) {
-      ordered[key] = orderProperties(obj[key]);
+    for (const key of Object.keys(n)) {
+      if (!(key in ordered)) ordered[key] = n[key];
     }
-  }
-
-  return ordered;
+    return ordered;
+  });
 }

--- a/scripts/generate-config-schema.ts
+++ b/scripts/generate-config-schema.ts
@@ -1,0 +1,21 @@
+import { writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { z } from 'zod';
+
+import { qualopsConfigSchema } from '../src/config/config-schema';
+import { orderProperties, postProcessDefs } from './config-schema/post-process';
+
+const jsonSchema = z.toJSONSchema(qualopsConfigSchema, {
+  reused: 'ref',
+}) as Record<string, unknown>;
+
+jsonSchema.$id = 'https://egg-ai.com/schemas/qualops-config.schema.json';
+jsonSchema.title = 'QualOps Configuration';
+jsonSchema.description = 'Schema for QualOps project configuration.';
+
+postProcessDefs(jsonSchema);
+
+const outPath = join(__dirname, '../docs/qualops-config.schema.json');
+writeFileSync(outPath, JSON.stringify(orderProperties(jsonSchema), null, 2) + '\n');
+console.log(`Generated JSON Schema at ${outPath}`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import { Command } from 'commander';
 import { executeAllStages } from './cli/commands/all-command';
 import { generateIndexCommand } from './cli/commands/generate-index-command';
 import { initClaudeCommand } from './cli/commands/init-claude-command';
+import { validateCommand } from './cli/commands/validate-command';
 import { withErrorHandling } from './cli/utils/error-handler';
 import { formatHelpText } from './cli/utils/help-formatter';
 import { DEFAULT_CONFIG_PATH } from './config/config';
@@ -48,6 +49,14 @@ program
     const parentOpts = command.parent?.opts() || {};
     const merged = { ...parentOpts, ...options };
     return withErrorHandling(generateIndexCommand, 'generate-index')(merged);
+  });
+
+program
+  .command('validate')
+  .description('Validate the config file without running any stages')
+  .action(function (_opts: Record<string, unknown>, command: Command) {
+    const parentOpts = command.parent?.opts() || {};
+    return withErrorHandling(validateCommand, 'validate')(parentOpts);
   });
 
 program

--- a/src/cli/commands/validate-command.ts
+++ b/src/cli/commands/validate-command.ts
@@ -1,0 +1,43 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { isAbsolute, join } from 'node:path';
+
+import { ConfigParseError, assertValidConfig, collectConfigWarnings } from '../../config/schema-validator';
+import { logger } from '../../shared/utils/logger';
+
+export async function validateCommand(options: Record<string, unknown>): Promise<void> {
+  const configPath = (options.config as string) || '.qualops/.qualopsrc.json';
+  const rcPath = isAbsolute(configPath) ? configPath : join(process.cwd(), configPath);
+
+  if (!existsSync(rcPath)) {
+    logger.error(`Config file not found: ${rcPath}`);
+    process.exit(1);
+  }
+
+  let rawConfig: Record<string, unknown>;
+  try {
+    rawConfig = JSON.parse(readFileSync(rcPath, 'utf-8'));
+  } catch (error) {
+    throw new ConfigParseError(rcPath, error instanceof Error ? error : new Error(String(error)));
+  }
+
+  assertValidConfig(rawConfig);
+
+  const warnings = collectConfigWarnings(rawConfig);
+
+  for (const dep of warnings.deprecations) {
+    logger.warn(`Deprecated field "${dep.path}": ${dep.description}`);
+  }
+  for (const unknown of warnings.unknownFields) {
+    logger.warn(
+      `Unknown field "${unknown.field}" at ${unknown.path} — ` +
+        `if this is a provider-specific option it will be passed through; otherwise check for a typo.`,
+    );
+  }
+
+  const warningCount = warnings.deprecations.length + warnings.unknownFields.length;
+  if (warningCount > 0) {
+    logger.info(`Config is valid with ${warningCount} warning(s).`);
+  } else {
+    logger.info('Config is valid.');
+  }
+}

--- a/src/cli/commands/validate-command.ts
+++ b/src/cli/commands/validate-command.ts
@@ -1,7 +1,11 @@
 import { existsSync, readFileSync } from 'node:fs';
 import { isAbsolute, join } from 'node:path';
 
-import { ConfigParseError, assertValidConfig, collectConfigWarnings } from '../../config/schema-validator';
+import {
+  ConfigParseError,
+  assertValidConfig,
+  collectConfigWarnings,
+} from '../../config/schema-validator';
 import { logger } from '../../shared/utils/logger';
 
 export async function validateCommand(options: Record<string, unknown>): Promise<void> {

--- a/src/cli/utils/error-handler.ts
+++ b/src/cli/utils/error-handler.ts
@@ -9,7 +9,6 @@ export function handleError(error: unknown, context?: string): never {
   const contextMsg = context ? `${context}: ` : '';
 
   if (isUserFacingError(error)) {
-    // Pre-formatted, human-readable — print as-is, no stack trace.
     logger.error(error.message);
   } else if (error instanceof Error) {
     logger.error(`${contextMsg}${error.message}`);
@@ -25,7 +24,6 @@ export function handleError(error: unknown, context?: string): never {
 
 export function handleStageError(stage: string, error: unknown): never {
   if (isUserFacingError(error)) {
-    // Pre-formatted, human-readable — print as-is, no stack trace or stage prefix.
     logger.error(error.message);
   } else {
     logger.error(`${stage} failed:`, error instanceof Error ? error.message : error);

--- a/src/cli/utils/error-handler.ts
+++ b/src/cli/utils/error-handler.ts
@@ -1,9 +1,17 @@
 import { logger } from '../../shared/utils/logger';
 
+/** Errors with `userFacing: true` are displayed without a stack trace. */
+function isUserFacingError(error: unknown): error is Error & { userFacing: true } {
+  return error instanceof Error && (error as { userFacing?: unknown }).userFacing === true;
+}
+
 export function handleError(error: unknown, context?: string): never {
   const contextMsg = context ? `${context}: ` : '';
 
-  if (error instanceof Error) {
+  if (isUserFacingError(error)) {
+    // Pre-formatted, human-readable — print as-is, no stack trace.
+    logger.error(error.message);
+  } else if (error instanceof Error) {
     logger.error(`${contextMsg}${error.message}`);
     if (error.stack) {
       logger.error('Stack trace:', error.stack);
@@ -16,9 +24,14 @@ export function handleError(error: unknown, context?: string): never {
 }
 
 export function handleStageError(stage: string, error: unknown): never {
-  logger.error(`${stage} failed:`, error instanceof Error ? error.message : error);
-  if (error instanceof Error && error.stack) {
-    logger.error('Stack trace:', error.stack);
+  if (isUserFacingError(error)) {
+    // Pre-formatted, human-readable — print as-is, no stack trace or stage prefix.
+    logger.error(error.message);
+  } else {
+    logger.error(`${stage} failed:`, error instanceof Error ? error.message : error);
+    if (error instanceof Error && error.stack) {
+      logger.error('Stack trace:', error.stack);
+    }
   }
   process.exit(1);
 }

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -1,3 +1,5 @@
+import { isAbsolute, normalize } from 'node:path';
+
 import { z } from 'zod';
 
 // --- Reusable primitives ---
@@ -20,6 +22,13 @@ const confidenceScore = z.int().min(1).max(10).meta({
 });
 const nonEmptyString = z.string().min(1).meta({ defName: 'nonEmptyString' });
 const nonEmptyStringArray = z.array(nonEmptyString).meta({ defName: 'nonEmptyStringArray' });
+const relativePath = nonEmptyString
+  .refine((p) => !isAbsolute(p), 'Must be a relative path.')
+  .refine(
+    (p) => !normalize(p).startsWith('..'),
+    'Path must not traverse outside its base directory.',
+  )
+  .meta({ defName: 'relativePath' });
 const outputFormat = z.enum(['json', 'html', 'markdown']).meta({
   defName: 'outputFormat',
   description: 'Output format for reports and generated files.',
@@ -75,7 +84,7 @@ const aiConfigSchema = z
 // --- Prompt config ---
 export const promptConfigSchema = z
   .object({
-    file: nonEmptyString.meta({ description: 'Prompt file path relative to .qualops/prompts.' }),
+    file: relativePath.meta({ description: 'Prompt file path relative to .qualops/prompts.' }),
     meta: z
       .record(z.string(), z.unknown())
       .optional()
@@ -87,7 +96,7 @@ export const promptConfigSchema = z
     description: 'Prompt reference object with optional metadata.',
   });
 
-const promptRef = z.union([nonEmptyString, promptConfigSchema]).meta({
+const promptRef = z.union([relativePath, promptConfigSchema]).meta({
   defName: 'promptRef',
   description: 'Prompt reference as a relative path string or { file, meta } object.',
 });
@@ -213,7 +222,7 @@ export const agenticConfigSchema = z
       .array(customAgentDefinitionSchema)
       .optional()
       .meta({ description: 'Custom agents loaded from config and optional agents directory.' }),
-    agentsDir: nonEmptyString
+    agentsDir: relativePath
       .optional()
       .meta({ description: 'Directory containing external custom agent files.' }),
     systemPrompt: z.string().optional().meta({

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -1,0 +1,642 @@
+import { z } from 'zod';
+
+// --- Reusable primitives ---
+
+const severity = z.enum(['critical', 'high', 'medium', 'low']).meta({
+  defName: 'severity',
+  description: 'Standard issue severity levels used across review, fix, and reporting.',
+});
+const severityList = z.array(severity).min(1).meta({
+  defName: 'severityList',
+  description: 'Non-empty array of severity levels.',
+  uniqueItems: true,
+});
+const aiProvider = z
+  .enum(['anthropic', 'openai', 'bedrock', 'github'])
+  .meta({ defName: 'aiProvider', description: 'Supported AI provider names.' });
+const confidenceScore = z.int().min(1).max(10).meta({
+  defName: 'confidenceScore',
+  description: 'Integer confidence score from 1 (lowest) to 10 (highest).',
+});
+const nonEmptyString = z.string().min(1).meta({ defName: 'nonEmptyString' });
+const nonEmptyStringArray = z.array(nonEmptyString).meta({ defName: 'nonEmptyStringArray' });
+const outputFormat = z.enum(['json', 'html', 'markdown']).meta({
+  defName: 'outputFormat',
+  description: 'Output format for reports and generated files.',
+});
+
+// --- AI stage config ---
+// .passthrough() because providers may have extra fields (e.g. topP, topK)
+const aiStageConfigSchema = z
+  .object({
+    provider: aiProvider,
+    model: nonEmptyString.meta({ description: 'Model name passed to the selected provider.' }),
+    inputPerMillion: z
+      .number()
+      .min(0)
+      .meta({ description: 'Estimated input token cost per million tokens.' }),
+    outputPerMillion: z
+      .number()
+      .min(0)
+      .meta({ description: 'Estimated output token cost per million tokens.' }),
+    temperature: z
+      .number()
+      .min(0)
+      .optional()
+      .meta({ description: 'Sampling temperature used by compatible providers.' }),
+    maxTokens: z.int().min(1).optional().meta({ description: 'Optional model output token cap.' }),
+  })
+  .passthrough()
+  .meta({ defName: 'aiStageConfig', description: 'AI configuration for a specific stage.' });
+
+const aiConfigSchema = z
+  .object({
+    reviewStage: aiStageConfigSchema.meta({
+      description:
+        'Settings for the review stage runtime. Although stages can be skipped, a previous review is always required for a fix stage, therefore this setting is required.',
+    }),
+    fixStage: aiStageConfigSchema
+      .optional()
+      .meta({ description: 'Settings for the fix stage runtime.' }),
+    judgeStage: aiStageConfigSchema.optional().meta({
+      description:
+        'Planned settings (currently unused) for configuring the judge stage (not yet implemented).',
+    }),
+  })
+  .strict()
+  .meta({ defName: 'aiConfig', description: 'AI provider and model settings for each stage.' });
+
+// --- Prompt config ---
+export const promptConfigSchema = z
+  .object({
+    file: nonEmptyString.meta({ description: 'Prompt file path relative to .qualops/prompts.' }),
+    meta: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .meta({ description: 'Optional metadata that can be used by prompt templates.' }),
+  })
+  .strict()
+  .meta({
+    defName: 'promptConfig',
+    description: 'Prompt reference object with optional metadata.',
+  });
+
+const promptRef = z.union([nonEmptyString, promptConfigSchema]).meta({
+  defName: 'promptRef',
+  description: 'Prompt reference as a relative path string or { file, meta } object.',
+});
+
+// --- Validation / Deduplication ---
+export const validationConfigSchema = z
+  .object({
+    enabled: z.boolean().optional().meta({ description: 'Enable validation pass for this scope.' }),
+    minConfidence: confidenceScore
+      .optional()
+      .meta({ description: 'Minimum confidence required before/after validation.' }),
+    prompt: promptRef.optional().meta({ description: 'Prompt used for AI-assisted validation.' }),
+  })
+  .strict()
+  .meta({
+    defName: 'validationConfig',
+    description: 'Validation stage settings used to filter/adjust detected issues.',
+  });
+
+export const deduplicationConfigSchema = z
+  .object({
+    enabled: z.boolean().optional().meta({ description: 'Enable deduplication for this scope.' }),
+    prompt: promptRef
+      .optional()
+      .meta({ description: 'Prompt used for AI-assisted deduplication.' }),
+  })
+  .strict()
+  .meta({
+    defName: 'deduplicationConfig',
+    description: 'Deduplication settings used to remove repeated issues per file.',
+  });
+
+// --- Review pass filters ---
+const reviewPassFiltersSchema = z
+  .object({
+    detectionTriggers: nonEmptyStringArray.optional().meta({
+      description: 'Regex patterns tested against file content; at least one match is required.',
+    }),
+    filePatterns: nonEmptyStringArray
+      .optional()
+      .meta({ description: 'Glob patterns a file path must match to be reviewed.' }),
+    excludePatterns: nonEmptyStringArray
+      .optional()
+      .meta({ description: 'Glob patterns that exclude matching files from the pass.' }),
+  })
+  .strict()
+  .meta({
+    defName: 'reviewPassFilters',
+    description: 'File/content filters used to decide whether a pass should review a file.',
+  });
+
+// --- Review pass ---
+export const reviewPassSchema = z
+  .object({
+    name: nonEmptyString.meta({ description: 'Display name for logging and report grouping.' }),
+    enabled: z
+      .boolean()
+      .meta({ description: 'Set false to disable this pass without removing it.' }),
+    docs: nonEmptyString
+      .optional()
+      .meta({ description: 'Optional docs reference used to build doc-aware review prompts.' }),
+    prompt: promptRef.meta({ description: 'Prompt reference used by this review pass.' }),
+    filters: reviewPassFiltersSchema
+      .optional()
+      .meta({ description: 'Optional filters to limit this pass to relevant files/content.' }),
+  })
+  .strict()
+  .meta({
+    defName: 'reviewPass',
+    description: 'Single review pass executed within a file-by-file pipeline job.',
+  });
+
+// --- Custom agent definition ---
+export const customAgentDefinitionSchema = z
+  .object({
+    name: nonEmptyString.meta({ description: 'Unique custom agent name.' }),
+    description: nonEmptyString.meta({
+      description: 'Human-readable purpose of the custom agent.',
+    }),
+    prompt: nonEmptyString.meta({ description: 'System instructions for the custom agent.' }),
+    tools: nonEmptyStringArray
+      .optional()
+      .meta({ description: 'Allowed tool names for the custom agent.' }),
+    model: z
+      .enum(['sonnet', 'opus', 'haiku'])
+      .meta({
+        defName: 'agentModel',
+        description: 'Optional model tier override for this custom agent.',
+      })
+      .optional(),
+  })
+  .strict()
+  .meta({
+    defName: 'customAgentDefinition',
+    description: 'Custom subagent definition merged with built-in agentic subagents.',
+  });
+
+// --- Agentic config ---
+export const agenticSubagentTypeSchema = z
+  .enum(['dependency-tracer', 'breaking-change-detector', 'security-analyzer', 'pattern-validator'])
+  .meta({
+    defName: 'agenticSubagentType',
+    description: 'Built-in subagent identifiers supported in agentic mode.',
+  });
+
+export const agenticConfigSchema = z
+  .object({
+    maxTurns: z
+      .int()
+      .min(1)
+      .optional()
+      .meta({ description: 'Maximum message/tool-call turns for the agentic run.' }),
+    maxBudgetUsd: z
+      .number()
+      .min(0)
+      .optional()
+      .meta({ description: 'Optional budget guardrail for agentic execution.' }),
+    enabledSubagents: z
+      .array(agenticSubagentTypeSchema)
+      .optional()
+      .meta({ description: 'Subset of built-in subagents to enable.' }),
+    customAgents: z
+      .array(customAgentDefinitionSchema)
+      .optional()
+      .meta({ description: 'Custom agents loaded from config and optional agents directory.' }),
+    agentsDir: nonEmptyString
+      .optional()
+      .meta({ description: 'Directory containing external custom agent files.' }),
+    systemPrompt: z.string().optional().meta({
+      description: 'Additional system instructions appended to the default agentic prompt.',
+    }),
+    contextMode: z
+      .enum(['diff', 'full', 'auto'])
+      .meta({
+        defName: 'contextMode',
+        description: 'How file context is sent: diff, full file content, or auto mode.',
+      })
+      .optional(),
+    maxTokensPerFile: z
+      .int()
+      .min(1)
+      .optional()
+      .meta({ description: 'Per-file token budget when building agentic context.' }),
+    maxTotalTokens: z
+      .int()
+      .min(1)
+      .optional()
+      .meta({ description: 'Total token budget for all file contexts in one agentic run.' }),
+  })
+  .strict()
+  .meta({
+    defName: 'agenticConfig',
+    description:
+      'Settings for agentic review execution (cross-file analysis with tools/subagents).',
+  });
+
+// --- Pipeline job (discriminated union by mode) ---
+const pipelineJobSharedFields = {
+  name: nonEmptyString,
+  enabled: z.boolean(),
+  agentic: agenticConfigSchema.optional(),
+  validation: validationConfigSchema.optional(),
+  deduplication: deduplicationConfigSchema.optional(),
+};
+
+const pipelineJobFileByFileSchema = z
+  .object({
+    ...pipelineJobSharedFields,
+    mode: z.literal('file-by-file').optional(),
+    passes: z.array(reviewPassSchema).min(1),
+  })
+  .strict()
+  .meta({
+    defName: 'pipelineJobFileByFile',
+    description: 'Pipeline job in file-by-file mode. Requires at least one pass.',
+  });
+
+const pipelineJobAgenticSchema = z
+  .object({
+    ...pipelineJobSharedFields,
+    mode: z.literal('agentic'),
+    passes: z.array(reviewPassSchema).optional(),
+  })
+  .strict()
+  .meta({
+    defName: 'pipelineJobAgentic',
+    description: 'Pipeline job in agentic mode. Passes are optional in this mode.',
+  });
+
+export const pipelineJobSchema = z
+  .union([pipelineJobAgenticSchema, pipelineJobFileByFileSchema])
+  .meta({
+    defName: 'pipelineJob',
+    description: 'Union type for supported pipeline job modes.',
+  });
+
+// --- Review config ---
+export const reviewConfigSchema = z
+  .object({
+    minConfidence: confidenceScore.optional().meta({
+      description: 'Base confidence threshold used by review and template rendering contexts.',
+    }),
+    maxConcurrentFiles: z
+      .int()
+      .min(1)
+      .optional()
+      .meta({ description: 'Concurrent file reviews for file-by-file pass execution.' }),
+    validation: validationConfigSchema
+      .optional()
+      .meta({ description: 'Global validation settings applied to all pipeline jobs.' }),
+    deduplication: deduplicationConfigSchema
+      .optional()
+      .meta({ description: 'Global deduplication settings applied to all pipeline jobs.' }),
+    pipeline: z
+      .array(pipelineJobSchema)
+      .min(1)
+      .meta({ description: 'Ordered list of review jobs to execute.' }),
+    sessionBased: z.boolean().optional().meta({
+      deprecated: true,
+      description: 'Legacy compatibility setting currently ignored by the active review pipeline.',
+    }),
+    maxFilesBeforeReset: z.int().min(1).optional().meta({
+      deprecated: true,
+      description: 'Legacy compatibility setting currently ignored by the active review pipeline.',
+    }),
+    maxContextTokens: z.int().min(1).optional().meta({
+      deprecated: true,
+      description: 'Legacy compatibility setting currently ignored by the active review pipeline.',
+    }),
+    enableValidation: z.boolean().optional().meta({
+      deprecated: true,
+      description: 'Legacy compatibility alias for review.validation.enabled.',
+    }),
+    enableDeduplication: z.boolean().optional().meta({
+      deprecated: true,
+      description: 'Legacy compatibility alias for review.deduplication.enabled.',
+    }),
+  })
+  .strict()
+  .meta({
+    defName: 'reviewConfig',
+    description: 'Top-level review stage configuration and job pipeline.',
+  });
+
+// --- Throttling config ---
+const throttlingConfigSchema = z
+  .object({
+    apiCallsPerMinute: z.int().min(1).optional().meta({
+      description: 'Maximum review-time AI calls per minute. If omitted, runtime defaults to 2.',
+    }),
+    enabled: z
+      .boolean()
+      .optional()
+      .meta({ deprecated: true, description: 'Legacy compatibility field currently ignored.' }),
+    maxRequestsPerMinute: z.int().min(1).optional().meta({
+      deprecated: true,
+      description: 'Legacy compatibility alias currently ignored at runtime.',
+    }),
+  })
+  .strict()
+  .meta({
+    defName: 'throttlingConfig',
+    description: 'API rate-limit settings for review-time AI calls.',
+  });
+
+// --- Performance config ---
+const performanceConfigSchema = z
+  .object({
+    throttling: throttlingConfigSchema.optional(),
+    maxFileSizeKB: z.int().min(1).optional().meta({
+      deprecated: true,
+      description: 'Legacy compatibility field currently not applied by active stages.',
+    }),
+    maxFilesPerBatch: z.int().min(1).optional().meta({
+      deprecated: true,
+      description: 'Legacy compatibility field currently not applied by active stages.',
+    }),
+    maxFilesPerProject: z.int().min(1).optional().meta({
+      deprecated: true,
+      description: 'Legacy compatibility field currently not applied by active stages.',
+    }),
+    timeoutSeconds: z.int().min(1).optional().meta({
+      deprecated: true,
+      description: 'Legacy compatibility field currently not applied by active stages.',
+    }),
+    maxTokensPerFile: z.int().min(1).optional().meta({
+      deprecated: true,
+      description: 'Legacy compatibility field currently not applied by active stages.',
+    }),
+    maxRetries: z.int().min(0).optional().meta({
+      deprecated: true,
+      description: 'Legacy compatibility field currently not applied by active stages.',
+    }),
+    maxConcurrentFiles: z.int().min(1).optional().meta({
+      deprecated: true,
+      description: 'Legacy compatibility field currently not applied by active stages.',
+    }),
+  })
+  .strict()
+  .meta({
+    defName: 'performanceConfig',
+    description:
+      'Compatibility fields for performance tuning. In the current runtime, throttling.apiCallsPerMinute is the only actively applied setting.',
+  });
+
+// --- Fix config ---
+const fixConfigSchema = z
+  .object({
+    maxConcurrentFixes: z
+      .int()
+      .min(1)
+      .optional()
+      .meta({ description: 'Maximum number of fixes generated concurrently.' }),
+    enabled: z
+      .boolean()
+      .optional()
+      .meta({ deprecated: true, description: 'Enable fix stage behaviours.' }),
+    prompt: nonEmptyString.optional().meta({
+      deprecated: true,
+      description: 'Optional fix prompt override used by fix generation workflows.',
+    }),
+    severities: severityList
+      .optional()
+      .meta({ deprecated: true, description: 'Severities eligible for fix generation.' }),
+    minConfidence: confidenceScore.optional().meta({
+      deprecated: true,
+      description: 'Minimum issue confidence required before generating fixes.',
+    }),
+    autoApply: z.boolean().optional().meta({
+      deprecated: true,
+      description:
+        'If true, enables automatic application of generated fixes when requested by stage options.',
+    }),
+  })
+  .strict()
+  .meta({
+    defName: 'fixConfig',
+    description:
+      'Fix stage controls for severity filtering, confidence threshold, and apply behaviour.',
+  });
+
+// --- Report config ---
+const reportConfigSchema = z
+  .object({
+    includedSeverities: severityList
+      .optional()
+      .meta({ description: 'Only issues with these severities are included in report outputs.' }),
+    generateIssueMarkdown: z
+      .boolean()
+      .optional()
+      .meta({ description: 'Generate per-issue markdown files alongside reports.' }),
+    enableRootCauseExtraction: z.boolean().optional().meta({
+      description: 'Enable post-processing that classifies issues into root-cause buckets.',
+    }),
+    outputFormat: outputFormat
+      .optional()
+      .meta({ deprecated: true, description: 'Preferred report format.' }),
+  })
+  .strict()
+  .meta({
+    defName: 'reportConfig',
+    description: 'Report rendering and severity filtering settings used by report and CI outputs.',
+  });
+
+// --- GitHub config ---
+const githubConfigSchema = z
+  .object({
+    postComments: z
+      .boolean()
+      .optional()
+      .meta({ description: 'Post or update a QualOps PR comment.' }),
+    skipOnDraft: z
+      .boolean()
+      .optional()
+      .meta({ description: 'Skip commenting/check updates for draft PRs.' }),
+    blockPipeline: z
+      .boolean()
+      .optional()
+      .meta({ description: 'Fail status/check when configured quality conditions are not met.' }),
+    maxInlineComments: z
+      .int()
+      .min(1)
+      .optional()
+      .meta({ description: 'Maximum number of inline annotations/comments created per run.' }),
+    enabled: z
+      .boolean()
+      .optional()
+      .meta({ deprecated: true, description: 'Enable GitHub integration behaviour.' }),
+  })
+  .strict()
+  .meta({ defName: 'githubConfig', description: 'GitHub pull request integration settings.' });
+
+// --- GitLab config ---
+const gitlabConfigSchema = z
+  .object({
+    blockPipeline: z
+      .boolean()
+      .optional()
+      .meta({ description: 'Fail CI pipeline when configured quality conditions are not met.' }),
+    enabled: z
+      .boolean()
+      .optional()
+      .meta({ deprecated: true, description: 'Enable GitLab integration behaviour.' }),
+    postComments: z
+      .boolean()
+      .optional()
+      .meta({ deprecated: true, description: 'Post or update a QualOps MR note.' }),
+    skipOnDraft: z.boolean().optional().meta({
+      deprecated: true,
+      description: 'Skip MR updates for draft merge requests when supported.',
+    }),
+  })
+  .strict()
+  .meta({
+    defName: 'gitlabConfig',
+    description:
+      'GitLab merge request integration settings. This section is read from a root .qualopsrc.json file.',
+  });
+
+// --- Paths config (deprecated section) ---
+const pathsConfigSchema = z
+  .object({
+    sessionsDir: nonEmptyString.optional().meta({ description: 'Custom sessions directory path.' }),
+    cacheDir: nonEmptyString.optional().meta({ description: 'Custom cache directory path.' }),
+    outputDir: nonEmptyString.optional().meta({ description: 'Custom output directory path.' }),
+  })
+  .strict()
+  .meta({
+    defName: 'pathsConfig',
+    description: 'Legacy directory override settings retained for compatibility.',
+  });
+
+// --- Logger config ---
+const loggerConfigSchema = z
+  .object({
+    level: z
+      .enum(['debug', 'info', 'warn', 'error'])
+      .meta({ defName: 'logLevel', description: 'Minimum log level to emit.' })
+      .optional(),
+    enableColors: z.boolean().optional().meta({ description: 'Enable ANSI colorized logs.' }),
+    enableTimestamps: z
+      .boolean()
+      .optional()
+      .meta({ description: 'Prefix logs with ISO timestamps.' }),
+    prefix: z
+      .string()
+      .optional()
+      .meta({ description: 'Optional static prefix added to each log line.' }),
+  })
+  .strict()
+  .meta({
+    defName: 'loggerConfig',
+    description: 'Logger output formatting options used by shared logger initialization.',
+  });
+
+// --- Top-level config ---
+export const qualopsConfigSchema = z
+  .object({
+    $schema: z.string().optional().meta({
+      description: 'Optional JSON Schema reference for editor/validator tooling.',
+      format: 'uri-reference',
+    }),
+    ai: aiConfigSchema.meta({ description: 'AI provider and model settings for each stage.' }),
+    review: reviewConfigSchema.meta({
+      description: 'Review pipeline configuration. Must include at least one pipeline job.',
+    }),
+    performance: performanceConfigSchema.optional().meta({
+      description:
+        'Compatibility settings for performance limits. In current runtime behavior, only throttling.apiCallsPerMinute is actively applied.',
+    }),
+    fix: fixConfigSchema
+      .optional()
+      .meta({ description: 'Fix generation behaviour and thresholds for the fix stage.' }),
+    report: reportConfigSchema.optional().meta({
+      description: 'Report output and filtering options used by report and CI integrations.',
+    }),
+    github: githubConfigSchema.optional().meta({
+      description: 'GitHub PR integration options for comments, annotations, and quality gating.',
+    }),
+    gitlab: gitlabConfigSchema
+      .optional()
+      .meta({ description: 'GitLab MR integration options for comments and pipeline blocking.' }),
+    paths: pathsConfigSchema.optional().meta({
+      deprecated: true,
+      description:
+        'Legacy directory overrides retained for compatibility. Current pipeline execution does not apply these values.',
+    }),
+    logger: loggerConfigSchema.optional().meta({
+      description:
+        'Logger behavior for console output (level, colors, timestamps, prefix). This is read from a root .qualopsrc.json file.',
+    }),
+    skipPatterns: nonEmptyStringArray.optional().meta({
+      deprecated: true,
+      description: 'Legacy compatibility field. Values from config files are currently ignored.',
+      default: ['node_modules/**', '.git/**', 'dist/**', 'build/**', 'coverage/**'],
+    }),
+    includePatterns: nonEmptyStringArray.optional().meta({
+      deprecated: true,
+      description: 'Legacy compatibility field. Values from config files are currently ignored.',
+    }),
+    maxFilesPerBatch: z.int().min(1).optional().meta({
+      deprecated: true,
+      description: 'Legacy compatibility field. Values from config files are currently ignored.',
+      default: 7,
+    }),
+    maxConcurrency: z.int().min(1).optional().meta({
+      deprecated: true,
+      description: 'Legacy compatibility field. Values from config files are currently ignored.',
+      default: 3,
+    }),
+    cacheEnabled: z.boolean().optional().meta({
+      deprecated: true,
+      description: 'Legacy compatibility field. Values from config files are currently ignored.',
+      default: true,
+    }),
+    cacheTTL: z.int().min(1).optional().meta({
+      deprecated: true,
+      description: 'Legacy compatibility field. Values from config files are currently ignored.',
+      default: 300000,
+    }),
+    outputFormat: outputFormat.optional().meta({
+      deprecated: true,
+      description: 'Legacy compatibility field. Values from config files are currently ignored.',
+      default: 'html',
+    }),
+    outputPath: nonEmptyString.optional().meta({
+      deprecated: true,
+      description: 'Legacy top-level override currently unused by runtime stage implementations.',
+    }),
+    verbose: z.boolean().optional().meta({
+      deprecated: true,
+      description:
+        'Legacy compatibility field. Values from config files are currently ignored (environment variables still apply).',
+      default: false,
+    }),
+    debug: z.boolean().optional().meta({
+      deprecated: true,
+      description:
+        'Legacy compatibility field. Values from config files are currently ignored (environment variables still apply).',
+      default: false,
+    }),
+    maxFileSizeKB: z.int().min(1).optional().meta({
+      deprecated: true,
+      description: 'Legacy compatibility field. Values from config files are currently ignored.',
+      default: 500,
+    }),
+    maxTokensPerFile: z.int().min(1).optional().meta({
+      deprecated: true,
+      description: 'Legacy compatibility field. Values from config files are currently ignored.',
+      default: 1000000,
+    }),
+    maxReactSteps: z.int().min(1).optional().meta({
+      deprecated: true,
+      description: 'Legacy compatibility field. Values from config files are currently ignored.',
+      default: 5,
+    }),
+  })
+  .strict();

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -26,7 +26,9 @@ const outputFormat = z.enum(['json', 'html', 'markdown']).meta({
 });
 
 // --- AI stage config ---
-// .passthrough() because providers may have extra fields (e.g. topP, topK)
+// .passthrough() because providers may have extra fields (e.g. topP, topK).
+// The `passthrough: true` meta tag is read by the schema validator to find
+// passthrough objects without poking at Zod internals.
 const aiStageConfigSchema = z
   .object({
     provider: aiProvider,
@@ -47,7 +49,11 @@ const aiStageConfigSchema = z
     maxTokens: z.int().min(1).optional().meta({ description: 'Optional model output token cap.' }),
   })
   .passthrough()
-  .meta({ defName: 'aiStageConfig', description: 'AI configuration for a specific stage.' });
+  .meta({
+    defName: 'aiStageConfig',
+    description: 'AI configuration for a specific stage.',
+    passthrough: true,
+  });
 
 const aiConfigSchema = z
   .object({

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { envConfig } from './env';
-import { validateConfig } from './schema-validator';
+import { assertValidConfig, collectConfigWarnings } from './schema-validator';
 import type { AIStageConfig, Config } from '../shared/types';
 import { logger } from '../shared/utils/logger';
 
@@ -84,10 +84,21 @@ export class ConfigService {
   private validateAgainstSchema(): void {
     if (Object.keys(this.rawConfig).length === 0) return;
 
-    const result = validateConfig(this.rawConfig);
+    // Throws ConfigValidationError on schema violations. The CLI's
+    // top-level error handler is responsible for catching it, formatting
+    // for the user, and exiting — this service should never call
+    // process.exit itself.
+    assertValidConfig(this.rawConfig);
 
-    for (const dep of result.deprecations) {
+    const warnings = collectConfigWarnings(this.rawConfig);
+    for (const dep of warnings.deprecations) {
       logger.warn(`[CONFIG] Deprecated field "${dep.path}": ${dep.description}`);
+    }
+    for (const unknown of warnings.unknownFields) {
+      logger.warn(
+        `[CONFIG] Unknown field "${unknown.field}" at ${unknown.path} — ignored. ` +
+          `If this is a provider-specific option it will still be passed through; otherwise check for a typo.`,
+      );
     }
   }
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -188,18 +188,6 @@ export class ConfigService {
     return stageConfig;
   }
 
-  getMaxFileSizeKB(): number {
-    return this.config.maxFileSizeKB ?? 500;
-  }
-
-  getMaxTokensPerFile(): number {
-    return this.config.maxTokensPerFile ?? 1000000;
-  }
-
-  getMaxReactSteps(): number {
-    return this.config.maxReactSteps ?? 5;
-  }
-
   isIssueMarkdownEnabled(): boolean {
     return this.config.report?.generateIssueMarkdown ?? false;
   }
@@ -220,27 +208,5 @@ export class ConfigService {
     }
 
     return errors;
-  }
-
-  getDirectories() {
-    const paths = this.rawConfig.paths as Record<string, unknown> | undefined;
-    return {
-      SESSIONS: (paths?.sessionsDir as string) ?? 'reports/sessions',
-      CACHE: (paths?.cacheDir as string) ?? '.qualops-cache',
-      OUTPUT: (paths?.outputDir as string) ?? 'reports',
-    } as const;
-  }
-
-  getPerformanceLimits() {
-    const perf = this.rawConfig.performance as Record<string, unknown> | undefined;
-    return {
-      maxFileSizeKB: (perf?.maxFileSizeKB as number) ?? this.config.maxFileSizeKB ?? 500,
-      maxFilesPerBatch: (perf?.maxFilesPerBatch as number) ?? this.config.maxFilesPerBatch ?? 10,
-      maxFilesPerProject: (perf?.maxFilesPerProject as number) ?? 10000,
-      timeoutSeconds: (perf?.timeoutSeconds as number) ?? 300,
-      maxTokensPerFile:
-        (perf?.maxTokensPerFile as number) ?? this.config.maxTokensPerFile ?? 1000000,
-      maxRetries: (perf?.maxRetries as number) ?? 2,
-    } as const;
   }
 }

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { envConfig } from './env';
+import { validateConfig } from './schema-validator';
 import type { AIStageConfig, Config } from '../shared/types';
 import { logger } from '../shared/utils/logger';
 
@@ -44,6 +45,7 @@ export class ConfigService {
 
   private constructor() {
     this.rawConfig = this.loadRawConfig();
+    this.validateAgainstSchema();
     this.config = this.loadConfig();
   }
 
@@ -76,6 +78,16 @@ export class ConfigService {
         `Failed to parse ${rcPath}: ${error instanceof Error ? error.message : String(error)}`,
       );
       return {};
+    }
+  }
+
+  private validateAgainstSchema(): void {
+    if (Object.keys(this.rawConfig).length === 0) return;
+
+    const result = validateConfig(this.rawConfig);
+
+    for (const dep of result.deprecations) {
+      logger.warn(`[CONFIG] Deprecated field "${dep.path}": ${dep.description}`);
     }
   }
 
@@ -137,6 +149,7 @@ export class ConfigService {
 
   reset(): void {
     this.rawConfig = this.loadRawConfig();
+    this.validateAgainstSchema();
     this.config = this.loadConfig();
   }
 

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -2,7 +2,7 @@ import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { envConfig } from './env';
-import { assertValidConfig, collectConfigWarnings } from './schema-validator';
+import { ConfigParseError, assertValidConfig, collectConfigWarnings } from './schema-validator';
 import type { AIStageConfig, Config } from '../shared/types';
 import { logger } from '../shared/utils/logger';
 
@@ -69,25 +69,19 @@ export class ConfigService {
       logger.warn(`Config file not found: ${rcPath}`);
       return {};
     }
+    const content = readFileSync(rcPath, 'utf-8');
+    logger.info(`Loaded config from: ${rcPath}`);
     try {
-      const content = readFileSync(rcPath, 'utf-8');
-      logger.info(`Loaded config from: ${rcPath}`);
       return JSON.parse(content);
     } catch (error) {
-      logger.warn(
-        `Failed to parse ${rcPath}: ${error instanceof Error ? error.message : String(error)}`,
-      );
-      return {};
+      throw new ConfigParseError(rcPath, error instanceof Error ? error : new Error(String(error)));
     }
   }
 
   private validateAgainstSchema(): void {
     if (Object.keys(this.rawConfig).length === 0) return;
 
-    // Throws ConfigValidationError on schema violations. The CLI's
-    // top-level error handler is responsible for catching it, formatting
-    // for the user, and exiting — this service should never call
-    // process.exit itself.
+    // Never call process.exit from this service — let the CLI error handler format and exit.
     assertValidConfig(this.rawConfig);
 
     const warnings = collectConfigWarnings(this.rawConfig);

--- a/src/config/schema-validator.ts
+++ b/src/config/schema-validator.ts
@@ -1,0 +1,84 @@
+import { z } from 'zod';
+
+import { qualopsConfigSchema } from './config-schema';
+
+export interface DeprecationWarning {
+  path: string;
+  description: string;
+}
+
+export interface ConfigValidationResult {
+  deprecations: DeprecationWarning[];
+}
+
+/**
+ * Validates raw config against the Zod schema.
+ * Throws on schema violations (unknown fields, missing required, type errors).
+ * Returns deprecation warnings for deprecated fields that are present.
+ */
+export function validateConfig(rawConfig: Record<string, unknown>): ConfigValidationResult {
+  qualopsConfigSchema.parse(rawConfig);
+
+  const deprecations = detectDeprecatedUsage(qualopsConfigSchema, rawConfig);
+  return { deprecations };
+}
+
+/**
+ * Walk the Zod schema's .shape, check .meta() for deprecated flags,
+ * and collect paths where deprecated fields are present in the config.
+ */
+function detectDeprecatedUsage(
+  schema: z.ZodObject<z.ZodRawShape>,
+  config: Record<string, unknown>,
+  prefix = '',
+): DeprecationWarning[] {
+  const warnings: DeprecationWarning[] = [];
+
+  for (const [key, fieldSchema] of Object.entries(schema.shape)) {
+    if (!(key in config) || config[key] === undefined) continue;
+
+    const fullPath = prefix ? `${prefix}.${key}` : key;
+
+    // Zod v4 shape entries are typed as $ZodType which doesn't expose .meta()
+    // at the TS level, but it exists at runtime.
+    const meta = (fieldSchema as any).meta?.();
+    if (meta?.deprecated) {
+      warnings.push({
+        path: fullPath,
+        description: (meta.description as string) ?? 'This field is deprecated.',
+      });
+    }
+
+    const inner = unwrapToObject(fieldSchema as any);
+    if (
+      inner &&
+      typeof config[key] === 'object' &&
+      config[key] !== null &&
+      !Array.isArray(config[key])
+    ) {
+      warnings.push(
+        ...detectDeprecatedUsage(inner, config[key] as Record<string, unknown>, fullPath),
+      );
+    }
+  }
+
+  return warnings;
+}
+
+/**
+ * Unwrap optional/meta wrappers to get the underlying ZodObject, if any.
+ */
+function unwrapToObject(schema: unknown): z.ZodObject<z.ZodRawShape> | null {
+  let current: any = schema;
+
+  // Unwrap meta/optional wrappers (they expose .unwrap())
+  while (current && typeof current.unwrap === 'function') {
+    current = current.unwrap();
+  }
+
+  if (current instanceof z.ZodObject) {
+    return current;
+  }
+
+  return null;
+}

--- a/src/config/schema-validator.ts
+++ b/src/config/schema-validator.ts
@@ -7,73 +7,120 @@ export interface DeprecationWarning {
   description: string;
 }
 
+export interface UnknownFieldWarning {
+  path: string;
+  field: string;
+}
+
 export interface ConfigValidationResult {
   deprecations: DeprecationWarning[];
+  unknownFields: UnknownFieldWarning[];
 }
 
 /**
- * Validates raw config against the Zod schema.
- * Throws on schema violations (unknown fields, missing required, type errors).
- * Returns deprecation warnings for deprecated fields that are present.
+ * Stable, machine-readable code for matching this error type without
+ * parsing the human-readable message.
  */
-export function validateConfig(rawConfig: Record<string, unknown>): ConfigValidationResult {
-  qualopsConfigSchema.parse(rawConfig);
+export const CONFIG_VALIDATION_ERROR_CODE = 'CONFIG_VALIDATION_ERROR' as const;
 
-  const deprecations = detectDeprecatedUsage(qualopsConfigSchema, rawConfig);
-  return { deprecations };
-}
+export class ConfigValidationError extends Error {
+  readonly errorCode = CONFIG_VALIDATION_ERROR_CODE;
+  /** Marks this error as ready for direct user display (no stack trace needed). */
+  readonly userFacing = true;
 
-/**
- * Walk the Zod schema's .shape, check .meta() for deprecated flags,
- * and collect paths where deprecated fields are present in the config.
- */
-function detectDeprecatedUsage(
-  schema: z.ZodObject<z.ZodRawShape>,
-  config: Record<string, unknown>,
-  prefix = '',
-): DeprecationWarning[] {
-  const warnings: DeprecationWarning[] = [];
-
-  for (const [key, fieldSchema] of Object.entries(schema.shape)) {
-    if (!(key in config) || config[key] === undefined) continue;
-
-    const fullPath = prefix ? `${prefix}.${key}` : key;
-
-    // Zod v4 shape entries are typed as $ZodType which doesn't expose .meta()
-    // at the TS level, but it exists at runtime.
-    const meta = (fieldSchema as any).meta?.();
-    if (meta?.deprecated) {
-      warnings.push({
-        path: fullPath,
-        description: (meta.description as string) ?? 'This field is deprecated.',
-      });
-    }
-
-    const inner = unwrapToObject(fieldSchema as any);
-    if (
-      inner &&
-      typeof config[key] === 'object' &&
-      config[key] !== null &&
-      !Array.isArray(config[key])
-    ) {
-      warnings.push(
-        ...detectDeprecatedUsage(inner, config[key] as Record<string, unknown>, fullPath),
-      );
-    }
+  constructor(public readonly issues: z.core.$ZodIssue[]) {
+    super(formatIssues(issues));
+    this.name = 'ConfigValidationError';
   }
+}
 
-  return warnings;
+/**
+ * Throws `ConfigValidationError` if the raw config violates the Zod schema
+ * (unknown fields, missing required, type errors). Pure assertion — no
+ * return value.
+ */
+export function assertValidConfig(rawConfig: Record<string, unknown>): void {
+  const result = qualopsConfigSchema.safeParse(rawConfig);
+  if (!result.success) {
+    throw new ConfigValidationError(result.error.issues);
+  }
+}
+
+/**
+ * Walks the schema and config to collect non-fatal warnings:
+ * - deprecation warnings for fields tagged with `.meta({ deprecated: true })`
+ * - unknown-field warnings for keys inside `.passthrough()` objects (where
+ *   typos would otherwise be silently accepted)
+ *
+ * Pure: never throws. Assumes the config has already been validated by
+ * `assertValidConfig`.
+ */
+export function collectConfigWarnings(rawConfig: Record<string, unknown>): ConfigValidationResult {
+  const deprecations: DeprecationWarning[] = [];
+  const unknownFields: UnknownFieldWarning[] = [];
+
+  walkSchemaWithConfig(qualopsConfigSchema, rawConfig, ({ schema, config, path, fieldPath }) => {
+    if (fieldPath) {
+      // Per-field visit: check for deprecated metadata on the field schema.
+      const meta = readMeta(fieldPath.fieldSchema);
+      if (meta?.deprecated) {
+        const description =
+          typeof meta.description === 'string' ? meta.description : 'This field is deprecated.';
+        deprecations.push({ path: fieldPath.path, description });
+      }
+      return;
+    }
+
+    // Per-object visit: check for unknown keys inside passthrough objects.
+    if (isPassthroughObject(schema)) {
+      const declared = new Set(Object.keys(schema.shape));
+      for (const key of Object.keys(config)) {
+        if (!declared.has(key)) {
+          unknownFields.push({ path: path || '<root>', field: key });
+        }
+      }
+    }
+  });
+
+  return { deprecations, unknownFields };
+}
+
+function formatIssues(issues: z.core.$ZodIssue[]): string {
+  const lines = issues.map((issue) => {
+    const path = issue.path.length > 0 ? issue.path.join('.') : '<root>';
+    return `  - ${path}: ${issue.message}`;
+  });
+  return `Invalid .qualopsrc.json configuration:\n${lines.join('\n')}`;
+}
+
+// --- Zod runtime escape hatch ---
+//
+// Zod v4 types `.shape` entries as `$ZodType` which doesn't expose `.meta()`,
+// `.unwrap()`, etc. at the TS level even though they exist at runtime. This
+// interface is the single, named place where we trade type-checking for
+// runtime introspection — easier to audit/replace than scattered `as any`s.
+
+interface ZodRuntime {
+  meta?: () => Record<string, unknown> | undefined;
+  unwrap?: () => unknown;
+}
+
+function asRuntime(schema: unknown): ZodRuntime {
+  return schema as ZodRuntime;
+}
+
+function readMeta(schema: unknown): Record<string, unknown> | undefined {
+  return asRuntime(schema).meta?.();
 }
 
 /**
  * Unwrap optional/meta wrappers to get the underlying ZodObject, if any.
  */
 function unwrapToObject(schema: unknown): z.ZodObject<z.ZodRawShape> | null {
-  let current: any = schema;
+  let current: unknown = schema;
 
-  // Unwrap meta/optional wrappers (they expose .unwrap())
-  while (current && typeof current.unwrap === 'function') {
-    current = current.unwrap();
+  while (asRuntime(current).unwrap) {
+    current = asRuntime(current).unwrap!();
   }
 
   if (current instanceof z.ZodObject) {
@@ -81,4 +128,64 @@ function unwrapToObject(schema: unknown): z.ZodObject<z.ZodRawShape> | null {
   }
 
   return null;
+}
+
+/**
+ * True if the object schema was created with `.passthrough()`. Detected via
+ * the `passthrough: true` meta tag declared at the schema definition site
+ * (see `aiStageConfigSchema` in `config-schema.ts`). This avoids depending
+ * on Zod internal layout (`def.catchall`).
+ */
+function isPassthroughObject(schema: z.ZodObject<z.ZodRawShape>): boolean {
+  return readMeta(schema)?.passthrough === true;
+}
+
+interface WalkVisitorArgs {
+  schema: z.ZodObject<z.ZodRawShape>;
+  config: Record<string, unknown>;
+  path: string;
+  /** Set when called for a specific field within `schema`; undefined for the root visit. */
+  fieldPath?: {
+    path: string;
+    fieldSchema: unknown;
+  };
+}
+
+/**
+ * Walks a schema/config tree depth-first. The visitor is called once for the
+ * root object, then once per field in each nested object. Recursion only
+ * descends into nested ZodObjects whose value in the config is also an
+ * object (not array, not null).
+ */
+function walkSchemaWithConfig(
+  schema: z.ZodObject<z.ZodRawShape>,
+  config: Record<string, unknown>,
+  visit: (args: WalkVisitorArgs) => void,
+  prefix = '',
+): void {
+  // Visit the object itself (no fieldPath — used for object-level checks
+  // like passthrough detection).
+  visit({ schema, config, path: prefix });
+
+  for (const [key, fieldSchema] of Object.entries(schema.shape)) {
+    if (!(key in config) || config[key] === undefined) continue;
+
+    const fullPath = prefix ? `${prefix}.${key}` : key;
+
+    // Visit the field (used for field-level checks like deprecation).
+    visit({
+      schema,
+      config,
+      path: prefix,
+      fieldPath: { path: fullPath, fieldSchema },
+    });
+
+    const value = config[key];
+    if (typeof value !== 'object' || value === null || Array.isArray(value)) continue;
+
+    const inner = unwrapToObject(fieldSchema);
+    if (!inner) continue;
+
+    walkSchemaWithConfig(inner, value as Record<string, unknown>, visit, fullPath);
+  }
 }

--- a/src/config/schema-validator.ts
+++ b/src/config/schema-validator.ts
@@ -2,30 +2,25 @@ import { z } from 'zod';
 
 import { qualopsConfigSchema } from './config-schema';
 
-export interface DeprecationWarning {
+interface DeprecationWarning {
   path: string;
   description: string;
 }
 
-export interface UnknownFieldWarning {
+interface UnknownFieldWarning {
   path: string;
   field: string;
 }
 
-export interface ConfigValidationResult {
+interface ConfigValidationResult {
   deprecations: DeprecationWarning[];
   unknownFields: UnknownFieldWarning[];
 }
 
-/**
- * Stable, machine-readable code for matching this error type without
- * parsing the human-readable message.
- */
 export const CONFIG_VALIDATION_ERROR_CODE = 'CONFIG_VALIDATION_ERROR' as const;
 
 export class ConfigValidationError extends Error {
   readonly errorCode = CONFIG_VALIDATION_ERROR_CODE;
-  /** Marks this error as ready for direct user display (no stack trace needed). */
   readonly userFacing = true;
 
   constructor(public readonly issues: z.core.$ZodIssue[]) {
@@ -34,10 +29,21 @@ export class ConfigValidationError extends Error {
   }
 }
 
+export const CONFIG_PARSE_ERROR_CODE = 'CONFIG_PARSE_ERROR' as const;
+
+export class ConfigParseError extends Error {
+  readonly errorCode = CONFIG_PARSE_ERROR_CODE;
+  readonly userFacing = true;
+
+  constructor(filePath: string, cause: Error) {
+    super(`Failed to parse ${filePath}:\n  ${cause.message}`);
+    this.name = 'ConfigParseError';
+  }
+}
+
 /**
  * Throws `ConfigValidationError` if the raw config violates the Zod schema
- * (unknown fields, missing required, type errors). Pure assertion — no
- * return value.
+ * (unknown fields, missing required, type errors).
  */
 export function assertValidConfig(rawConfig: Record<string, unknown>): void {
   const result = qualopsConfigSchema.safeParse(rawConfig);

--- a/src/shared/types/config.ts
+++ b/src/shared/types/config.ts
@@ -1,79 +1,32 @@
+import type { z } from 'zod';
+
+import type {
+  agenticConfigSchema,
+  agenticSubagentTypeSchema,
+  customAgentDefinitionSchema,
+  deduplicationConfigSchema,
+  pipelineJobSchema,
+  promptConfigSchema,
+  reviewConfigSchema,
+  reviewPassSchema,
+  validationConfigSchema,
+} from '../../config/config-schema';
+
+// --- Config types derived from Zod schemas ---
+
 export type ReviewMode = 'file-by-file' | 'agentic';
+export type AgenticSubagentType = z.infer<typeof agenticSubagentTypeSchema>;
 
-export type AgenticSubagentType =
-  | 'dependency-tracer'
-  | 'breaking-change-detector'
-  | 'security-analyzer'
-  | 'pattern-validator';
+export type CustomAgentDefinition = z.infer<typeof customAgentDefinitionSchema>;
+export type AgenticConfig = z.infer<typeof agenticConfigSchema>;
+export type ReviewConfig = z.infer<typeof reviewConfigSchema>;
+export type PipelineJob = z.infer<typeof pipelineJobSchema>;
+export type ReviewPass = z.infer<typeof reviewPassSchema>;
+export type PromptConfig = z.infer<typeof promptConfigSchema>;
+export type ValidationConfig = z.infer<typeof validationConfigSchema>;
+export type DeduplicationConfig = z.infer<typeof deduplicationConfigSchema>;
 
-export interface CustomAgentDefinition {
-  name: string;
-  description: string;
-  prompt: string;
-  tools?: string[];
-  model?: 'sonnet' | 'opus' | 'haiku';
-}
-
-export interface AgenticConfig {
-  maxTurns?: number;
-  maxBudgetUsd?: number;
-  enabledSubagents?: AgenticSubagentType[];
-  customAgents?: CustomAgentDefinition[];
-  agentsDir?: string;
-  systemPrompt?: string;
-  contextMode?: 'diff' | 'full' | 'auto';
-  maxTokensPerFile?: number;
-  maxTotalTokens?: number;
-}
-
-export interface ReviewConfig {
-  minConfidence?: number;
-  sessionBased?: boolean;
-  maxFilesBeforeReset?: number;
-  maxContextTokens?: number;
-  maxConcurrentFiles?: number;
-  validation?: ValidationConfig;
-  deduplication?: DeduplicationConfig;
-  pipeline: PipelineJob[];
-}
-
-export interface PipelineJob {
-  name: string;
-  enabled: boolean;
-  mode?: ReviewMode;
-  agentic?: AgenticConfig;
-  validation?: ValidationConfig;
-  deduplication?: DeduplicationConfig;
-  passes: ReviewPass[];
-}
-
-export interface ReviewPass {
-  name: string;
-  enabled: boolean;
-  docs?: string;
-  prompt: string | PromptConfig;
-  filters?: {
-    detectionTriggers?: string[];
-    filePatterns?: string[];
-    excludePatterns?: string[];
-  };
-}
-
-export interface PromptConfig {
-  file: string;
-  meta?: Record<string, any>;
-}
-
-export interface ValidationConfig {
-  enabled?: boolean;
-  minConfidence?: number;
-  prompt?: string | PromptConfig;
-}
-
-export interface DeduplicationConfig {
-  enabled?: boolean;
-  prompt?: string | PromptConfig;
-}
+// --- Domain types (kept as hand-written interfaces) ---
 
 export interface FileInfo {
   path: string;

--- a/src/stages/review/agentic/loaders/agent-loader.ts
+++ b/src/stages/review/agentic/loaders/agent-loader.ts
@@ -1,5 +1,5 @@
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
-import { join, basename } from 'node:path';
+import { join, basename, resolve } from 'node:path';
 
 import type { AgenticConfig, CustomAgentDefinition } from '../../../../shared/types/config';
 import { logger } from '../../../../shared/utils/logger';
@@ -15,7 +15,7 @@ export class AgentLoader {
   private cwd: string;
 
   constructor(cwd?: string) {
-    this.cwd = cwd || process.cwd();
+    this.cwd = resolve(cwd || process.cwd());
   }
 
   loadCustomAgents(config: AgenticConfig): Record<string, AgentDefinition> {
@@ -31,7 +31,14 @@ export class AgentLoader {
 
     // Load from agents directory
     const agentsDir = config.agentsDir || '.qualops/agents';
-    const fullAgentsDir = join(this.cwd, agentsDir);
+    const fullAgentsDir = resolve(this.cwd, agentsDir);
+
+    if (!fullAgentsDir.startsWith(this.cwd)) {
+      logger.warn(
+        `[AgentLoader] agentsDir "${agentsDir}" resolves outside project directory. Path traversal is not allowed.`,
+      );
+      return agents;
+    }
 
     if (existsSync(fullAgentsDir)) {
       const files = readdirSync(fullAgentsDir).filter((f) => f.endsWith('.md'));

--- a/src/stages/review/loaders/prompt-loader.ts
+++ b/src/stages/review/loaders/prompt-loader.ts
@@ -1,10 +1,10 @@
 import { readFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 
 import type { PromptConfig } from '../../../shared/types/config';
 import { logger } from '../../../shared/utils/logger';
 
-const PROMPTS_BASE_PATH = join(process.cwd(), '.qualops/prompts');
+const PROMPTS_BASE_PATH = resolve(process.cwd(), '.qualops/prompts');
 
 interface LoadedPrompt {
   content: string;
@@ -30,7 +30,13 @@ export class PromptLoader {
       return cached;
     }
 
-    const fullPath = join(PROMPTS_BASE_PATH, promptPath);
+    const fullPath = resolve(PROMPTS_BASE_PATH, promptPath);
+
+    if (!fullPath.startsWith(PROMPTS_BASE_PATH)) {
+      throw new Error(
+        `Prompt path "${promptPath}" resolves outside the prompts directory. Path traversal is not allowed.`,
+      );
+    }
 
     try {
       const content = await readFile(fullPath, 'utf-8');

--- a/src/stages/review/loaders/prompt-loader.ts
+++ b/src/stages/review/loaders/prompt-loader.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises';
-import { join, resolve } from 'node:path';
+import { resolve } from 'node:path';
 
 import type { PromptConfig } from '../../../shared/types/config';
 import { logger } from '../../../shared/utils/logger';

--- a/src/stages/review/processors/dedup-resolver.ts
+++ b/src/stages/review/processors/dedup-resolver.ts
@@ -9,7 +9,7 @@ import type {
 import { logger } from '../../../shared/utils/logger';
 import { PromptLoader } from '../loaders/prompt-loader';
 import { TemplateEngine } from '../loaders/template-engine';
-import { globalRateLimiter } from '../utils/global-rate-limiter';
+import { getGlobalRateLimiter } from '../utils/global-rate-limiter';
 
 const ISSUES_SECTION = `
 
@@ -116,7 +116,7 @@ export class DeduplicationResolver {
       REVIEW_MIN_CONFIDENCE: this.globalConfig.minConfidence ?? 4,
     });
 
-    await globalRateLimiter.throttleApiCall(this.aiProvider.name);
+    await getGlobalRateLimiter().throttleApiCall(this.aiProvider.name);
 
     const response = await this.aiProvider.complete({
       messages: [{ role: 'user', content: prompt }],

--- a/src/stages/review/processors/file-reviewer.ts
+++ b/src/stages/review/processors/file-reviewer.ts
@@ -3,7 +3,7 @@ import { fixMalformedJson } from '../../../ai/shared/parsers/json-parser';
 import type { ReviewIssue } from '../../../shared/types';
 import type { FileInfo } from '../../../shared/types/config';
 import { logger } from '../../../shared/utils/logger';
-import { globalRateLimiter } from '../utils/global-rate-limiter';
+import { getGlobalRateLimiter } from '../utils/global-rate-limiter';
 import { addLineNumbers } from '../utils/line-numbered-content';
 
 interface Message {
@@ -73,7 +73,7 @@ export class FileReviewer {
       },
     ];
 
-    await globalRateLimiter.throttleApiCall(this.aiProvider.name);
+    await getGlobalRateLimiter().throttleApiCall(this.aiProvider.name);
 
     const response = await this.aiProvider.complete({
       messages,

--- a/src/stages/review/processors/validation-resolver.ts
+++ b/src/stages/review/processors/validation-resolver.ts
@@ -9,7 +9,7 @@ import type {
 import { logger } from '../../../shared/utils/logger';
 import { PromptLoader } from '../loaders/prompt-loader';
 import { TemplateEngine } from '../loaders/template-engine';
-import { globalRateLimiter } from '../utils/global-rate-limiter';
+import { getGlobalRateLimiter } from '../utils/global-rate-limiter';
 
 const ISSUES_SECTION = `
 
@@ -145,7 +145,7 @@ export class ValidationResolver {
       REVIEW_MIN_CONFIDENCE: this.globalConfig.minConfidence ?? 4,
     });
 
-    await globalRateLimiter.throttleApiCall(this.aiProvider.name);
+    await getGlobalRateLimiter().throttleApiCall(this.aiProvider.name);
 
     const response = await this.aiProvider.complete({
       messages: [{ role: 'user', content: prompt }],

--- a/src/stages/review/utils/global-rate-limiter.ts
+++ b/src/stages/review/utils/global-rate-limiter.ts
@@ -58,4 +58,16 @@ class GlobalRateLimiter {
   }
 }
 
-export const globalRateLimiter = new GlobalRateLimiter();
+/**
+ * Lazy singleton. Construction touches `ConfigService.getInstance()`, which can
+ * throw `ConfigParseError` / `ConfigValidationError` for a broken config.
+ * Building eagerly at module-load time would let those errors escape
+ * `cli.ts`'s `withErrorHandling` wrapper — deferring construction until first
+ * use keeps config errors inside the CLI error boundary.
+ */
+let instance: GlobalRateLimiter | undefined;
+
+export function getGlobalRateLimiter(): GlobalRateLimiter {
+  if (!instance) instance = new GlobalRateLimiter();
+  return instance;
+}

--- a/tests/integration/config-schema.integration.spec.ts
+++ b/tests/integration/config-schema.integration.spec.ts
@@ -3,172 +3,138 @@ import { join } from 'node:path';
 
 import { z } from 'zod';
 
+import { qualopsConfigSchema } from '@/config/config-schema';
+
 const schemaPath = join(__dirname, '../../docs/qualops-config.schema.json');
 
-// Zod definitions mirroring the JSON Schema meta-structure
-// Note that future support for JSON schema is in preview: https://zod.dev/json-schema
-const jsonSchemaPrimitive = z.enum(['string', 'number', 'integer', 'boolean', 'object', 'array']);
-
-const defObject = z.object({
-  type: jsonSchemaPrimitive.optional(),
-  description: z.string().optional(),
-  properties: z.record(z.string(), z.unknown()).optional(),
-  required: z.array(z.string()).optional(),
-  $ref: z.string().optional(),
-  anyOf: z.array(z.unknown()).optional(),
-  oneOf: z.array(z.unknown()).optional(),
-  enum: z.array(z.unknown()).optional(),
-  items: z.unknown().optional(),
-});
-
-const topLevelSchema = z.object({
-  $schema: z.string().min(1),
-  $id: z.string().min(1),
-  title: z.string().min(1),
-  description: z.string().min(1),
-  type: z.literal('object'),
-  additionalProperties: z.boolean(),
-  required: z.array(z.string()).min(1),
-  properties: z.record(z.string(), z.unknown()),
-  $defs: z.record(z.string(), defObject),
-});
-
-// Required top-level property keys
-const REQUIRED_TOP_LEVEL_REQUIRED = ['ai', 'review'];
-
-// Required $defs keys
-const REQUIRED_DEFS = [
-  'aiStageConfig',
-  'aiProvider',
-  'reviewConfig',
-  'pipelineJob',
-  'pipelineJobFileByFile',
-  'pipelineJobAgentic',
-  'reviewPass',
-  'validationConfig',
-  'deduplicationConfig',
-  'performanceConfig',
-  'fixConfig',
-  'reportConfig',
-  'githubConfig',
-  'gitlabConfig',
-  'loggerConfig',
-  'severity',
-  'issueType',
-];
-
-// Required properties on specific $defs
-const DEF_REQUIRED_FIELDS: Record<string, string[]> = {
-  aiStageConfig: ['provider', 'model', 'inputPerMillion', 'outputPerMillion'],
-  reviewPass: ['name', 'enabled', 'prompt'],
-  pipelineJobFileByFile: ['name', 'enabled', 'passes'],
-  pipelineJobAgentic: ['name', 'enabled', 'mode'],
-  customAgentDefinition: ['name', 'description', 'prompt'],
-  promptConfig: ['file'],
-  reviewConfig: ['pipeline'],
-};
-
-describe('qualops-config.schema.json integrity', () => {
-  let raw: unknown;
-  let parseResult: ReturnType<typeof topLevelSchema.safeParse>;
+describe('qualops-config.schema.json integrity (Zod-generated)', () => {
+  let schema: Record<string, unknown>;
 
   beforeAll(() => {
     const content = readFileSync(schemaPath, 'utf-8');
-    raw = JSON.parse(content);
-    parseResult = topLevelSchema.safeParse(raw);
+    schema = JSON.parse(content);
   });
 
-  it('parses as valid JSON and matches top-level schema shape', () => {
-    expect(parseResult.success).toBe(true);
+  function resolveDef(prop: Record<string, unknown>): Record<string, unknown> {
+    const ref = prop.$ref as string | undefined;
+    if (!ref) return prop;
+    const name = ref.replace('#/$defs/', '');
+    return (schema.$defs as Record<string, Record<string, unknown>>)[name];
+  }
+
+  it('is valid JSON with expected top-level structure', () => {
+    expect(schema.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
+    expect(schema.$id).toContain('qualops-config.schema.json');
+    expect(schema.title).toBe('QualOps Configuration');
+    expect(schema.type).toBe('object');
+    expect(schema.additionalProperties).toBe(false);
   });
 
-  it('has the correct $schema and $id', () => {
-    expect(parseResult.data!.$schema).toBe('https://json-schema.org/draft/2020-12/schema');
-    expect(parseResult.data!.$id).toContain('qualops-config.schema.json');
+  it('requires "ai" and "review"', () => {
+    expect(schema.required).toEqual(expect.arrayContaining(['ai', 'review']));
   });
 
-  it('requires "ai" and "review" at the top level', () => {
-    for (const field of REQUIRED_TOP_LEVEL_REQUIRED) {
-      expect(parseResult.data!.required).toContain(field);
-    }
-  });
-
-  it('has all expected $defs', () => {
-    for (const def of REQUIRED_DEFS) {
-      expect(parseResult.data!.$defs).toHaveProperty(def);
-    }
-  });
-
-  it.each(Object.entries(DEF_REQUIRED_FIELDS))(
-    '$defs.%s has the expected required fields',
-    (defName, requiredFields) => {
-      const def = parseResult.data!.$defs[defName];
-      expect(def).toBeDefined();
-      for (const field of requiredFields) {
-        expect(def.required).toContain(field);
-      }
-    },
-  );
-
-  it('aiProvider enum contains the three supported providers', () => {
-    const aiProvider = parseResult.data!.$defs['aiProvider'];
-    expect(aiProvider.enum).toEqual(expect.arrayContaining(['anthropic', 'openai', 'bedrock']));
-  });
-
-  it('severity enum contains all four severity levels', () => {
-    const severity = parseResult.data!.$defs['severity'];
-    expect(severity.enum).toEqual(expect.arrayContaining(['critical', 'high', 'medium', 'low']));
-  });
-
-  it('issueType enum contains all four issue types', () => {
-    const issueType = parseResult.data!.$defs['issueType'];
-    expect(issueType.enum).toEqual(
-      expect.arrayContaining(['bug', 'security', 'performance', 'maintainability']),
+  it('has top-level properties for all config sections', () => {
+    const props = Object.keys(schema.properties as Record<string, unknown>);
+    expect(props).toEqual(
+      expect.arrayContaining([
+        '$schema',
+        'ai',
+        'review',
+        'performance',
+        'fix',
+        'report',
+        'github',
+        'gitlab',
+        'logger',
+        'paths',
+        'skipPatterns',
+      ]),
     );
   });
 
-  it('pipelineJob uses oneOf referencing agentic and file-by-file variants', () => {
-    const pipelineJob = parseResult.data!.$defs['pipelineJob'];
-    expect(pipelineJob.oneOf).toBeDefined();
-    expect(pipelineJob.oneOf).toHaveLength(2);
-    const refs = (pipelineJob.oneOf as Array<{ $ref: string }>).map((o) => o.$ref);
-    expect(refs).toContain('#/$defs/pipelineJobAgentic');
-    expect(refs).toContain('#/$defs/pipelineJobFileByFile');
-  });
-
-  it('all $ref values within $defs point to existing definitions or valid paths', () => {
-    const refPattern = /^#\/\$defs\/(.+)$/;
-    for (const [defName, def] of Object.entries(parseResult.data!.$defs)) {
-      const checkRefs = (node: unknown, path: string) => {
-        if (node === null || typeof node !== 'object') return;
-        const obj = node as Record<string, unknown>;
-        if ('$ref' in obj && typeof obj.$ref === 'string') {
-          const match = obj.$ref.match(refPattern);
-          if (match) {
-            expect(parseResult.data!.$defs).toHaveProperty(
-              match[1],
-              // include path for easier debugging
-            );
-          }
-        }
-        for (const value of Object.values(obj)) {
-          checkRefs(value, `${path} > ${JSON.stringify(value)?.slice(0, 40)}`);
-        }
-      };
-      checkRefs(def, defName);
+  it('marks deprecated top-level fields', () => {
+    const properties = schema.properties as Record<string, Record<string, unknown>>;
+    const deprecatedFields = [
+      'paths',
+      'skipPatterns',
+      'includePatterns',
+      'maxFilesPerBatch',
+      'maxConcurrency',
+      'cacheEnabled',
+      'cacheTTL',
+      'outputFormat',
+      'outputPath',
+      'verbose',
+      'debug',
+      'maxFileSizeKB',
+      'maxTokensPerFile',
+      'maxReactSteps',
+    ];
+    for (const field of deprecatedFields) {
+      expect(properties[field]?.deprecated).toBe(true);
     }
   });
 
-  it('top-level properties that use $ref point to existing $defs', () => {
+  it('ai.reviewStage has required fields: provider, model, inputPerMillion, outputPerMillion', () => {
+    const aiProp = (schema.properties as any).ai;
+    const aiDef = resolveDef(aiProp);
+    const reviewStageRef = aiDef.properties?.reviewStage?.$ref;
+    expect(reviewStageRef).toBeDefined();
+
+    const defName = reviewStageRef.replace('#/$defs/', '');
+    const def = (schema.$defs as Record<string, any>)[defName];
+    expect(def).toBeDefined();
+    expect(def.required).toEqual(
+      expect.arrayContaining(['provider', 'model', 'inputPerMillion', 'outputPerMillion']),
+    );
+  });
+
+  it('review section requires pipeline', () => {
+    const reviewProp = (schema.properties as any).review;
+    const reviewDef = resolveDef(reviewProp);
+    expect(reviewDef.required).toContain('pipeline');
+  });
+
+  it('all $ref values point to existing $defs', () => {
+    const defs = schema.$defs as Record<string, unknown>;
     const refPattern = /^#\/\$defs\/(.+)$/;
-    for (const [_propName, propValue] of Object.entries(parseResult.data!.properties)) {
-      const prop = propValue as Record<string, unknown>;
-      if (typeof prop.$ref === 'string') {
-        const match = prop.$ref.match(refPattern);
+
+    const checkRefs = (node: unknown) => {
+      if (node === null || typeof node !== 'object') return;
+      const obj = node as Record<string, unknown>;
+      if ('$ref' in obj && typeof obj.$ref === 'string') {
+        const match = obj.$ref.match(refPattern);
         if (match) {
-          expect(parseResult.data!.$defs).toHaveProperty(match[1]);
+          expect(defs).toHaveProperty(match[1]);
         }
       }
-    }
+      for (const value of Object.values(obj)) {
+        checkRefs(value);
+      }
+    };
+
+    checkRefs(schema);
+  });
+
+  it('matches the Zod schema via round-trip generation', () => {
+    // Generate the JSON Schema from the same Zod source
+    const generated = z.toJSONSchema(qualopsConfigSchema, {
+      reused: 'ref',
+    }) as Record<string, unknown>;
+
+    // The file should match the generated output (excluding metadata fields we add)
+    expect(schema.type).toBe(generated.type);
+    expect(schema.required).toEqual(generated.required);
+    expect(schema.additionalProperties).toBe(generated.additionalProperties);
+    expect(Object.keys(schema.properties as object).sort()).toEqual(
+      Object.keys(generated.properties as object).sort(),
+    );
+  });
+
+  it('accepts the actual .qualopsrc.json config via Zod parse', () => {
+    const configPath = join(__dirname, '../../.qualops/.qualopsrc.json');
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(() => qualopsConfigSchema.parse(config)).not.toThrow();
   });
 });

--- a/tests/unit/cli/utils/error-handler.spec.ts
+++ b/tests/unit/cli/utils/error-handler.spec.ts
@@ -90,6 +90,46 @@ describe('handleError', () => {
     });
   });
 
+  describe('with user-facing errors', () => {
+    it('should print message as-is and skip stack trace', () => {
+      const error = Object.assign(
+        new Error('Invalid .qualopsrc.json configuration:\n  - foo: bar'),
+        {
+          userFacing: true as const,
+        },
+      );
+      error.stack = 'Error: Invalid ...\n    at someFile.ts:10:5';
+
+      handleError(error, 'qualops');
+
+      // Message printed verbatim — no context prefix, no stack trace.
+      expect(mockLogger.error).toHaveBeenCalledTimes(1);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Invalid .qualopsrc.json configuration:\n  - foo: bar',
+      );
+      expect(mockLogger.error).not.toHaveBeenCalledWith('Stack trace:', expect.anything());
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+
+    it('should still exit with code 1', () => {
+      const error = Object.assign(new Error('user-facing'), { userFacing: true as const });
+
+      handleError(error);
+
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+
+    it('should not treat plain errors as user-facing', () => {
+      const error = new Error('regular error');
+      error.stack = 'Error: regular error\n    at file.ts:1:1';
+
+      handleError(error);
+
+      // Stack trace IS logged for non-user-facing errors.
+      expect(mockLogger.error).toHaveBeenCalledWith('Stack trace:', expect.any(String));
+    });
+  });
+
   describe('with non-Error values', () => {
     it('should log string error without context', () => {
       handleError('String error message');
@@ -398,6 +438,28 @@ describe('handleStageError', () => {
     it('should exit with code 1 on null', () => {
       handleStageError('report', null);
 
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe('with user-facing errors', () => {
+    it('should print message as-is and skip stack trace and stage prefix', () => {
+      const error = Object.assign(new Error('Invalid .qualopsrc.json configuration:\n  - foo'), {
+        userFacing: true as const,
+      });
+      error.stack = 'Error: Invalid ...\n    at someFile.ts:10:5';
+
+      handleStageError('review', error);
+
+      expect(mockLogger.error).toHaveBeenCalledTimes(1);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        'Invalid .qualopsrc.json configuration:\n  - foo',
+      );
+      expect(mockLogger.error).not.toHaveBeenCalledWith('Stack trace:', expect.anything());
+      expect(mockLogger.error).not.toHaveBeenCalledWith(
+        expect.stringContaining('review failed:'),
+        expect.anything(),
+      );
       expect(mockProcessExit).toHaveBeenCalledWith(1);
     });
   });

--- a/tests/unit/config/config.spec.ts
+++ b/tests/unit/config/config.spec.ts
@@ -443,63 +443,6 @@ describe('ConfigService', () => {
     });
   });
 
-  describe('getMaxFileSizeKB', () => {
-    it('should return maxFileSizeKB from config', () => {
-      const instance = ConfigService.getInstance();
-      expect(instance.getMaxFileSizeKB()).toBe(500);
-    });
-
-    it('should return default when maxFileSizeKB is undefined', () => {
-      const instance = ConfigService.getInstance();
-      instance.set('maxFileSizeKB', undefined);
-      expect(instance.getMaxFileSizeKB()).toBe(500);
-    });
-
-    it('should return custom value when set', () => {
-      const instance = ConfigService.getInstance();
-      instance.set('maxFileSizeKB', 1000);
-      expect(instance.getMaxFileSizeKB()).toBe(1000);
-    });
-  });
-
-  describe('getMaxTokensPerFile', () => {
-    it('should return maxTokensPerFile from config', () => {
-      const instance = ConfigService.getInstance();
-      expect(instance.getMaxTokensPerFile()).toBe(1000000);
-    });
-
-    it('should return default when maxTokensPerFile is undefined', () => {
-      const instance = ConfigService.getInstance();
-      instance.set('maxTokensPerFile', undefined);
-      expect(instance.getMaxTokensPerFile()).toBe(1000000);
-    });
-
-    it('should return custom value when set', () => {
-      const instance = ConfigService.getInstance();
-      instance.set('maxTokensPerFile', 500000);
-      expect(instance.getMaxTokensPerFile()).toBe(500000);
-    });
-  });
-
-  describe('getMaxReactSteps', () => {
-    it('should return maxReactSteps from config', () => {
-      const instance = ConfigService.getInstance();
-      expect(instance.getMaxReactSteps()).toBe(5);
-    });
-
-    it('should return default when maxReactSteps is undefined', () => {
-      const instance = ConfigService.getInstance();
-      instance.set('maxReactSteps', undefined);
-      expect(instance.getMaxReactSteps()).toBe(5);
-    });
-
-    it('should return custom value when set', () => {
-      const instance = ConfigService.getInstance();
-      instance.set('maxReactSteps', 10);
-      expect(instance.getMaxReactSteps()).toBe(10);
-    });
-  });
-
   describe('validate', () => {
     it('should return empty array when config is valid', () => {
       const aiConfig = {
@@ -557,70 +500,6 @@ describe('ConfigService', () => {
     });
   });
 
-  describe('getDirectories', () => {
-    it('should return default directories', () => {
-      const instance = ConfigService.getInstance();
-      const directories = instance.getDirectories();
-      expect(directories.SESSIONS).toBe('reports/sessions');
-      expect(directories.CACHE).toBe('.qualops-cache');
-    });
-
-    it('should return custom directories from config', () => {
-      mockExistsSync.mockReturnValue(true);
-      mockReadFileSync.mockReturnValue(
-        JSON.stringify({
-          ...VALID_MINIMAL_CONFIG,
-          paths: {
-            sessionsDir: '/custom/sessions',
-            cacheDir: '/custom/cache',
-          },
-        }),
-      );
-      const instance = ConfigService.getInstance();
-      const directories = instance.getDirectories();
-      expect(directories.SESSIONS).toBe('/custom/sessions');
-      expect(directories.CACHE).toBe('/custom/cache');
-    });
-  });
-
-  describe('getPerformanceLimits', () => {
-    it('should return default performance limits', () => {
-      const instance = ConfigService.getInstance();
-      const limits = instance.getPerformanceLimits();
-      expect(limits.maxFileSizeKB).toBe(500);
-      expect(limits.maxFilesPerBatch).toBe(7);
-      expect(limits.maxFilesPerProject).toBe(10000);
-      expect(limits.timeoutSeconds).toBe(300);
-      expect(limits.maxTokensPerFile).toBe(1000000);
-      expect(limits.maxRetries).toBe(2);
-    });
-
-    it('should return custom performance limits from config', () => {
-      mockExistsSync.mockReturnValue(true);
-      mockReadFileSync.mockReturnValue(
-        JSON.stringify({
-          ...VALID_MINIMAL_CONFIG,
-          performance: {
-            maxFileSizeKB: 1000,
-            maxFilesPerBatch: 15,
-            maxFilesPerProject: 5000,
-            timeoutSeconds: 600,
-            maxTokensPerFile: 2000000,
-            maxRetries: 3,
-          },
-        }),
-      );
-      const instance = ConfigService.getInstance();
-      const limits = instance.getPerformanceLimits();
-      expect(limits.maxFileSizeKB).toBe(1000);
-      expect(limits.maxFilesPerBatch).toBe(15);
-      expect(limits.maxFilesPerProject).toBe(5000);
-      expect(limits.timeoutSeconds).toBe(600);
-      expect(limits.maxTokensPerFile).toBe(2000000);
-      expect(limits.maxRetries).toBe(3);
-    });
-  });
-
   describe('getCriticalStages', () => {
     it('should return critical stages', () => {
       const stages = CRITICAL_STAGES;
@@ -634,44 +513,6 @@ describe('ConfigService', () => {
       expect(cacheConfig.VERSION).toBe('1.0.0');
       expect(cacheConfig.MAX_ENTRIES).toBe(10000);
       expect(cacheConfig.TTL_DAYS).toBe(7);
-    });
-  });
-
-  describe('getConfigValue', () => {
-    it('should return nested config value', () => {
-      mockExistsSync.mockReturnValue(true);
-      mockReadFileSync.mockReturnValue(
-        JSON.stringify({
-          ...VALID_MINIMAL_CONFIG,
-          paths: {
-            sessionsDir: '/custom/sessions',
-          },
-        }),
-      );
-      const instance = ConfigService.getInstance();
-      const directories = instance.getDirectories();
-      expect(directories.SESSIONS).toBe('/custom/sessions');
-    });
-
-    it('should return default when path is not set', () => {
-      mockExistsSync.mockReturnValue(true);
-      mockReadFileSync.mockReturnValue(JSON.stringify(VALID_MINIMAL_CONFIG));
-      const instance = ConfigService.getInstance();
-      const directories = instance.getDirectories();
-      expect(directories.SESSIONS).toBe('reports/sessions');
-    });
-
-    it('should return default when config file does not exist', () => {
-      mockExistsSync.mockReturnValue(false);
-      const instance = ConfigService.getInstance();
-      const directories = instance.getDirectories();
-      expect(directories.SESSIONS).toBe('reports/sessions');
-    });
-
-    it('should throw on invalid JSON', () => {
-      mockExistsSync.mockReturnValue(true);
-      mockReadFileSync.mockReturnValue('invalid json');
-      expect(() => ConfigService.getInstance()).toThrow(ConfigParseError);
     });
   });
 

--- a/tests/unit/config/config.spec.ts
+++ b/tests/unit/config/config.spec.ts
@@ -28,15 +28,22 @@ jest.mock('@/config/env', () => ({
 }));
 jest.mock('node:fs');
 jest.mock('@/shared/utils/logger');
+jest.mock('@/config/schema-validator', () => ({
+  validateConfig: jest.fn(() => ({ deprecations: [] })),
+}));
 
 const mockExistsSync = existsSync as jest.MockedFunction<typeof existsSync>;
 const mockReadFileSync = readFileSync as jest.MockedFunction<typeof readFileSync>;
 
 import { CACHE_CONFIG, ConfigService, CRITICAL_STAGES, FILE_NAMES } from '@/config/config';
 import { envConfig } from '@/config/env';
+import { validateConfig } from '@/config/schema-validator';
 import type { Config } from '@/shared/types';
+import { logger } from '@/shared/utils/logger';
 
 const mockEnvConfig = envConfig as jest.Mocked<typeof envConfig>;
+const mockValidateConfig = validateConfig as jest.MockedFunction<typeof validateConfig>;
+const mockLogger = logger as jest.Mocked<typeof logger>;
 
 describe('ConfigService', () => {
   let originalCwd: string;
@@ -650,6 +657,78 @@ describe('ConfigService', () => {
     it('should export CACHE_CONFIG constant', () => {
       const { CACHE_CONFIG } = require('@/config/config');
       expect(CACHE_CONFIG.VERSION).toBe('1.0.0');
+    });
+  });
+
+  describe('schema validation integration', () => {
+    it('should call validateConfig when config file exists', () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify({ ai: {}, review: {} }));
+
+      ConfigService.getInstance();
+      expect(mockValidateConfig).toHaveBeenCalledWith({ ai: {}, review: {} });
+    });
+
+    it('should skip validation when config file does not exist', () => {
+      mockExistsSync.mockReturnValue(false);
+      ConfigService.getInstance();
+      expect(mockValidateConfig).not.toHaveBeenCalled();
+    });
+
+    it('should skip validation when config is empty (invalid JSON fallback)', () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue('invalid json');
+      ConfigService.getInstance();
+      expect(mockValidateConfig).not.toHaveBeenCalled();
+    });
+
+    it('should throw when validateConfig throws', () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify({ bad: true }));
+      mockValidateConfig.mockImplementationOnce(() => {
+        throw new Error('Schema validation failed');
+      });
+      expect(() => ConfigService.getInstance()).toThrow('Schema validation failed');
+    });
+
+    it('should log warnings for deprecations', () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify({ ai: {}, review: {} }));
+      mockValidateConfig.mockReturnValueOnce({
+        deprecations: [
+          { path: 'verbose', description: 'Legacy field.' },
+          { path: 'skipPatterns', description: 'Legacy field.' },
+        ],
+      });
+
+      ConfigService.getInstance();
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        '[CONFIG] Deprecated field "verbose": Legacy field.',
+      );
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        '[CONFIG] Deprecated field "skipPatterns": Legacy field.',
+      );
+    });
+
+    it('should not log warnings when there are no deprecations', () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify({ ai: {}, review: {} }));
+      mockValidateConfig.mockReturnValueOnce({ deprecations: [] });
+
+      ConfigService.getInstance();
+      expect(mockValidateConfig).toHaveBeenCalledWith({ ai: {}, review: {} });
+      expect(mockLogger.warn).not.toHaveBeenCalled();
+    });
+
+    it('should validate on reset', () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify({ ai: {}, review: {} }));
+
+      const instance = ConfigService.getInstance();
+      mockValidateConfig.mockClear();
+
+      instance.reset();
+      expect(mockValidateConfig).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/tests/unit/config/config.spec.ts
+++ b/tests/unit/config/config.spec.ts
@@ -28,34 +28,42 @@ jest.mock('@/config/env', () => ({
 }));
 jest.mock('node:fs');
 jest.mock('@/shared/utils/logger');
-jest.mock('@/config/schema-validator', () => {
-  const actual = jest.requireActual('@/config/schema-validator');
-  return {
-    ...actual,
-    assertValidConfig: jest.fn(() => undefined),
-    collectConfigWarnings: jest.fn(() => ({ deprecations: [], unknownFields: [] })),
-  };
-});
 
 const mockExistsSync = existsSync as jest.MockedFunction<typeof existsSync>;
 const mockReadFileSync = readFileSync as jest.MockedFunction<typeof readFileSync>;
 
 import { CACHE_CONFIG, ConfigService, CRITICAL_STAGES, FILE_NAMES } from '@/config/config';
 import { envConfig } from '@/config/env';
-import {
-  assertValidConfig,
-  collectConfigWarnings,
-  ConfigValidationError,
-} from '@/config/schema-validator';
+import { ConfigParseError, ConfigValidationError } from '@/config/schema-validator';
 import type { Config } from '@/shared/types';
 import { logger } from '@/shared/utils/logger';
 
 const mockEnvConfig = envConfig as jest.Mocked<typeof envConfig>;
-const mockAssertValidConfig = assertValidConfig as jest.MockedFunction<typeof assertValidConfig>;
-const mockCollectConfigWarnings = collectConfigWarnings as jest.MockedFunction<
-  typeof collectConfigWarnings
->;
 const mockLogger = logger as jest.Mocked<typeof logger>;
+
+/**
+ * Minimal config that satisfies real schema validation. Use as a base and
+ * spread extra sections on top when tests need specific fields populated.
+ */
+const VALID_MINIMAL_CONFIG = {
+  ai: {
+    reviewStage: {
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-5-20250929',
+      inputPerMillion: 3,
+      outputPerMillion: 15,
+    },
+  },
+  review: {
+    pipeline: [
+      {
+        name: 'test-job',
+        enabled: true,
+        passes: [{ name: 'test-pass', enabled: true, prompt: 'test.md' }],
+      },
+    ],
+  },
+} as const;
 
 describe('ConfigService', () => {
   let originalCwd: string;
@@ -134,8 +142,7 @@ describe('ConfigService', () => {
   describe('loadConfig', () => {
     it('should load configuration from .qualopsrc.json', () => {
       const rcConfig = {
-        review: { maxConcurrentFiles: 10 },
-        ai: { reviewStage: { provider: 'openai', model: 'gpt-4' } },
+        ...VALID_MINIMAL_CONFIG,
         performance: { maxFileSizeKB: 1000 },
         fix: { maxConcurrentFixes: 5 },
       };
@@ -144,7 +151,6 @@ describe('ConfigService', () => {
 
       const instance = ConfigService.getInstance();
       expect(instance.get('review')).toEqual(rcConfig.review);
-
       expect(instance.get('ai')).toEqual(rcConfig.ai);
       expect(instance.get('fix')).toEqual(rcConfig.fix);
       expect(instance.get('maxFileSizeKB')).toBe(1000);
@@ -152,6 +158,7 @@ describe('ConfigService', () => {
 
     it('should handle throttling configuration', () => {
       const rcConfig = {
+        ...VALID_MINIMAL_CONFIG,
         performance: {
           throttling: {
             apiCallsPerMinute: 60,
@@ -174,8 +181,15 @@ describe('ConfigService', () => {
 
     it('should load configuration from .qualops/.qualopsrc.json', () => {
       const rcConfig = {
-        review: { maxConcurrentFiles: 15 },
-        ai: { reviewStage: { provider: 'anthropic', model: 'claude-3' } },
+        ...VALID_MINIMAL_CONFIG,
+        ai: {
+          reviewStage: {
+            provider: 'anthropic',
+            model: 'claude-3',
+            inputPerMillion: 3,
+            outputPerMillion: 15,
+          },
+        },
       };
 
       mockExistsSync.mockReturnValue(true);
@@ -186,10 +200,10 @@ describe('ConfigService', () => {
       expect(instance.get('ai')).toEqual(rcConfig.ai);
     });
 
-    it('should handle invalid JSON in .qualopsrc.json', () => {
+    it('should throw ConfigParseError on invalid JSON in .qualopsrc.json', () => {
       mockExistsSync.mockReturnValue(true);
       mockReadFileSync.mockReturnValue('invalid json');
-      expect(() => ConfigService.getInstance()).not.toThrow();
+      expect(() => ConfigService.getInstance()).toThrow(ConfigParseError);
     });
 
     it('should override maxFilesPerBatch from environment', () => {
@@ -289,12 +303,17 @@ describe('ConfigService', () => {
     });
 
     it('should reload from .qualopsrc.json on reset', () => {
-      const rcConfig = { performance: { maxFileSizeKB: 2000 } };
+      const rcConfig = {
+        ...VALID_MINIMAL_CONFIG,
+        performance: { maxFileSizeKB: 2000 },
+      };
       mockExistsSync.mockReturnValue(true);
       mockReadFileSync.mockReturnValue(JSON.stringify(rcConfig));
 
       const instance = ConfigService.getInstance();
-      mockReadFileSync.mockReturnValue(JSON.stringify({ performance: { maxFileSizeKB: 3000 } }));
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({ ...VALID_MINIMAL_CONFIG, performance: { maxFileSizeKB: 3000 } }),
+      );
       instance.reset();
       expect(instance.get('maxFileSizeKB')).toBe(3000);
     });
@@ -550,6 +569,7 @@ describe('ConfigService', () => {
       mockExistsSync.mockReturnValue(true);
       mockReadFileSync.mockReturnValue(
         JSON.stringify({
+          ...VALID_MINIMAL_CONFIG,
           paths: {
             sessionsDir: '/custom/sessions',
             cacheDir: '/custom/cache',
@@ -579,6 +599,7 @@ describe('ConfigService', () => {
       mockExistsSync.mockReturnValue(true);
       mockReadFileSync.mockReturnValue(
         JSON.stringify({
+          ...VALID_MINIMAL_CONFIG,
           performance: {
             maxFileSizeKB: 1000,
             maxFilesPerBatch: 15,
@@ -621,6 +642,7 @@ describe('ConfigService', () => {
       mockExistsSync.mockReturnValue(true);
       mockReadFileSync.mockReturnValue(
         JSON.stringify({
+          ...VALID_MINIMAL_CONFIG,
           paths: {
             sessionsDir: '/custom/sessions',
           },
@@ -631,27 +653,25 @@ describe('ConfigService', () => {
       expect(directories.SESSIONS).toBe('/custom/sessions');
     });
 
-    it('should return undefined when path does not exist', () => {
+    it('should return default when path is not set', () => {
       mockExistsSync.mockReturnValue(true);
-      mockReadFileSync.mockReturnValue(JSON.stringify({}));
+      mockReadFileSync.mockReturnValue(JSON.stringify(VALID_MINIMAL_CONFIG));
       const instance = ConfigService.getInstance();
       const directories = instance.getDirectories();
       expect(directories.SESSIONS).toBe('reports/sessions');
     });
 
-    it('should return undefined when config file does not exist', () => {
+    it('should return default when config file does not exist', () => {
       mockExistsSync.mockReturnValue(false);
       const instance = ConfigService.getInstance();
       const directories = instance.getDirectories();
       expect(directories.SESSIONS).toBe('reports/sessions');
     });
 
-    it('should handle invalid JSON gracefully', () => {
+    it('should throw on invalid JSON', () => {
       mockExistsSync.mockReturnValue(true);
       mockReadFileSync.mockReturnValue('invalid json');
-      const instance = ConfigService.getInstance();
-      const directories = instance.getDirectories();
-      expect(directories.SESSIONS).toBe('reports/sessions');
+      expect(() => ConfigService.getInstance()).toThrow(ConfigParseError);
     });
   });
 
@@ -673,81 +693,60 @@ describe('ConfigService', () => {
   });
 
   describe('schema validation integration', () => {
-    it('should call assertValidConfig and collectConfigWarnings when config file exists', () => {
-      mockExistsSync.mockReturnValue(true);
-      mockReadFileSync.mockReturnValue(JSON.stringify({ ai: {}, review: {} }));
-
-      ConfigService.getInstance();
-      expect(mockAssertValidConfig).toHaveBeenCalledWith({ ai: {}, review: {} });
-      expect(mockCollectConfigWarnings).toHaveBeenCalledWith({ ai: {}, review: {} });
-    });
-
-    it('should skip validation when config file does not exist', () => {
+    it('should not throw when config file does not exist', () => {
       mockExistsSync.mockReturnValue(false);
-      ConfigService.getInstance();
-      expect(mockAssertValidConfig).not.toHaveBeenCalled();
-      expect(mockCollectConfigWarnings).not.toHaveBeenCalled();
+      expect(() => ConfigService.getInstance()).not.toThrow();
     });
 
-    it('should skip validation when config is empty (invalid JSON fallback)', () => {
+    it('should throw ConfigParseError on invalid JSON', () => {
       mockExistsSync.mockReturnValue(true);
-      mockReadFileSync.mockReturnValue('invalid json');
-      ConfigService.getInstance();
-      expect(mockAssertValidConfig).not.toHaveBeenCalled();
-      expect(mockCollectConfigWarnings).not.toHaveBeenCalled();
-    });
-
-    it('should rethrow unexpected errors from assertValidConfig', () => {
-      mockExistsSync.mockReturnValue(true);
-      mockReadFileSync.mockReturnValue(JSON.stringify({ bad: true }));
-      mockAssertValidConfig.mockImplementationOnce(() => {
-        throw new Error('unexpected failure');
-      });
-      expect(() => ConfigService.getInstance()).toThrow('unexpected failure');
+      mockReadFileSync.mockReturnValue('invalid json {{');
+      expect(() => ConfigService.getInstance()).toThrow(ConfigParseError);
     });
 
     it('should propagate ConfigValidationError to the caller (no process.exit)', () => {
       // ConfigService no longer catches or exits — the CLI's top-level
       // error handler is responsible for that. The service just throws.
       mockExistsSync.mockReturnValue(true);
-      mockReadFileSync.mockReturnValue(JSON.stringify({ bad: true }));
-      mockAssertValidConfig.mockImplementationOnce(() => {
-        throw new ConfigValidationError([
-          { code: 'custom', path: ['bad'], message: 'Unrecognized key', input: {} } as never,
-        ]);
-      });
-
+      mockReadFileSync.mockReturnValue(JSON.stringify({ unknownTopLevelField: true }));
       expect(() => ConfigService.getInstance()).toThrow(ConfigValidationError);
-      expect(mockCollectConfigWarnings).not.toHaveBeenCalled();
     });
 
     it('should log warnings for deprecations', () => {
       mockExistsSync.mockReturnValue(true);
-      mockReadFileSync.mockReturnValue(JSON.stringify({ ai: {}, review: {} }));
-      mockCollectConfigWarnings.mockReturnValueOnce({
-        deprecations: [
-          { path: 'verbose', description: 'Legacy field.' },
-          { path: 'skipPatterns', description: 'Legacy field.' },
-        ],
-        unknownFields: [],
-      });
+      // `verbose` and `skipPatterns` are real deprecated top-level fields.
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          ...VALID_MINIMAL_CONFIG,
+          verbose: true,
+          skipPatterns: ['node_modules/**'],
+        }),
+      );
 
       ConfigService.getInstance();
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        '[CONFIG] Deprecated field "verbose": Legacy field.',
+        expect.stringContaining('[CONFIG] Deprecated field "verbose"'),
       );
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        '[CONFIG] Deprecated field "skipPatterns": Legacy field.',
+        expect.stringContaining('[CONFIG] Deprecated field "skipPatterns"'),
       );
     });
 
     it('should log warnings for unknown passthrough fields', () => {
       mockExistsSync.mockReturnValue(true);
-      mockReadFileSync.mockReturnValue(JSON.stringify({ ai: {}, review: {} }));
-      mockCollectConfigWarnings.mockReturnValueOnce({
-        deprecations: [],
-        unknownFields: [{ path: 'ai.reviewStage', field: 'notARealField' }],
-      });
+      // `ai.reviewStage` is a passthrough object, so unknown keys survive
+      // strict validation but are surfaced as warnings.
+      mockReadFileSync.mockReturnValue(
+        JSON.stringify({
+          ...VALID_MINIMAL_CONFIG,
+          ai: {
+            reviewStage: {
+              ...VALID_MINIMAL_CONFIG.ai.reviewStage,
+              notARealField: 'oops',
+            },
+          },
+        }),
+      );
 
       ConfigService.getInstance();
       expect(mockLogger.warn).toHaveBeenCalledWith(
@@ -757,24 +756,10 @@ describe('ConfigService', () => {
 
     it('should not log warnings when there are no deprecations or unknown fields', () => {
       mockExistsSync.mockReturnValue(true);
-      mockReadFileSync.mockReturnValue(JSON.stringify({ ai: {}, review: {} }));
-      mockCollectConfigWarnings.mockReturnValueOnce({ deprecations: [], unknownFields: [] });
+      mockReadFileSync.mockReturnValue(JSON.stringify(VALID_MINIMAL_CONFIG));
 
       ConfigService.getInstance();
       expect(mockLogger.warn).not.toHaveBeenCalled();
-    });
-
-    it('should validate on reset', () => {
-      mockExistsSync.mockReturnValue(true);
-      mockReadFileSync.mockReturnValue(JSON.stringify({ ai: {}, review: {} }));
-
-      const instance = ConfigService.getInstance();
-      mockAssertValidConfig.mockClear();
-      mockCollectConfigWarnings.mockClear();
-
-      instance.reset();
-      expect(mockAssertValidConfig).toHaveBeenCalledTimes(1);
-      expect(mockCollectConfigWarnings).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/tests/unit/config/config.spec.ts
+++ b/tests/unit/config/config.spec.ts
@@ -28,21 +28,33 @@ jest.mock('@/config/env', () => ({
 }));
 jest.mock('node:fs');
 jest.mock('@/shared/utils/logger');
-jest.mock('@/config/schema-validator', () => ({
-  validateConfig: jest.fn(() => ({ deprecations: [] })),
-}));
+jest.mock('@/config/schema-validator', () => {
+  const actual = jest.requireActual('@/config/schema-validator');
+  return {
+    ...actual,
+    assertValidConfig: jest.fn(() => undefined),
+    collectConfigWarnings: jest.fn(() => ({ deprecations: [], unknownFields: [] })),
+  };
+});
 
 const mockExistsSync = existsSync as jest.MockedFunction<typeof existsSync>;
 const mockReadFileSync = readFileSync as jest.MockedFunction<typeof readFileSync>;
 
 import { CACHE_CONFIG, ConfigService, CRITICAL_STAGES, FILE_NAMES } from '@/config/config';
 import { envConfig } from '@/config/env';
-import { validateConfig } from '@/config/schema-validator';
+import {
+  assertValidConfig,
+  collectConfigWarnings,
+  ConfigValidationError,
+} from '@/config/schema-validator';
 import type { Config } from '@/shared/types';
 import { logger } from '@/shared/utils/logger';
 
 const mockEnvConfig = envConfig as jest.Mocked<typeof envConfig>;
-const mockValidateConfig = validateConfig as jest.MockedFunction<typeof validateConfig>;
+const mockAssertValidConfig = assertValidConfig as jest.MockedFunction<typeof assertValidConfig>;
+const mockCollectConfigWarnings = collectConfigWarnings as jest.MockedFunction<
+  typeof collectConfigWarnings
+>;
 const mockLogger = logger as jest.Mocked<typeof logger>;
 
 describe('ConfigService', () => {
@@ -661,44 +673,63 @@ describe('ConfigService', () => {
   });
 
   describe('schema validation integration', () => {
-    it('should call validateConfig when config file exists', () => {
+    it('should call assertValidConfig and collectConfigWarnings when config file exists', () => {
       mockExistsSync.mockReturnValue(true);
       mockReadFileSync.mockReturnValue(JSON.stringify({ ai: {}, review: {} }));
 
       ConfigService.getInstance();
-      expect(mockValidateConfig).toHaveBeenCalledWith({ ai: {}, review: {} });
+      expect(mockAssertValidConfig).toHaveBeenCalledWith({ ai: {}, review: {} });
+      expect(mockCollectConfigWarnings).toHaveBeenCalledWith({ ai: {}, review: {} });
     });
 
     it('should skip validation when config file does not exist', () => {
       mockExistsSync.mockReturnValue(false);
       ConfigService.getInstance();
-      expect(mockValidateConfig).not.toHaveBeenCalled();
+      expect(mockAssertValidConfig).not.toHaveBeenCalled();
+      expect(mockCollectConfigWarnings).not.toHaveBeenCalled();
     });
 
     it('should skip validation when config is empty (invalid JSON fallback)', () => {
       mockExistsSync.mockReturnValue(true);
       mockReadFileSync.mockReturnValue('invalid json');
       ConfigService.getInstance();
-      expect(mockValidateConfig).not.toHaveBeenCalled();
+      expect(mockAssertValidConfig).not.toHaveBeenCalled();
+      expect(mockCollectConfigWarnings).not.toHaveBeenCalled();
     });
 
-    it('should throw when validateConfig throws', () => {
+    it('should rethrow unexpected errors from assertValidConfig', () => {
       mockExistsSync.mockReturnValue(true);
       mockReadFileSync.mockReturnValue(JSON.stringify({ bad: true }));
-      mockValidateConfig.mockImplementationOnce(() => {
-        throw new Error('Schema validation failed');
+      mockAssertValidConfig.mockImplementationOnce(() => {
+        throw new Error('unexpected failure');
       });
-      expect(() => ConfigService.getInstance()).toThrow('Schema validation failed');
+      expect(() => ConfigService.getInstance()).toThrow('unexpected failure');
+    });
+
+    it('should propagate ConfigValidationError to the caller (no process.exit)', () => {
+      // ConfigService no longer catches or exits — the CLI's top-level
+      // error handler is responsible for that. The service just throws.
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify({ bad: true }));
+      mockAssertValidConfig.mockImplementationOnce(() => {
+        throw new ConfigValidationError([
+          { code: 'custom', path: ['bad'], message: 'Unrecognized key', input: {} } as never,
+        ]);
+      });
+
+      expect(() => ConfigService.getInstance()).toThrow(ConfigValidationError);
+      expect(mockCollectConfigWarnings).not.toHaveBeenCalled();
     });
 
     it('should log warnings for deprecations', () => {
       mockExistsSync.mockReturnValue(true);
       mockReadFileSync.mockReturnValue(JSON.stringify({ ai: {}, review: {} }));
-      mockValidateConfig.mockReturnValueOnce({
+      mockCollectConfigWarnings.mockReturnValueOnce({
         deprecations: [
           { path: 'verbose', description: 'Legacy field.' },
           { path: 'skipPatterns', description: 'Legacy field.' },
         ],
+        unknownFields: [],
       });
 
       ConfigService.getInstance();
@@ -710,13 +741,26 @@ describe('ConfigService', () => {
       );
     });
 
-    it('should not log warnings when there are no deprecations', () => {
+    it('should log warnings for unknown passthrough fields', () => {
       mockExistsSync.mockReturnValue(true);
       mockReadFileSync.mockReturnValue(JSON.stringify({ ai: {}, review: {} }));
-      mockValidateConfig.mockReturnValueOnce({ deprecations: [] });
+      mockCollectConfigWarnings.mockReturnValueOnce({
+        deprecations: [],
+        unknownFields: [{ path: 'ai.reviewStage', field: 'notARealField' }],
+      });
 
       ConfigService.getInstance();
-      expect(mockValidateConfig).toHaveBeenCalledWith({ ai: {}, review: {} });
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.stringContaining('[CONFIG] Unknown field "notARealField" at ai.reviewStage'),
+      );
+    });
+
+    it('should not log warnings when there are no deprecations or unknown fields', () => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify({ ai: {}, review: {} }));
+      mockCollectConfigWarnings.mockReturnValueOnce({ deprecations: [], unknownFields: [] });
+
+      ConfigService.getInstance();
       expect(mockLogger.warn).not.toHaveBeenCalled();
     });
 
@@ -725,10 +769,12 @@ describe('ConfigService', () => {
       mockReadFileSync.mockReturnValue(JSON.stringify({ ai: {}, review: {} }));
 
       const instance = ConfigService.getInstance();
-      mockValidateConfig.mockClear();
+      mockAssertValidConfig.mockClear();
+      mockCollectConfigWarnings.mockClear();
 
       instance.reset();
-      expect(mockValidateConfig).toHaveBeenCalledTimes(1);
+      expect(mockAssertValidConfig).toHaveBeenCalledTimes(1);
+      expect(mockCollectConfigWarnings).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/tests/unit/config/schema-validator.spec.ts
+++ b/tests/unit/config/schema-validator.spec.ts
@@ -1,5 +1,7 @@
 import {
+  CONFIG_PARSE_ERROR_CODE,
   CONFIG_VALIDATION_ERROR_CODE,
+  ConfigParseError,
   ConfigValidationError,
   assertValidConfig,
   collectConfigWarnings,
@@ -245,6 +247,33 @@ describe('assertValidConfig', () => {
         expect((err as ConfigValidationError).userFacing).toBe(true);
       }
     });
+  });
+});
+
+describe('ConfigParseError', () => {
+  it('exposes a stable machine-readable error code', () => {
+    const err = new ConfigParseError('/tmp/.qualopsrc.json', new Error('Unexpected token }'));
+    expect(err.errorCode).toBe(CONFIG_PARSE_ERROR_CODE);
+    expect(err.errorCode).toBe('CONFIG_PARSE_ERROR');
+  });
+
+  it('marks the error as user-facing so the CLI can suppress the stack trace', () => {
+    const err = new ConfigParseError('/tmp/.qualopsrc.json', new Error('Unexpected token }'));
+    expect(err.userFacing).toBe(true);
+  });
+
+  it('includes the file path and cause message', () => {
+    const err = new ConfigParseError(
+      '/tmp/project/.qualopsrc.json',
+      new Error('Unexpected token } in JSON at position 42'),
+    );
+    expect(err.message).toContain('/tmp/project/.qualopsrc.json');
+    expect(err.message).toContain('Unexpected token } in JSON at position 42');
+  });
+
+  it('has a distinct error name', () => {
+    const err = new ConfigParseError('/tmp/.qualopsrc.json', new Error('boom'));
+    expect(err.name).toBe('ConfigParseError');
   });
 });
 

--- a/tests/unit/config/schema-validator.spec.ts
+++ b/tests/unit/config/schema-validator.spec.ts
@@ -1,6 +1,9 @@
-import { z } from 'zod';
-
-import { validateConfig } from '@/config/schema-validator';
+import {
+  CONFIG_VALIDATION_ERROR_CODE,
+  ConfigValidationError,
+  assertValidConfig,
+  collectConfigWarnings,
+} from '@/config/schema-validator';
 
 // Minimal valid config for tests
 const minimalValidConfig = {
@@ -23,10 +26,10 @@ const minimalValidConfig = {
   },
 };
 
-describe('validateConfig', () => {
+describe('assertValidConfig', () => {
   describe('valid configs', () => {
     it('accepts minimal valid config', () => {
-      expect(() => validateConfig(minimalValidConfig)).not.toThrow();
+      expect(() => assertValidConfig(minimalValidConfig)).not.toThrow();
     });
 
     it('accepts full config with all sections', () => {
@@ -39,12 +42,12 @@ describe('validateConfig', () => {
         gitlab: { blockPipeline: false },
         logger: { level: 'info', enableColors: true },
       };
-      expect(() => validateConfig(fullConfig)).not.toThrow();
+      expect(() => assertValidConfig(fullConfig)).not.toThrow();
     });
 
     it('accepts config with $schema field', () => {
       const config = { $schema: '../docs/qualops-config.schema.json', ...minimalValidConfig };
-      expect(() => validateConfig(config)).not.toThrow();
+      expect(() => assertValidConfig(config)).not.toThrow();
     });
 
     it('accepts agentic pipeline job without passes', () => {
@@ -61,7 +64,7 @@ describe('validateConfig', () => {
           ],
         },
       };
-      expect(() => validateConfig(config)).not.toThrow();
+      expect(() => assertValidConfig(config)).not.toThrow();
     });
 
     it('accepts AI stage config with extra provider-specific fields', () => {
@@ -76,77 +79,79 @@ describe('validateConfig', () => {
         },
         review: minimalValidConfig.review,
       };
-      expect(() => validateConfig(config)).not.toThrow();
+      expect(() => assertValidConfig(config)).not.toThrow();
     });
   });
 
   describe('schema violations (throws)', () => {
     it('throws when ai section is missing', () => {
-      expect(() => validateConfig({ review: minimalValidConfig.review })).toThrow(z.ZodError);
+      expect(() => assertValidConfig({ review: minimalValidConfig.review })).toThrow(
+        ConfigValidationError,
+      );
     });
 
     it('throws when review section is missing', () => {
-      expect(() => validateConfig({ ai: minimalValidConfig.ai })).toThrow(z.ZodError);
+      expect(() => assertValidConfig({ ai: minimalValidConfig.ai })).toThrow(ConfigValidationError);
     });
 
     it('throws on unknown top-level field', () => {
-      expect(() => validateConfig({ ...minimalValidConfig, unknownField: true })).toThrow(
-        z.ZodError,
+      expect(() => assertValidConfig({ ...minimalValidConfig, unknownField: true })).toThrow(
+        ConfigValidationError,
       );
     });
 
     it('throws on type mismatch (string instead of object)', () => {
-      expect(() => validateConfig({ ...minimalValidConfig, ai: 'not-an-object' })).toThrow(
-        z.ZodError,
+      expect(() => assertValidConfig({ ...minimalValidConfig, ai: 'not-an-object' })).toThrow(
+        ConfigValidationError,
       );
     });
 
     it('throws when ai.reviewStage is missing', () => {
-      expect(() => validateConfig({ ai: {}, review: minimalValidConfig.review })).toThrow(
-        z.ZodError,
+      expect(() => assertValidConfig({ ai: {}, review: minimalValidConfig.review })).toThrow(
+        ConfigValidationError,
       );
     });
 
     it('throws when pipeline is empty', () => {
-      expect(() => validateConfig({ ai: minimalValidConfig.ai, review: { pipeline: [] } })).toThrow(
-        z.ZodError,
-      );
+      expect(() =>
+        assertValidConfig({ ai: minimalValidConfig.ai, review: { pipeline: [] } }),
+      ).toThrow(ConfigValidationError);
     });
 
     it('throws when file-by-file job has no passes', () => {
       expect(() =>
-        validateConfig({
+        assertValidConfig({
           ai: minimalValidConfig.ai,
           review: {
             pipeline: [{ name: 'job', enabled: true }],
           },
         }),
-      ).toThrow(z.ZodError);
+      ).toThrow(ConfigValidationError);
     });
 
     it('throws when file-by-file job has empty passes', () => {
       expect(() =>
-        validateConfig({
+        assertValidConfig({
           ai: minimalValidConfig.ai,
           review: {
             pipeline: [{ name: 'job', enabled: true, passes: [] }],
           },
         }),
-      ).toThrow(z.ZodError);
+      ).toThrow(ConfigValidationError);
     });
 
     it('throws on unknown field inside review', () => {
       expect(() =>
-        validateConfig({
+        assertValidConfig({
           ...minimalValidConfig,
           review: { ...minimalValidConfig.review, foobar: true },
         }),
-      ).toThrow(z.ZodError);
+      ).toThrow(ConfigValidationError);
     });
 
     it('throws on invalid AI provider', () => {
       expect(() =>
-        validateConfig({
+        assertValidConfig({
           ai: {
             reviewStage: {
               provider: 'invalid-provider',
@@ -157,22 +162,169 @@ describe('validateConfig', () => {
           },
           review: minimalValidConfig.review,
         }),
-      ).toThrow(z.ZodError);
+      ).toThrow(ConfigValidationError);
     });
 
     it('throws on invalid confidence score (out of range)', () => {
       expect(() =>
-        validateConfig({
+        assertValidConfig({
           ...minimalValidConfig,
           review: { ...minimalValidConfig.review, minConfidence: 15 },
         }),
-      ).toThrow(z.ZodError);
+      ).toThrow(ConfigValidationError);
+    });
+  });
+
+  describe('error message formatting', () => {
+    it('prefixes message with a human-readable header', () => {
+      try {
+        assertValidConfig({ ...minimalValidConfig, unknownField: true });
+        fail('expected ConfigValidationError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ConfigValidationError);
+        expect((err as Error).message).toContain('Invalid .qualopsrc.json configuration:');
+      }
+    });
+
+    it('includes a bullet line with path and message per issue', () => {
+      try {
+        assertValidConfig({ ...minimalValidConfig, unknownField: true });
+        fail('expected ConfigValidationError');
+      } catch (err) {
+        const message = (err as Error).message;
+        expect(message).toMatch(/^ {2}- <root>: .*unknownField/m);
+      }
+    });
+
+    it('formats nested field paths with dot notation', () => {
+      try {
+        assertValidConfig({
+          ...minimalValidConfig,
+          ai: {
+            reviewStage: {
+              provider: 'not-a-provider',
+              model: 'm',
+              inputPerMillion: 0,
+              outputPerMillion: 0,
+            },
+          },
+        });
+        fail('expected ConfigValidationError');
+      } catch (err) {
+        const message = (err as Error).message;
+        expect(message).toContain('ai.reviewStage.provider');
+      }
+    });
+
+    it('exposes ZodIssue objects on the error instance', () => {
+      try {
+        assertValidConfig({ review: minimalValidConfig.review });
+        fail('expected ConfigValidationError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ConfigValidationError);
+        expect((err as ConfigValidationError).issues.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('exposes a stable machine-readable error code', () => {
+      try {
+        assertValidConfig({ review: minimalValidConfig.review });
+        fail('expected ConfigValidationError');
+      } catch (err) {
+        expect(err).toBeInstanceOf(ConfigValidationError);
+        expect((err as ConfigValidationError).errorCode).toBe(CONFIG_VALIDATION_ERROR_CODE);
+        expect((err as ConfigValidationError).errorCode).toBe('CONFIG_VALIDATION_ERROR');
+      }
+    });
+
+    it('marks the error as user-facing so the CLI can suppress the stack trace', () => {
+      try {
+        assertValidConfig({ review: minimalValidConfig.review });
+        fail('expected ConfigValidationError');
+      } catch (err) {
+        expect((err as ConfigValidationError).userFacing).toBe(true);
+      }
+    });
+  });
+});
+
+describe('collectConfigWarnings', () => {
+  describe('unknown passthrough field detection', () => {
+    it('returns no unknown fields for a clean config', () => {
+      const result = collectConfigWarnings(minimalValidConfig);
+      expect(result.unknownFields).toEqual([]);
+    });
+
+    it('detects unknown fields inside ai.reviewStage', () => {
+      const config = {
+        ...minimalValidConfig,
+        ai: {
+          reviewStage: {
+            ...minimalValidConfig.ai.reviewStage,
+            notARealField: 'oops',
+          },
+        },
+      };
+      const result = collectConfigWarnings(config);
+      expect(result.unknownFields).toContainEqual({
+        path: 'ai.reviewStage',
+        field: 'notARealField',
+      });
+    });
+
+    it('detects unknown fields inside ai.fixStage', () => {
+      const config = {
+        ...minimalValidConfig,
+        ai: {
+          ...minimalValidConfig.ai,
+          fixStage: {
+            provider: 'anthropic',
+            model: 'claude-sonnet-4-5-20250929',
+            inputPerMillion: 3,
+            outputPerMillion: 15,
+            misspelled: true,
+          },
+        },
+      };
+      const result = collectConfigWarnings(config);
+      expect(result.unknownFields).toContainEqual({
+        path: 'ai.fixStage',
+        field: 'misspelled',
+      });
+    });
+
+    it('flags every key not declared in the passthrough shape', () => {
+      const config = {
+        ...minimalValidConfig,
+        ai: {
+          reviewStage: {
+            ...minimalValidConfig.ai.reviewStage,
+            topP: 0.9,
+          },
+        },
+      };
+      const result = collectConfigWarnings(config);
+      // topP is provider-specific but undeclared — flagged as unknown.
+      // This is the intended tradeoff: every unknown key surfaces a warning,
+      // and provider-specific ones are simply expected noise.
+      expect(result.unknownFields.map((f) => f.field)).toEqual(['topP']);
+    });
+
+    it('throws (does not warn) for unknown keys inside strict objects', () => {
+      // Passthrough detection only fires inside `.passthrough()` schemas.
+      // Unknown keys in `.strict()` schemas are caught by `assertValidConfig`,
+      // not by warnings.
+      const config = {
+        ...minimalValidConfig,
+        review: { ...minimalValidConfig.review, notARealReviewField: true },
+      };
+      expect(() => assertValidConfig(config)).toThrow(ConfigValidationError);
     });
   });
 
   describe('deprecation detection', () => {
     it('returns no deprecations for config without deprecated fields', () => {
-      const result = validateConfig(minimalValidConfig);
+      const result = collectConfigWarnings(minimalValidConfig);
       expect(result.deprecations).toEqual([]);
     });
 
@@ -183,7 +335,7 @@ describe('validateConfig', () => {
         verbose: true,
         debug: false,
       };
-      const result = validateConfig(config);
+      const result = collectConfigWarnings(config);
       const paths = result.deprecations.map((d) => d.path);
       expect(paths).toContain('skipPatterns');
       expect(paths).toContain('verbose');
@@ -199,7 +351,7 @@ describe('validateConfig', () => {
           maxFilesBeforeReset: 100,
         },
       };
-      const result = validateConfig(config);
+      const result = collectConfigWarnings(config);
       const paths = result.deprecations.map((d) => d.path);
       expect(paths).toContain('review.sessionBased');
       expect(paths).toContain('review.maxFilesBeforeReset');
@@ -212,7 +364,7 @@ describe('validateConfig', () => {
           throttling: { enabled: true, maxRequestsPerMinute: 50 },
         },
       };
-      const result = validateConfig(config);
+      const result = collectConfigWarnings(config);
       const paths = result.deprecations.map((d) => d.path);
       expect(paths).toContain('performance.throttling.enabled');
       expect(paths).toContain('performance.throttling.maxRequestsPerMinute');
@@ -228,7 +380,7 @@ describe('validateConfig', () => {
           autoApply: false,
         },
       };
-      const result = validateConfig(config);
+      const result = collectConfigWarnings(config);
       const paths = result.deprecations.map((d) => d.path);
       expect(paths).toContain('fix.enabled');
       expect(paths).toContain('fix.severities');
@@ -241,7 +393,7 @@ describe('validateConfig', () => {
         ...minimalValidConfig,
         paths: { sessionsDir: 'custom/sessions' },
       };
-      const result = validateConfig(config);
+      const result = collectConfigWarnings(config);
       const paths = result.deprecations.map((d) => d.path);
       expect(paths).toContain('paths');
     });
@@ -251,7 +403,7 @@ describe('validateConfig', () => {
         ...minimalValidConfig,
         verbose: true,
       };
-      const result = validateConfig(config);
+      const result = collectConfigWarnings(config);
       const verboseWarning = result.deprecations.find((d) => d.path === 'verbose');
       expect(verboseWarning).toBeDefined();
       expect(verboseWarning!.description).toContain('Legacy');
@@ -262,7 +414,7 @@ describe('validateConfig', () => {
         ...minimalValidConfig,
         github: { enabled: true, postComments: true },
       };
-      const result = validateConfig(config);
+      const result = collectConfigWarnings(config);
       const paths = result.deprecations.map((d) => d.path);
       expect(paths).toContain('github.enabled');
     });
@@ -272,7 +424,7 @@ describe('validateConfig', () => {
         ...minimalValidConfig,
         github: { postComments: true },
       };
-      const result = validateConfig(config);
+      const result = collectConfigWarnings(config);
       const paths = result.deprecations.map((d) => d.path);
       expect(paths).not.toContain('github.enabled');
     });
@@ -384,11 +536,12 @@ describe('validateConfig', () => {
         skipPatterns: ['node_modules/**', '.git/**'],
       };
 
-      const result = validateConfig(config);
-      // Should pass but have deprecation warnings
-      expect(result.deprecations.length).toBeGreaterThan(0);
+      expect(() => assertValidConfig(config)).not.toThrow();
+      const warnings = collectConfigWarnings(config);
+      // Should have deprecation warnings
+      expect(warnings.deprecations.length).toBeGreaterThan(0);
       // Spot-check a few expected deprecations
-      const paths = result.deprecations.map((d) => d.path);
+      const paths = warnings.deprecations.map((d) => d.path);
       expect(paths).toContain('skipPatterns');
       expect(paths).toContain('fix.enabled');
       expect(paths).toContain('performance.throttling.enabled');

--- a/tests/unit/config/schema-validator.spec.ts
+++ b/tests/unit/config/schema-validator.spec.ts
@@ -1,0 +1,397 @@
+import { z } from 'zod';
+
+import { validateConfig } from '@/config/schema-validator';
+
+// Minimal valid config for tests
+const minimalValidConfig = {
+  ai: {
+    reviewStage: {
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-5-20250929',
+      inputPerMillion: 3,
+      outputPerMillion: 15,
+    },
+  },
+  review: {
+    pipeline: [
+      {
+        name: 'test-job',
+        enabled: true,
+        passes: [{ name: 'test-pass', enabled: true, prompt: 'test.md' }],
+      },
+    ],
+  },
+};
+
+describe('validateConfig', () => {
+  describe('valid configs', () => {
+    it('accepts minimal valid config', () => {
+      expect(() => validateConfig(minimalValidConfig)).not.toThrow();
+    });
+
+    it('accepts full config with all sections', () => {
+      const fullConfig = {
+        ...minimalValidConfig,
+        performance: { throttling: { apiCallsPerMinute: 60 } },
+        fix: { maxConcurrentFixes: 5 },
+        report: { includedSeverities: ['critical', 'high'] },
+        github: { postComments: true, blockPipeline: false },
+        gitlab: { blockPipeline: false },
+        logger: { level: 'info', enableColors: true },
+      };
+      expect(() => validateConfig(fullConfig)).not.toThrow();
+    });
+
+    it('accepts config with $schema field', () => {
+      const config = { $schema: '../docs/qualops-config.schema.json', ...minimalValidConfig };
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+
+    it('accepts agentic pipeline job without passes', () => {
+      const config = {
+        ai: minimalValidConfig.ai,
+        review: {
+          pipeline: [
+            {
+              name: 'agentic-job',
+              enabled: true,
+              mode: 'agentic',
+              agentic: { maxTurns: 10, contextMode: 'auto' },
+            },
+          ],
+        },
+      };
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+
+    it('accepts AI stage config with extra provider-specific fields', () => {
+      const config = {
+        ai: {
+          reviewStage: {
+            ...minimalValidConfig.ai.reviewStage,
+            topP: 0.9,
+            topK: 40,
+            customField: 'value',
+          },
+        },
+        review: minimalValidConfig.review,
+      };
+      expect(() => validateConfig(config)).not.toThrow();
+    });
+  });
+
+  describe('schema violations (throws)', () => {
+    it('throws when ai section is missing', () => {
+      expect(() => validateConfig({ review: minimalValidConfig.review })).toThrow(z.ZodError);
+    });
+
+    it('throws when review section is missing', () => {
+      expect(() => validateConfig({ ai: minimalValidConfig.ai })).toThrow(z.ZodError);
+    });
+
+    it('throws on unknown top-level field', () => {
+      expect(() => validateConfig({ ...minimalValidConfig, unknownField: true })).toThrow(
+        z.ZodError,
+      );
+    });
+
+    it('throws on type mismatch (string instead of object)', () => {
+      expect(() => validateConfig({ ...minimalValidConfig, ai: 'not-an-object' })).toThrow(
+        z.ZodError,
+      );
+    });
+
+    it('throws when ai.reviewStage is missing', () => {
+      expect(() => validateConfig({ ai: {}, review: minimalValidConfig.review })).toThrow(
+        z.ZodError,
+      );
+    });
+
+    it('throws when pipeline is empty', () => {
+      expect(() => validateConfig({ ai: minimalValidConfig.ai, review: { pipeline: [] } })).toThrow(
+        z.ZodError,
+      );
+    });
+
+    it('throws when file-by-file job has no passes', () => {
+      expect(() =>
+        validateConfig({
+          ai: minimalValidConfig.ai,
+          review: {
+            pipeline: [{ name: 'job', enabled: true }],
+          },
+        }),
+      ).toThrow(z.ZodError);
+    });
+
+    it('throws when file-by-file job has empty passes', () => {
+      expect(() =>
+        validateConfig({
+          ai: minimalValidConfig.ai,
+          review: {
+            pipeline: [{ name: 'job', enabled: true, passes: [] }],
+          },
+        }),
+      ).toThrow(z.ZodError);
+    });
+
+    it('throws on unknown field inside review', () => {
+      expect(() =>
+        validateConfig({
+          ...minimalValidConfig,
+          review: { ...minimalValidConfig.review, foobar: true },
+        }),
+      ).toThrow(z.ZodError);
+    });
+
+    it('throws on invalid AI provider', () => {
+      expect(() =>
+        validateConfig({
+          ai: {
+            reviewStage: {
+              provider: 'invalid-provider',
+              model: 'x',
+              inputPerMillion: 0,
+              outputPerMillion: 0,
+            },
+          },
+          review: minimalValidConfig.review,
+        }),
+      ).toThrow(z.ZodError);
+    });
+
+    it('throws on invalid confidence score (out of range)', () => {
+      expect(() =>
+        validateConfig({
+          ...minimalValidConfig,
+          review: { ...minimalValidConfig.review, minConfidence: 15 },
+        }),
+      ).toThrow(z.ZodError);
+    });
+  });
+
+  describe('deprecation detection', () => {
+    it('returns no deprecations for config without deprecated fields', () => {
+      const result = validateConfig(minimalValidConfig);
+      expect(result.deprecations).toEqual([]);
+    });
+
+    it('detects deprecated top-level fields', () => {
+      const config = {
+        ...minimalValidConfig,
+        skipPatterns: ['node_modules/**'],
+        verbose: true,
+        debug: false,
+      };
+      const result = validateConfig(config);
+      const paths = result.deprecations.map((d) => d.path);
+      expect(paths).toContain('skipPatterns');
+      expect(paths).toContain('verbose');
+      expect(paths).toContain('debug');
+    });
+
+    it('detects deprecated nested fields in review section', () => {
+      const config = {
+        ...minimalValidConfig,
+        review: {
+          ...minimalValidConfig.review,
+          sessionBased: true,
+          maxFilesBeforeReset: 100,
+        },
+      };
+      const result = validateConfig(config);
+      const paths = result.deprecations.map((d) => d.path);
+      expect(paths).toContain('review.sessionBased');
+      expect(paths).toContain('review.maxFilesBeforeReset');
+    });
+
+    it('detects deprecated fields in performance.throttling', () => {
+      const config = {
+        ...minimalValidConfig,
+        performance: {
+          throttling: { enabled: true, maxRequestsPerMinute: 50 },
+        },
+      };
+      const result = validateConfig(config);
+      const paths = result.deprecations.map((d) => d.path);
+      expect(paths).toContain('performance.throttling.enabled');
+      expect(paths).toContain('performance.throttling.maxRequestsPerMinute');
+    });
+
+    it('detects deprecated fields in fix section', () => {
+      const config = {
+        ...minimalValidConfig,
+        fix: {
+          enabled: true,
+          severities: ['critical'],
+          minConfidence: 8,
+          autoApply: false,
+        },
+      };
+      const result = validateConfig(config);
+      const paths = result.deprecations.map((d) => d.path);
+      expect(paths).toContain('fix.enabled');
+      expect(paths).toContain('fix.severities');
+      expect(paths).toContain('fix.minConfidence');
+      expect(paths).toContain('fix.autoApply');
+    });
+
+    it('detects deprecated paths section', () => {
+      const config = {
+        ...minimalValidConfig,
+        paths: { sessionsDir: 'custom/sessions' },
+      };
+      const result = validateConfig(config);
+      const paths = result.deprecations.map((d) => d.path);
+      expect(paths).toContain('paths');
+    });
+
+    it('includes description in deprecation warnings', () => {
+      const config = {
+        ...minimalValidConfig,
+        verbose: true,
+      };
+      const result = validateConfig(config);
+      const verboseWarning = result.deprecations.find((d) => d.path === 'verbose');
+      expect(verboseWarning).toBeDefined();
+      expect(verboseWarning!.description).toContain('Legacy');
+    });
+
+    it('detects deprecated github.enabled', () => {
+      const config = {
+        ...minimalValidConfig,
+        github: { enabled: true, postComments: true },
+      };
+      const result = validateConfig(config);
+      const paths = result.deprecations.map((d) => d.path);
+      expect(paths).toContain('github.enabled');
+    });
+
+    it('ignores deprecated fields that are not present', () => {
+      const config = {
+        ...minimalValidConfig,
+        github: { postComments: true },
+      };
+      const result = validateConfig(config);
+      const paths = result.deprecations.map((d) => d.path);
+      expect(paths).not.toContain('github.enabled');
+    });
+  });
+
+  describe('real-world config', () => {
+    it('validates a full production-like config', () => {
+      const config = {
+        $schema: '../docs/qualops-config.schema.json',
+        ai: {
+          reviewStage: {
+            provider: 'anthropic',
+            model: 'claude-sonnet-4-5-20250929',
+            inputPerMillion: 3,
+            outputPerMillion: 15,
+            temperature: 0,
+          },
+          fixStage: {
+            provider: 'anthropic',
+            model: 'claude-sonnet-4-5-20250929',
+            inputPerMillion: 3,
+            outputPerMillion: 15,
+            temperature: 0,
+          },
+          judgeStage: {
+            provider: 'anthropic',
+            model: 'claude-sonnet-4-5-20250929',
+            inputPerMillion: 3,
+            outputPerMillion: 15,
+            temperature: 0,
+          },
+        },
+        performance: {
+          maxFileSizeKB: 500,
+          maxFilesPerBatch: 15,
+          maxTokensPerFile: 8000,
+          timeoutSeconds: 300,
+          throttling: {
+            enabled: true,
+            maxRequestsPerMinute: 50,
+          },
+        },
+        review: {
+          minConfidence: 7,
+          maxConcurrentFiles: 3,
+          validation: {
+            enabled: true,
+            minConfidence: 7,
+            prompt: 'validation.md',
+          },
+          deduplication: {
+            enabled: true,
+            prompt: 'deduplication.md',
+          },
+          pipeline: [
+            {
+              name: 'fileByFileJob',
+              enabled: true,
+              passes: [
+                {
+                  name: 'Error Handling',
+                  enabled: true,
+                  prompt: 'review.md',
+                  filters: {
+                    detectionTriggers: ['try', 'catch'],
+                    filePatterns: ['src/**/*.ts'],
+                    excludePatterns: ['**/*.spec.ts'],
+                  },
+                },
+              ],
+            },
+            {
+              name: 'agenticJob',
+              enabled: true,
+              mode: 'agentic',
+              agentic: {
+                maxTurns: 15,
+                contextMode: 'auto',
+                enabledSubagents: ['security-analyzer', 'dependency-tracer'],
+              },
+            },
+          ],
+        },
+        fix: {
+          enabled: true,
+          severities: ['critical', 'high'],
+          minConfidence: 8,
+          maxConcurrentFixes: 5,
+          autoApply: false,
+        },
+        report: {
+          outputFormat: 'html',
+          includedSeverities: ['critical', 'high', 'medium', 'low'],
+          enableRootCauseExtraction: false,
+        },
+        github: {
+          enabled: false,
+          postComments: false,
+          skipOnDraft: false,
+          blockPipeline: false,
+          maxInlineComments: 50,
+        },
+        gitlab: {
+          enabled: false,
+          postComments: false,
+          skipOnDraft: false,
+          blockPipeline: false,
+        },
+        skipPatterns: ['node_modules/**', '.git/**'],
+      };
+
+      const result = validateConfig(config);
+      // Should pass but have deprecation warnings
+      expect(result.deprecations.length).toBeGreaterThan(0);
+      // Spot-check a few expected deprecations
+      const paths = result.deprecations.map((d) => d.path);
+      expect(paths).toContain('skipPatterns');
+      expect(paths).toContain('fix.enabled');
+      expect(paths).toContain('performance.throttling.enabled');
+    });
+  });
+});

--- a/tests/unit/config/schema-validator.spec.ts
+++ b/tests/unit/config/schema-validator.spec.ts
@@ -1,3 +1,4 @@
+import { promptConfigSchema } from '@/config/config-schema';
 import {
   CONFIG_PARSE_ERROR_CODE,
   CONFIG_VALIDATION_ERROR_CODE,
@@ -274,6 +275,127 @@ describe('ConfigParseError', () => {
   it('has a distinct error name', () => {
     const err = new ConfigParseError('/tmp/.qualopsrc.json', new Error('boom'));
     expect(err.name).toBe('ConfigParseError');
+  });
+});
+
+describe('path traversal validation', () => {
+  describe('promptConfigSchema', () => {
+    it('accepts a normal relative path', () => {
+      const result = promptConfigSchema.safeParse({ file: 'review.md' });
+      expect(result.success).toBe(true);
+    });
+
+    it('accepts a nested relative path', () => {
+      const result = promptConfigSchema.safeParse({ file: 'custom/review.md' });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects absolute path', () => {
+      const result = promptConfigSchema.safeParse({ file: '/etc/passwd' });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects path traversal with ../', () => {
+      const result = promptConfigSchema.safeParse({ file: '../../../etc/passwd' });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects path traversal embedded in path', () => {
+      const result = promptConfigSchema.safeParse({ file: 'foo/../../etc/passwd' });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts path with .. in filename (not traversal)', () => {
+      const result = promptConfigSchema.safeParse({ file: 'my..file.md' });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('agentsDir in full config', () => {
+    it('accepts normal relative agents dir', () => {
+      const config = {
+        ...minimalValidConfig,
+        review: {
+          pipeline: [
+            {
+              name: 'agentic-job',
+              enabled: true,
+              mode: 'agentic',
+              agentic: { agentsDir: '.qualops/agents' },
+            },
+          ],
+        },
+      };
+      expect(() => assertValidConfig(config)).not.toThrow();
+    });
+
+    it('rejects absolute agentsDir', () => {
+      const config = {
+        ...minimalValidConfig,
+        review: {
+          pipeline: [
+            {
+              name: 'agentic-job',
+              enabled: true,
+              mode: 'agentic',
+              agentic: { agentsDir: '/tmp/evil' },
+            },
+          ],
+        },
+      };
+      expect(() => assertValidConfig(config)).toThrow();
+    });
+
+    it('rejects traversal in agentsDir', () => {
+      const config = {
+        ...minimalValidConfig,
+        review: {
+          pipeline: [
+            {
+              name: 'agentic-job',
+              enabled: true,
+              mode: 'agentic',
+              agentic: { agentsDir: '../../malicious' },
+            },
+          ],
+        },
+      };
+      expect(() => assertValidConfig(config)).toThrow();
+    });
+  });
+
+  describe('prompt ref as bare string in pipeline passes', () => {
+    it('rejects traversal in bare prompt string', () => {
+      const config = {
+        ...minimalValidConfig,
+        review: {
+          pipeline: [
+            {
+              name: 'test-job',
+              enabled: true,
+              passes: [{ name: 'test-pass', enabled: true, prompt: '../../../etc/passwd' }],
+            },
+          ],
+        },
+      };
+      expect(() => assertValidConfig(config)).toThrow();
+    });
+
+    it('accepts normal bare prompt string', () => {
+      const config = {
+        ...minimalValidConfig,
+        review: {
+          pipeline: [
+            {
+              name: 'test-job',
+              enabled: true,
+              passes: [{ name: 'test-pass', enabled: true, prompt: 'review.md' }],
+            },
+          ],
+        },
+      };
+      expect(() => assertValidConfig(config)).not.toThrow();
+    });
   });
 });
 

--- a/tests/unit/scripts/config-schema/post-process.spec.ts
+++ b/tests/unit/scripts/config-schema/post-process.spec.ts
@@ -1,0 +1,801 @@
+import type { RefContext } from '../../../../scripts/config-schema/post-process';
+import {
+  buildInlineSet,
+  buildRenameMap,
+  deduplicateRefDescriptions,
+  extractNamedInlineDefs,
+  normalizeZodOutput,
+  orderProperties,
+  postProcessDefs,
+  resolveRefChain,
+  rewriteRefs,
+} from '../../../../scripts/config-schema/post-process';
+
+describe('buildRenameMap', () => {
+  it('maps defs with defName to their declared name', () => {
+    const defs = {
+      __schema0: { defName: 'severity', type: 'string', enum: ['critical', 'high'] },
+      __schema1: { type: 'boolean' },
+    };
+    expect(buildRenameMap(defs)).toEqual({
+      __schema0: 'severity',
+      __schema1: '__schema1',
+    });
+  });
+
+  it('returns identity mapping when no defName is present', () => {
+    const defs = { x: { type: 'string' } };
+    expect(buildRenameMap(defs)).toEqual({ x: 'x' });
+  });
+
+  it('returns empty map for empty defs', () => {
+    expect(buildRenameMap({})).toEqual({});
+  });
+});
+
+describe('buildInlineSet', () => {
+  it('marks unnamed $ref defs as inlinable', () => {
+    const defs = {
+      __schema0: { $ref: '#/$defs/__schema1' },
+      __schema1: { defName: 'foo', type: 'object', properties: {} },
+    };
+    const result = buildInlineSet(defs);
+    expect(result.has('__schema0')).toBe(true);
+    expect(result.has('__schema1')).toBe(false);
+  });
+
+  it('marks unnamed boolean defs as inlinable', () => {
+    const defs = { __schema0: { type: 'boolean' } };
+    expect(buildInlineSet(defs).has('__schema0')).toBe(true);
+  });
+
+  it('marks unnamed number defs as inlinable', () => {
+    const defs = { __schema0: { type: 'number', minimum: 0 } };
+    expect(buildInlineSet(defs).has('__schema0')).toBe(true);
+  });
+
+  it('marks unnamed string defs as inlinable', () => {
+    const defs = { __schema0: { type: 'string' } };
+    expect(buildInlineSet(defs).has('__schema0')).toBe(true);
+  });
+
+  it('marks unnamed integer (non-enum) defs as inlinable', () => {
+    const defs = { __schema0: { type: 'integer', minimum: 1, maximum: 10 } };
+    expect(buildInlineSet(defs).has('__schema0')).toBe(true);
+  });
+
+  it('does not mark integer enums as inlinable', () => {
+    const defs = { __schema0: { type: 'integer', enum: [1, 2, 3] } };
+    expect(buildInlineSet(defs).has('__schema0')).toBe(false);
+  });
+
+  it('marks empty objects (no properties) as inlinable', () => {
+    const defs = { __schema0: { type: 'object' } };
+    expect(buildInlineSet(defs).has('__schema0')).toBe(true);
+  });
+
+  it('does not mark objects with properties as inlinable', () => {
+    const defs = { __schema0: { type: 'object', properties: { a: { type: 'string' } } } };
+    expect(buildInlineSet(defs).has('__schema0')).toBe(false);
+  });
+
+  it('marks array defs as inlinable', () => {
+    const defs = { __schema0: { type: 'array', items: { type: 'string' } } };
+    expect(buildInlineSet(defs).has('__schema0')).toBe(true);
+  });
+
+  it('marks completely empty defs as inlinable', () => {
+    const defs = { __schema0: {} };
+    expect(buildInlineSet(defs).has('__schema0')).toBe(true);
+  });
+
+  it('skips defs that have a defName (renamed defs)', () => {
+    const defs = { __schema0: { defName: 'severity', type: 'string' } };
+    expect(buildInlineSet(defs).has('__schema0')).toBe(false);
+  });
+
+  it('inlines primitives with descriptions', () => {
+    const defs = {
+      __schema0: { type: 'boolean', description: 'Enable feature.' },
+    };
+    expect(buildInlineSet(defs).has('__schema0')).toBe(true);
+  });
+
+  it('skips extracted defs where key equals defName', () => {
+    const defs = {
+      severity: { defName: 'severity', type: 'string', enum: ['critical', 'high'] },
+    };
+    expect(buildInlineSet(defs).has('severity')).toBe(false);
+  });
+});
+
+describe('extractNamedInlineDefs', () => {
+  it('extracts an inline object with defName into $defs', () => {
+    const defs: Record<string, Record<string, unknown>> = {};
+    const schema = {
+      properties: {
+        review: {
+          defName: 'reviewConfig',
+          description: 'Review config',
+          type: 'object',
+          additionalProperties: false,
+          properties: { pipeline: {} },
+        },
+      },
+    };
+
+    extractNamedInlineDefs(schema, defs);
+
+    expect(schema.properties.review).toEqual({
+      $ref: '#/$defs/reviewConfig',
+      description: 'Review config',
+    });
+    expect(defs.reviewConfig).toEqual({
+      defName: 'reviewConfig',
+      description: 'Review config',
+      type: 'object',
+      additionalProperties: false,
+      properties: { pipeline: {} },
+    });
+  });
+
+  it('keeps description and deprecated as siblings on the $ref', () => {
+    const defs: Record<string, Record<string, unknown>> = {};
+    const schema = {
+      properties: {
+        paths: {
+          defName: 'pathsConfig',
+          description: 'Legacy paths',
+          deprecated: true,
+          type: 'object',
+          properties: {},
+        },
+      },
+    };
+
+    extractNamedInlineDefs(schema, defs);
+
+    expect(schema.properties.paths).toEqual({
+      $ref: '#/$defs/pathsConfig',
+      description: 'Legacy paths',
+      deprecated: true,
+    });
+  });
+
+  it('does not extract objects without defName', () => {
+    const defs: Record<string, Record<string, unknown>> = {};
+    const schema = {
+      properties: {
+        simple: { type: 'string' },
+      },
+    };
+
+    extractNamedInlineDefs(schema, defs);
+
+    expect(schema.properties.simple).toEqual({ type: 'string' });
+    expect(Object.keys(defs)).toHaveLength(0);
+  });
+
+  it('does not extract objects that already have a $ref', () => {
+    const defs: Record<string, Record<string, unknown>> = {};
+    const schema = {
+      properties: {
+        field: { defName: 'foo', $ref: '#/$defs/bar' },
+      },
+    };
+
+    extractNamedInlineDefs(schema, defs);
+
+    expect(schema.properties.field).toEqual({ defName: 'foo', $ref: '#/$defs/bar' });
+    expect(Object.keys(defs)).toHaveLength(0);
+  });
+
+  it('does not overwrite existing $defs with the same name', () => {
+    const defs: Record<string, Record<string, unknown>> = {
+      existing: { type: 'number' },
+    };
+    const schema = {
+      properties: {
+        field: { defName: 'existing', type: 'string' },
+      },
+    };
+
+    extractNamedInlineDefs(schema, defs);
+
+    expect(defs.existing).toEqual({ type: 'number' });
+    expect(schema.properties.field).toEqual({ defName: 'existing', type: 'string' });
+  });
+
+  it('recurses into nested structures', () => {
+    const defs: Record<string, Record<string, unknown>> = {};
+    const schema = {
+      properties: {
+        outer: {
+          properties: {
+            inner: {
+              defName: 'innerConfig',
+              description: 'Nested',
+              type: 'object',
+              properties: {},
+            },
+          },
+        },
+      },
+    };
+
+    extractNamedInlineDefs(schema, defs);
+
+    expect(schema.properties.outer.properties.inner).toEqual({
+      $ref: '#/$defs/innerConfig',
+      description: 'Nested',
+    });
+    expect(defs.innerConfig).toBeDefined();
+  });
+
+  it('handles arrays', () => {
+    const defs: Record<string, Record<string, unknown>> = {};
+    const schema = {
+      items: [
+        {
+          defName: 'itemSchema',
+          description: 'An item',
+          type: 'object',
+          properties: {},
+        },
+      ],
+    };
+
+    extractNamedInlineDefs(schema, defs);
+
+    expect(schema.items[0]).toEqual({
+      $ref: '#/$defs/itemSchema',
+      description: 'An item',
+    });
+    expect(defs.itemSchema).toBeDefined();
+  });
+});
+
+describe('resolveRefChain', () => {
+  function makeCtx(
+    defs: Record<string, Record<string, unknown>>,
+    overrides?: Partial<RefContext>,
+  ): RefContext {
+    return {
+      defs,
+      renameMap: overrides?.renameMap ?? buildRenameMap(defs),
+      inlineSet: overrides?.inlineSet ?? buildInlineSet(defs),
+    };
+  }
+
+  it('resolves a single def without $ref', () => {
+    const defs = { a: { type: 'boolean' } };
+    expect(resolveRefChain(defs, 'a', makeCtx(defs))).toEqual({ type: 'boolean' });
+  });
+
+  it('follows a single $ref hop', () => {
+    const defs = {
+      a: { description: 'deprecated field', $ref: '#/$defs/b' },
+      b: { type: 'boolean' },
+    };
+    const ctx = makeCtx(defs, { inlineSet: new Set(['a', 'b']) });
+    expect(resolveRefChain(defs, 'a', ctx)).toEqual({
+      description: 'deprecated field',
+      type: 'boolean',
+    });
+  });
+
+  it('follows a multi-hop $ref chain', () => {
+    const defs = {
+      a: { deprecated: true, $ref: '#/$defs/b' },
+      b: { description: 'middle', $ref: '#/$defs/c' },
+      c: { type: 'string' },
+    };
+    const ctx = makeCtx(defs, { inlineSet: new Set(['a', 'b', 'c']) });
+    expect(resolveRefChain(defs, 'a', ctx)).toEqual({
+      deprecated: true,
+      description: 'middle',
+      type: 'string',
+    });
+  });
+
+  it('first property wins on key conflicts', () => {
+    const defs = {
+      a: { description: 'first', $ref: '#/$defs/b' },
+      b: { description: 'second', type: 'string' },
+    };
+    const ctx = makeCtx(defs, { inlineSet: new Set(['a', 'b']) });
+    expect(resolveRefChain(defs, 'a', ctx)).toEqual({
+      description: 'first',
+      type: 'string',
+    });
+  });
+
+  it('returns null for empty def', () => {
+    const defs = { a: {} };
+    expect(resolveRefChain(defs, 'a', makeCtx(defs))).toBeNull();
+  });
+
+  it('stops at non-inlinable $ref and preserves it', () => {
+    const defs = {
+      a: { deprecated: true, $ref: '#/$defs/missing' },
+    };
+    const ctx = makeCtx(defs, { inlineSet: new Set(['a']) });
+    expect(resolveRefChain(defs, 'a', ctx)).toEqual({
+      deprecated: true,
+      $ref: '#/$defs/missing',
+    });
+  });
+
+  it('stops at a named def and preserves the $ref', () => {
+    const defs = {
+      wrapper: { description: 'per-field', $ref: '#/$defs/namedDef' },
+      namedDef: { type: 'object', properties: { a: {} } },
+    };
+    const ctx = makeCtx(defs, {
+      inlineSet: new Set(['wrapper']),
+      renameMap: { wrapper: 'wrapper', namedDef: 'namedDef' },
+    });
+
+    expect(resolveRefChain(defs, 'wrapper', ctx)).toEqual({
+      description: 'per-field',
+      $ref: '#/$defs/namedDef',
+    });
+  });
+
+  it('renames the $ref when the named def has a different final name', () => {
+    const defs = {
+      wrapper: { description: 'stage config', $ref: '#/$defs/__schema5' },
+      __schema5: { type: 'object', defName: 'aiStageConfig', properties: {} },
+    };
+    const ctx = makeCtx(defs, {
+      inlineSet: new Set(['wrapper']),
+      renameMap: { wrapper: 'wrapper', __schema5: 'aiStageConfig' },
+    });
+
+    expect(resolveRefChain(defs, 'wrapper', ctx)).toEqual({
+      description: 'stage config',
+      $ref: '#/$defs/aiStageConfig',
+    });
+  });
+
+  it('fully resolves when all defs in chain are inlinable', () => {
+    const defs = {
+      a: { deprecated: true, $ref: '#/$defs/b' },
+      b: { type: 'boolean' },
+    };
+    const ctx = makeCtx(defs, {
+      inlineSet: new Set(['a', 'b']),
+      renameMap: { a: 'a', b: 'b' },
+    });
+
+    expect(resolveRefChain(defs, 'a', ctx)).toEqual({
+      deprecated: true,
+      type: 'boolean',
+    });
+  });
+});
+
+describe('rewriteRefs', () => {
+  function makeCtx(overrides: {
+    defs: Record<string, Record<string, unknown>>;
+    renameMap?: Record<string, string>;
+    inlineSet?: Set<string>;
+  }): RefContext {
+    return {
+      defs: overrides.defs,
+      renameMap: overrides.renameMap ?? buildRenameMap(overrides.defs),
+      inlineSet: overrides.inlineSet ?? buildInlineSet(overrides.defs),
+    };
+  }
+
+  it('inlines a $ref to an inlinable def', () => {
+    const defs = { __s0: { type: 'boolean' } };
+    const ctx = makeCtx({ defs, inlineSet: new Set(['__s0']) });
+    const obj = { field: { $ref: '#/$defs/__s0' } };
+
+    rewriteRefs(obj, ctx);
+
+    expect(obj.field).toEqual({ type: 'boolean' });
+  });
+
+  it('renames $ref to a named def', () => {
+    const defs = { __s0: { defName: 'severity', type: 'string', enum: ['high'] } };
+    const ctx = makeCtx({ defs, renameMap: { __s0: 'severity' }, inlineSet: new Set() });
+    const obj = { field: { $ref: '#/$defs/__s0' } };
+
+    rewriteRefs(obj, ctx);
+
+    expect((obj.field as any).$ref).toBe('#/$defs/severity');
+  });
+
+  it('preserves existing properties when inlining', () => {
+    const defs = { __s0: { type: 'boolean' } };
+    const ctx = makeCtx({ defs, inlineSet: new Set(['__s0']) });
+    const obj = { field: { description: 'keep me', $ref: '#/$defs/__s0' } };
+
+    rewriteRefs(obj, ctx);
+
+    expect(obj.field).toEqual({ description: 'keep me', type: 'boolean' });
+  });
+
+  it('handles empty def inlining (passthrough additionalProperties)', () => {
+    const defs = { __s0: {} };
+    const ctx = makeCtx({ defs, inlineSet: new Set(['__s0']) });
+    const obj = { additionalProperties: { $ref: '#/$defs/__s0' } };
+
+    rewriteRefs(obj, ctx);
+
+    expect(obj.additionalProperties).toEqual({});
+  });
+
+  it('recursively processes inlined content with nested $refs', () => {
+    const defs = {
+      __s0: { description: 'wrapper', $ref: '#/$defs/__s1' },
+      __s1: { type: 'object', properties: { a: { $ref: '#/$defs/__s2' } } },
+      __s2: { type: 'string' },
+    };
+    const ctx = makeCtx({
+      defs,
+      renameMap: { __s0: '__s0', __s1: '__s1', __s2: '__s2' },
+      inlineSet: new Set(['__s0', '__s1', '__s2']),
+    });
+    const obj = { field: { $ref: '#/$defs/__s0' } };
+
+    rewriteRefs(obj, ctx);
+
+    expect(obj.field).toEqual({
+      description: 'wrapper',
+      type: 'object',
+      properties: { a: { type: 'string' } },
+    });
+  });
+
+  it('handles arrays', () => {
+    const defs = { __s0: { type: 'boolean' } };
+    const ctx = makeCtx({ defs, inlineSet: new Set(['__s0']) });
+    const obj = { anyOf: [{ $ref: '#/$defs/__s0' }, { type: 'null' }] };
+
+    rewriteRefs(obj, ctx);
+
+    expect(obj.anyOf).toEqual([{ type: 'boolean' }, { type: 'null' }]);
+  });
+
+  it('preserves $ref to named def when inlining a wrapper', () => {
+    const defs = {
+      __s0: { description: 'stage config', $ref: '#/$defs/__s1' },
+      __s1: { defName: 'aiStageConfig', type: 'object', properties: { model: {} } },
+    };
+    const ctx = makeCtx({
+      defs,
+      renameMap: { __s0: '__s0', __s1: 'aiStageConfig' },
+      inlineSet: new Set(['__s0']),
+    });
+    const obj = { reviewStage: { $ref: '#/$defs/__s0' } };
+
+    rewriteRefs(obj, ctx);
+
+    expect(obj.reviewStage).toEqual({
+      description: 'stage config',
+      $ref: '#/$defs/aiStageConfig',
+    });
+  });
+
+  it('does not flatten named defs shared across multiple fields', () => {
+    const defs = {
+      __w1: { description: 'review', $ref: '#/$defs/__named' },
+      __w2: { description: 'fix', $ref: '#/$defs/__named' },
+      __named: { defName: 'shared', type: 'object', properties: {} },
+    };
+    const ctx = makeCtx({
+      defs,
+      renameMap: { __w1: '__w1', __w2: '__w2', __named: 'shared' },
+      inlineSet: new Set(['__w1', '__w2']),
+    });
+    const obj = {
+      a: { $ref: '#/$defs/__w1' },
+      b: { $ref: '#/$defs/__w2' },
+    };
+
+    rewriteRefs(obj, ctx);
+
+    expect(obj.a).toEqual({ description: 'review', $ref: '#/$defs/shared' });
+    expect(obj.b).toEqual({ description: 'fix', $ref: '#/$defs/shared' });
+  });
+});
+
+describe('normalizeZodOutput', () => {
+  it('removes defName from a flat object', () => {
+    const obj = { defName: 'foo', type: 'string' };
+    normalizeZodOutput(obj);
+    expect(obj).toEqual({ type: 'string' });
+  });
+
+  it('removes defName recursively', () => {
+    const obj = {
+      properties: {
+        a: { defName: 'bar', type: 'number' },
+      },
+      $defs: {
+        x: { defName: 'baz', type: 'boolean' },
+      },
+    };
+    normalizeZodOutput(obj);
+    expect(obj.properties.a).toEqual({ type: 'number' });
+    expect(obj.$defs.x).toEqual({ type: 'boolean' });
+  });
+
+  it('handles arrays', () => {
+    const obj = { items: [{ defName: 'a', type: 'string' }] };
+    normalizeZodOutput(obj);
+    expect(obj.items[0]).toEqual({ type: 'string' });
+  });
+
+  it('handles null and primitives without error', () => {
+    expect(() => normalizeZodOutput(null)).not.toThrow();
+    expect(() => normalizeZodOutput('string')).not.toThrow();
+    expect(() => normalizeZodOutput(42)).not.toThrow();
+  });
+
+  it('converts const to single-element enum', () => {
+    const obj = { type: 'string', const: 'agentic' } as Record<string, unknown>;
+    normalizeZodOutput(obj);
+    expect(obj.enum).toEqual(['agentic']);
+    expect(obj.const).toBeUndefined();
+  });
+
+  it('normalizes empty additionalProperties to true', () => {
+    const obj = { type: 'object', additionalProperties: {} } as Record<string, unknown>;
+    normalizeZodOutput(obj);
+    expect(obj.additionalProperties).toBe(true);
+  });
+
+  it('strips MAX_SAFE_INTEGER ceiling on integers', () => {
+    const obj = { type: 'integer', minimum: 1, maximum: Number.MAX_SAFE_INTEGER };
+    normalizeZodOutput(obj);
+    expect(obj.maximum).toBeUndefined();
+    expect(obj.minimum).toBe(1);
+  });
+
+  it('promotes anyOf to oneOf', () => {
+    const obj = { anyOf: [{ $ref: '#/$defs/a' }, { $ref: '#/$defs/b' }] } as Record<
+      string,
+      unknown
+    >;
+    normalizeZodOutput(obj);
+    expect(obj.oneOf).toEqual([{ $ref: '#/$defs/a' }, { $ref: '#/$defs/b' }]);
+    expect(obj.anyOf).toBeUndefined();
+  });
+
+  it('strips trivial propertyNames { type: "string" }', () => {
+    const obj = { type: 'object', propertyNames: { type: 'string' } } as Record<string, unknown>;
+    normalizeZodOutput(obj);
+    expect(obj.propertyNames).toBeUndefined();
+  });
+
+  it('keeps non-trivial propertyNames', () => {
+    const obj = {
+      type: 'object',
+      propertyNames: { type: 'string', pattern: '^[a-z]+$' },
+    } as Record<string, unknown>;
+    normalizeZodOutput(obj);
+    expect(obj.propertyNames).toEqual({ type: 'string', pattern: '^[a-z]+$' });
+  });
+});
+
+describe('deduplicateRefDescriptions', () => {
+  it('removes description that matches the referenced def', () => {
+    const defs = { severity: { description: 'Severity levels', type: 'string' } };
+    const schema = {
+      properties: { level: { description: 'Severity levels', $ref: '#/$defs/severity' } },
+    };
+    deduplicateRefDescriptions(schema, defs);
+    expect((schema.properties.level as any).description).toBeUndefined();
+    expect((schema.properties.level as any).$ref).toBe('#/$defs/severity');
+  });
+
+  it('keeps description that differs from the def', () => {
+    const defs = { severity: { description: 'Severity levels', type: 'string' } };
+    const schema = {
+      properties: { level: { description: 'Custom description', $ref: '#/$defs/severity' } },
+    };
+    deduplicateRefDescriptions(schema, defs);
+    expect((schema.properties.level as any).description).toBe('Custom description');
+  });
+
+  it('handles missing def gracefully', () => {
+    const defs = {};
+    const schema = {
+      properties: { level: { description: 'Some desc', $ref: '#/$defs/missing' } },
+    };
+    deduplicateRefDescriptions(schema, defs);
+    expect((schema.properties.level as any).description).toBe('Some desc');
+  });
+});
+
+describe('orderProperties', () => {
+  it('places $schema, $id, title, description before type and properties', () => {
+    const input = {
+      properties: { a: { type: 'string' } },
+      type: 'object',
+      description: 'A schema',
+      title: 'Test',
+      $id: 'test',
+      $schema: 'draft-2020-12',
+    };
+    const result = orderProperties(input) as Record<string, unknown>;
+    const keys = Object.keys(result);
+    expect(keys.indexOf('$schema')).toBeLessThan(keys.indexOf('type'));
+    expect(keys.indexOf('$id')).toBeLessThan(keys.indexOf('type'));
+    expect(keys.indexOf('title')).toBeLessThan(keys.indexOf('type'));
+    expect(keys.indexOf('description')).toBeLessThan(keys.indexOf('type'));
+    expect(keys.indexOf('type')).toBeLessThan(keys.indexOf('properties'));
+  });
+
+  it('places additionalProperties before properties', () => {
+    const input = { properties: {}, additionalProperties: false, type: 'object' };
+    const result = orderProperties(input) as Record<string, unknown>;
+    const keys = Object.keys(result);
+    expect(keys.indexOf('additionalProperties')).toBeLessThan(keys.indexOf('properties'));
+  });
+
+  it('places $defs last', () => {
+    const input = { $defs: {}, type: 'object', properties: {} };
+    const result = orderProperties(input) as Record<string, unknown>;
+    const keys = Object.keys(result);
+    expect(keys.indexOf('$defs')).toBe(keys.length - 1);
+  });
+
+  it('preserves unknown keys after known keys', () => {
+    const input = { customKey: 'value', type: 'string', description: 'test' };
+    const result = orderProperties(input) as Record<string, unknown>;
+    const keys = Object.keys(result);
+    expect(keys.indexOf('description')).toBeLessThan(keys.indexOf('customKey'));
+    expect(keys.indexOf('type')).toBeLessThan(keys.indexOf('customKey'));
+  });
+
+  it('recurses into nested objects', () => {
+    const input = {
+      properties: {
+        a: { properties: { b: {} }, type: 'object', description: 'nested' },
+      },
+    };
+    const result = orderProperties(input) as any;
+    const nestedKeys = Object.keys(result.properties.a);
+    expect(nestedKeys.indexOf('description')).toBeLessThan(nestedKeys.indexOf('type'));
+    expect(nestedKeys.indexOf('type')).toBeLessThan(nestedKeys.indexOf('properties'));
+  });
+
+  it('recurses into arrays', () => {
+    const input = { anyOf: [{ type: 'string', description: 'first' }] };
+    const result = orderProperties(input) as any;
+    const itemKeys = Object.keys(result.anyOf[0]);
+    expect(itemKeys.indexOf('description')).toBeLessThan(itemKeys.indexOf('type'));
+  });
+
+  it('passes through null and primitives', () => {
+    expect(orderProperties(null)).toBeNull();
+    expect(orderProperties('string')).toBe('string');
+    expect(orderProperties(42)).toBe(42);
+    expect(orderProperties(true)).toBe(true);
+  });
+});
+
+describe('postProcessDefs (integration)', () => {
+  it('renames, inlines, and strips in one pass', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        severity: { $ref: '#/$defs/__schema0' },
+        enabled: { $ref: '#/$defs/__schema1' },
+        name: { description: 'A name', $ref: '#/$defs/__schema2' },
+      },
+      $defs: {
+        __schema0: {
+          defName: 'severity',
+          type: 'string',
+          enum: ['critical', 'high'],
+        },
+        __schema1: { type: 'boolean' },
+        __schema2: { type: 'string', minLength: 1 },
+      },
+    };
+
+    postProcessDefs(schema);
+
+    // __schema0 renamed to severity
+    expect(schema.$defs).toHaveProperty('severity');
+    expect(schema.$defs).not.toHaveProperty('__schema0');
+    expect((schema.$defs as any).severity.defName).toBeUndefined();
+
+    // $ref updated to use new name
+    expect((schema.properties.severity as any).$ref).toBe('#/$defs/severity');
+
+    // __schema1 (boolean) inlined
+    expect(schema.$defs).not.toHaveProperty('__schema1');
+    expect(schema.properties.enabled).toEqual({ type: 'boolean' });
+
+    // __schema2 (string) inlined, preserving existing description
+    expect(schema.$defs).not.toHaveProperty('__schema2');
+    expect(schema.properties.name).toEqual({
+      description: 'A name',
+      type: 'string',
+      minLength: 1,
+    });
+  });
+
+  it('handles schema without $defs', () => {
+    const schema = { type: 'object', properties: {} };
+    expect(() => postProcessDefs(schema)).not.toThrow();
+  });
+
+  it('handles deprecated $ref chains', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        legacy: { $ref: '#/$defs/__schema0' },
+      },
+      $defs: {
+        __schema0: { deprecated: true, description: 'Legacy field', $ref: '#/$defs/__schema1' },
+        __schema1: { type: 'boolean' },
+      },
+    };
+
+    postProcessDefs(schema);
+
+    expect(schema.properties.legacy).toEqual({
+      deprecated: true,
+      description: 'Legacy field',
+      type: 'boolean',
+    });
+    expect(schema.$defs).not.toHaveProperty('__schema0');
+    expect(schema.$defs).not.toHaveProperty('__schema1');
+  });
+
+  it('preserves $ref to named defs used in multiple places', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        reviewStage: { $ref: '#/$defs/__w1' },
+        fixStage: { $ref: '#/$defs/__w2' },
+      },
+      $defs: {
+        __w1: { description: 'Review stage', $ref: '#/$defs/__named' },
+        __w2: { description: 'Fix stage', $ref: '#/$defs/__named' },
+        __named: {
+          defName: 'aiStageConfig',
+          type: 'object',
+          properties: { model: { type: 'string' } },
+        },
+      },
+    };
+
+    postProcessDefs(schema);
+
+    expect(schema.properties.reviewStage).toEqual({
+      description: 'Review stage',
+      $ref: '#/$defs/aiStageConfig',
+    });
+    expect(schema.properties.fixStage).toEqual({
+      description: 'Fix stage',
+      $ref: '#/$defs/aiStageConfig',
+    });
+    expect(schema.$defs).toHaveProperty('aiStageConfig');
+    expect(schema.$defs).not.toHaveProperty('__named');
+    expect(schema.$defs).not.toHaveProperty('__w1');
+    expect(schema.$defs).not.toHaveProperty('__w2');
+  });
+
+  it('inlines empty defs from passthrough()', () => {
+    const schema = {
+      type: 'object',
+      properties: {},
+      $defs: {
+        __s0: {},
+      },
+    };
+
+    postProcessDefs(schema);
+
+    expect(schema.$defs).not.toHaveProperty('__s0');
+  });
+});

--- a/tests/unit/stages/review/agentic/loaders/agent-loader.spec.ts
+++ b/tests/unit/stages/review/agentic/loaders/agent-loader.spec.ts
@@ -1,0 +1,99 @@
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import { AgentLoader } from '@/stages/review/agentic/loaders/agent-loader';
+
+const tmpDir = join(__dirname, '__tmp_agent_loader__');
+const agentsDir = join(tmpDir, '.qualops', 'agents');
+
+beforeAll(() => {
+  mkdirSync(agentsDir, { recursive: true });
+  writeFileSync(
+    join(agentsDir, 'test-agent.md'),
+    '---\ndescription: A test agent\ntools: [Read, Grep]\nmodel: sonnet\n---\nYou are a test agent.',
+  );
+});
+
+afterAll(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('AgentLoader', () => {
+  describe('path traversal protection', () => {
+    it('rejects agentsDir with ../ traversal', () => {
+      const loader = new AgentLoader(tmpDir);
+      const result = loader.loadCustomAgents({ agentsDir: '../../etc' });
+      expect(result).toEqual({});
+    });
+
+    it('rejects agentsDir with embedded traversal', () => {
+      const loader = new AgentLoader(tmpDir);
+      const result = loader.loadCustomAgents({ agentsDir: 'foo/../../../etc' });
+      expect(result).toEqual({});
+    });
+
+    it('rejects absolute agentsDir outside cwd', () => {
+      const loader = new AgentLoader(tmpDir);
+      const result = loader.loadCustomAgents({ agentsDir: '/tmp/evil' });
+      expect(result).toEqual({});
+    });
+
+    it('allows a relative agentsDir within cwd', () => {
+      const loader = new AgentLoader(tmpDir);
+      const result = loader.loadCustomAgents({ agentsDir: '.qualops/agents' });
+      expect(Object.keys(result)).toContain('test-agent');
+    });
+  });
+
+  describe('loading agents from markdown', () => {
+    it('loads agent definition with frontmatter fields', () => {
+      const loader = new AgentLoader(tmpDir);
+      const result = loader.loadCustomAgents({ agentsDir: '.qualops/agents' });
+      const agent = result['test-agent'];
+      expect(agent).toBeDefined();
+      expect(agent.description).toBe('A test agent');
+      expect(agent.prompt).toBe('You are a test agent.');
+      expect(agent.tools).toEqual(['Read', 'Grep']);
+      expect(agent.model).toBe('sonnet');
+    });
+
+    it('skips markdown files with empty body', () => {
+      const emptyDir = join(tmpDir, 'empty-agents');
+      mkdirSync(emptyDir, { recursive: true });
+      writeFileSync(join(emptyDir, 'empty.md'), '---\ndescription: empty\n---\n   ');
+
+      const loader = new AgentLoader(tmpDir);
+      const result = loader.loadCustomAgents({ agentsDir: 'empty-agents' });
+      expect(result).toEqual({});
+
+      rmSync(emptyDir, { recursive: true, force: true });
+    });
+
+    it('returns empty when agents directory does not exist', () => {
+      const loader = new AgentLoader(tmpDir);
+      const result = loader.loadCustomAgents({ agentsDir: 'nonexistent' });
+      expect(result).toEqual({});
+    });
+  });
+
+  describe('inline custom agents', () => {
+    it('loads agents from customAgents config', () => {
+      const loader = new AgentLoader(tmpDir);
+      const result = loader.loadCustomAgents({
+        agentsDir: 'nonexistent',
+        customAgents: [
+          {
+            name: 'inline-agent',
+            description: 'An inline agent',
+            prompt: 'Do things.',
+          },
+        ],
+      });
+      expect(result['inline-agent']).toBeDefined();
+      expect(result['inline-agent'].description).toBe('An inline agent');
+      expect(result['inline-agent'].prompt).toBe('Do things.');
+      expect(result['inline-agent'].tools).toEqual(['Read', 'Grep', 'Glob']);
+      expect(result['inline-agent'].model).toBe('sonnet');
+    });
+  });
+});

--- a/tests/unit/stages/review/agentic/loaders/agent-loader.spec.ts
+++ b/tests/unit/stages/review/agentic/loaders/agent-loader.spec.ts
@@ -1,5 +1,5 @@
 import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
-import { join, resolve } from 'node:path';
+import { join } from 'node:path';
 
 import { AgentLoader } from '@/stages/review/agentic/loaders/agent-loader';
 

--- a/tests/unit/stages/review/loaders/prompt-loader.spec.ts
+++ b/tests/unit/stages/review/loaders/prompt-loader.spec.ts
@@ -1,0 +1,44 @@
+import { resolve } from 'node:path';
+
+import { PromptLoader } from '@/stages/review/loaders/prompt-loader';
+
+describe('PromptLoader', () => {
+  beforeEach(() => {
+    PromptLoader.clearCache();
+  });
+
+  describe('path traversal protection', () => {
+    it('rejects ../ traversal', async () => {
+      await expect(PromptLoader.load('../../../etc/passwd')).rejects.toThrow(
+        /resolves outside the prompts directory/,
+      );
+    });
+
+    it('rejects embedded traversal that escapes base', async () => {
+      await expect(PromptLoader.load('foo/../../../../etc/passwd')).rejects.toThrow(
+        /resolves outside the prompts directory/,
+      );
+    });
+
+    it('rejects absolute path', async () => {
+      await expect(PromptLoader.load('/etc/passwd')).rejects.toThrow(
+        /resolves outside the prompts directory/,
+      );
+    });
+
+    it('rejects traversal in promptConfig object', async () => {
+      await expect(
+        PromptLoader.load({ file: '../../../etc/passwd', meta: {} }),
+      ).rejects.toThrow(/resolves outside the prompts directory/);
+    });
+
+    it('does not reject normal relative path (fails with file not found, not traversal)', async () => {
+      await expect(PromptLoader.load('nonexistent.md')).rejects.toThrow(
+        /Failed to load prompt/,
+      );
+      await expect(PromptLoader.load('nonexistent.md')).rejects.not.toThrow(
+        /resolves outside the prompts directory/,
+      );
+    });
+  });
+});

--- a/tests/unit/stages/review/loaders/prompt-loader.spec.ts
+++ b/tests/unit/stages/review/loaders/prompt-loader.spec.ts
@@ -1,5 +1,3 @@
-import { resolve } from 'node:path';
-
 import { PromptLoader } from '@/stages/review/loaders/prompt-loader';
 
 describe('PromptLoader', () => {
@@ -27,15 +25,13 @@ describe('PromptLoader', () => {
     });
 
     it('rejects traversal in promptConfig object', async () => {
-      await expect(
-        PromptLoader.load({ file: '../../../etc/passwd', meta: {} }),
-      ).rejects.toThrow(/resolves outside the prompts directory/);
+      await expect(PromptLoader.load({ file: '../../../etc/passwd', meta: {} })).rejects.toThrow(
+        /resolves outside the prompts directory/,
+      );
     });
 
     it('does not reject normal relative path (fails with file not found, not traversal)', async () => {
-      await expect(PromptLoader.load('nonexistent.md')).rejects.toThrow(
-        /Failed to load prompt/,
-      );
+      await expect(PromptLoader.load('nonexistent.md')).rejects.toThrow(/Failed to load prompt/);
       await expect(PromptLoader.load('nonexistent.md')).rejects.not.toThrow(
         /resolves outside the prompts directory/,
       );

--- a/tests/unit/stages/review/utils/global-rate-limiter.spec.ts
+++ b/tests/unit/stages/review/utils/global-rate-limiter.spec.ts
@@ -9,7 +9,10 @@ jest.mock('@/shared/utils/logger');
 
 import { ConfigService } from '@/config/config';
 import { logger } from '@/shared/utils/logger';
-import { globalRateLimiter } from '@/stages/review/utils/global-rate-limiter';
+import { getGlobalRateLimiter } from '@/stages/review/utils/global-rate-limiter';
+
+// Shared singleton — tests reset its fields in beforeEach rather than rebuilding it.
+const globalRateLimiter = getGlobalRateLimiter();
 
 describe('GlobalRateLimiter', () => {
   let mockConfigService: {


### PR DESCRIPTION
## Summary

  Introduces runtime validation for `.qualopsrc.json` using Zod as the single source of truth for config types and schema. Replaces the hand-maintained `docs/qualops-config.schema.json` with a generated
  artifact derived from the Zod schemas.

  ### What changed

  - **`src/config/config-schema.ts`** — new Zod schemas for every config section (`ai`, `review`, `performance`, `fix`, `report`, `github`, `gitlab`, `paths`, `logger`, and top-level). Deprecated fields are
  tagged with `.meta({ deprecated: true, description })` so they flow into the generated JSON Schema and runtime warnings.
  - **`src/config/schema-validator.ts`** — `assertValidConfig()` parses the raw config and throws `ConfigValidationError` on schema violations. `collectConfigWarnings()` walks the schema to detect deprecated field usage and unknown passthrough fields.
  - **`src/config/config.ts`** — calls `assertValidConfig()` in the constructor. Schema violations (unknown fields, missing required, type mismatches) throw immediately; deprecated fields log `[CONFIG] Deprecated
  field "…"` warnings but don't break existing configs. Invalid JSON throws `ConfigParseError` instead of silently returning `{}`.
  - **`src/cli/commands/validate-command.ts`** — new `qualops validate` command for standalone config validation without running any stages. Reports schema errors, deprecation warnings, and unknown passthrough fields. Inherits the `--config` flag.
  - **`src/shared/types/config.ts`** — config interfaces replaced with `z.infer<>` re-exports. Domain types (`FileInfo`, `ReviewTask`, etc.) stay as hand-written interfaces.
  - **`scripts/generate-config-schema.ts` + `scripts/config-schema/post-process.ts`** — regenerates `docs/qualops-config.schema.json` from the Zod schemas. Post-processing renames auto-generated `$defs`,
  inlines trivial ones, normalizes Zod output quirks (`const`→`enum`, `anyOf`→`oneOf`, etc.), deduplicates sibling descriptions, and orders properties for a readable, diff-friendly output. Run via `npm run
  generate:schema`.
  - **`docs/qualops-config.schema.json`** — regenerated; no longer hand-maintained.
  - Dead `ConfigService` methods removed: `getMaxFileSizeKB()`, `getMaxTokensPerFile()`, `getMaxReactSteps()`, `getDirectories()`, `getPerformanceLimits()` — uncalled since Nov 2025.

  ### Validation behavior

  - **Schema violations throw** — unknown fields (`.strict()`), missing required sections, type mismatches → hard error with clear message
  - **Deprecated fields warn** — old configs keep working, users get informed via `logger.warn`
  - **`qualops validate`** — standalone command to check config validity without running stages

  ### Scope

  Phase 1: Zod schemas, runtime validation, deprecation warnings, JSON Schema generation, validate CLI command.
  Phase 2 (future): centralized config class refactor so all access flows through typed parsed config (today `config.ts` and `schema-validator.ts` still carry duplicate defaults).

  ## Test plan

  - [x] `npm test` — new unit tests for `schema-validator` (valid configs, missing required sections, unknown fields, deprecated field detection, nested deprecations) and `post-process` (rename/inline/normalize
   passes, full `postProcessDefs` integration)
  - [x] `npm run test:integration` — schema integrity tests updated to resolve `$ref` before asserting structure
  - [x] `npm run build` — compiles without errors
  - [x] `npm run generate:schema` — regenerates `docs/qualops-config.schema.json`; diff should be empty after running on a clean branch
  - [x] Manual: `qualops validate` with valid config → shows deprecation warnings, exits 0
  - [x] Manual: `qualops validate` with invalid config → clean validation error, exits 1
  - [x] Manual: `qualops validate` with broken JSON → clean parse error, exits 1
  - [x] Manual: add an unknown field to `.qualopsrc.json` → validation throws with a clear error
  - [x] Manual: remove the `ai` section → validation throws
  - [x] Manual: run with a config containing deprecated fields → warnings logged, app runs normally


🤖 Generated with [Claude Code](https://claude.com/claude-code)