### PR TITLE
feat(config): subagent model override + consistent ModelConfig style

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,11 @@
 # Anthropic API Configuration
 # ANTHROPIC_API_KEY=your-api-key-here
 
+# OpenAI API Configuration
+# OPENAI_API_KEY=your-api-key-here
+# OPENAI_BASE_URL=  # Optional: override to use Azure OpenAI or other compatible endpoints
+#                   # Azure example: https://<resource>.openai.azure.com/openai/deployments/<deployment>
+
 # AWS Bedrock Configuration
 # AWS_REGION=eu-west-1
 # AWS_ACCESS_KEY_ID=your-access-key

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade eslint from 9.x to 10.x, migrate `eslint-plugin-import` to `eslint-plugin-import-x`
 
 ### Added
+- You can now specify a model and provider together in stage config using `model: { provider: "openai", name: "gpt-4o" }` instead of relying on a separate top-level `provider` field.
 - OpenTelemetry observability instrumentation across the full review pipeline (file-by-file, agentic, and eval runs), with auto-detection for Langfuse and generic OTLP backends. All span attributes are sanitized to prevent credential leakage.
 - Agentic jobs now support a `prompt` field for file-based prompt instructions, combined with the existing inline `systemPrompt`
 - GitHub Models AI provider (`provider: "github"`) via `https://models.github.ai/inference`

--- a/evals/src/config.js
+++ b/evals/src/config.js
@@ -29,10 +29,14 @@ function listPresets() {
 
 function readPresetMeta(presetFile) {
   try {
-    const config = JSON.parse(fs.readFileSync(presetFile, 'utf-8'));
+    const { ConfigService } = require('@/config/config');
+    ConfigService.setConfigPath(path.relative(QUALOPS_ROOT, presetFile));
+    const resolved = ConfigService.getInstance().getResolvedStageConfig('review');
+    const rawConfig = JSON.parse(fs.readFileSync(presetFile, 'utf-8'));
     return {
-      model: config.ai?.reviewStage?.model,
-      mode: config.review?.pipeline?.find((j) => j.enabled)?.mode || 'file-by-file',
+      model: resolved.model,
+      provider: resolved.provider,
+      mode: rawConfig.review?.pipeline?.find((j) => j.enabled)?.mode || 'file-by-file',
     };
   } catch {
     return {};
@@ -64,14 +68,15 @@ function buildConfig(args) {
   const presetFile = resolvePreset(presetName);
 
   let presetMeta = {};
-  if (presetFile) {
-    presetMeta = readPresetMeta(presetFile);
+  const metaFile = presetFile || path.join(QUALOPS_ROOT, DEFAULT_QUALOPSRC);
+  if (fs.existsSync(metaFile)) {
+    presetMeta = readPresetMeta(metaFile);
   }
 
   const mode = args.mode || presetMeta.mode || 'file-by-file';
   const modelOverride = args.model || null;
   const model = modelOverride || presetMeta.model || 'claude-sonnet-4-6';
-  const provider = args.provider || 'anthropic';
+  const provider = args.provider || presetMeta.provider || null;
   const limit = args.limit ? parseInt(args.limit, 10) : Infinity;
   const skipJudge = args['no-judge'] === 'true';
   const severityFilter = args.severity

--- a/evals/src/qualops-bridge/provider.ts
+++ b/evals/src/qualops-bridge/provider.ts
@@ -2,9 +2,7 @@ import { readFileSync, mkdirSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 
-import { AnthropicProvider } from '@/ai/providers/anthropic';
-import { OpenAIProvider } from '@/ai/providers/openai';
-import { BedrockProvider } from '@/ai/providers/bedrock';
+import { AIFactory } from '@/ai/providers/factory';
 import type { AIProvider } from '@/ai/providers/provider';
 import { AgenticExecutor } from '@/stages/review/agentic/agentic-executor';
 import { FileReviewer } from '@/stages/review/processors/file-reviewer';
@@ -13,7 +11,6 @@ import { setCurrentSession } from '@/shared/runtime/session-context';
 import { ConfigLoader } from '@/stages/review/loaders/config-loader';
 import { ConfigService } from '@/config/config';
 import type { ReviewIssue } from '@/shared/types';
-import type { AIStageConfig } from '@/shared/types';
 import type { FileInfo, PipelineJob } from '@/shared/types/config';
 
 import type { EvalCase, EvalConfig, DetectedIssue, ReviewResult } from './types.js';
@@ -242,43 +239,32 @@ function parseLineNumber(location: string): number {
 }
 
 async function createProvider(config: EvalConfig): Promise<AIProvider> {
-  // Use AI config from qualopsrc if loaded, with EvalConfig as override
-  let stageConfig: AIStageConfig;
-  try {
-    const fromRc = ConfigService.getInstance().getAIStageConfig('review');
-    stageConfig = {
-      ...fromRc,
-      provider: config.provider ?? fromRc.provider,
-      model: config.model || fromRc.model,
-    };
-  } catch {
-    stageConfig = {
-      provider: config.provider ?? 'anthropic',
-      model: config.model || 'claude-sonnet-4-6',
-      inputPerMillion: 0,
-      outputPerMillion: 0,
-      temperature: 0,
-    };
+  if (config.provider || config.model) {
+    const configService = ConfigService.getInstance();
+    try {
+      const resolved = configService.getResolvedStageConfig('review');
+      configService.set('ai', {
+        ...configService.get('ai'),
+        reviewStage: {
+          ...resolved,
+          ...(config.provider && { provider: config.provider }),
+          ...(config.model && { model: config.model }),
+        },
+      });
+    } catch {
+      configService.set('ai', {
+        reviewStage: {
+          provider: config.provider ?? 'anthropic',
+          model: config.model || 'claude-sonnet-4-6',
+          inputPerMillion: 0,
+          outputPerMillion: 0,
+        },
+      });
+    }
+    AIFactory.clear();
   }
 
-  let provider: AIProvider;
-
-  switch (stageConfig.provider) {
-    case 'anthropic':
-      provider = new AnthropicProvider(stageConfig);
-      break;
-    case 'openai':
-      provider = new OpenAIProvider(stageConfig);
-      break;
-    case 'bedrock':
-      provider = new BedrockProvider(stageConfig);
-      break;
-    default:
-      throw new Error(`Unknown provider: ${stageConfig.provider}`);
-  }
-
-  await provider.initialize();
-  return provider;
+  return AIFactory.createForStage('review');
 }
 
 function loadSystemPrompt(): string {

--- a/qualops-config.schema.json
+++ b/qualops-config.schema.json
@@ -238,23 +238,47 @@
       "type": "string",
       "minLength": 1
     },
+    "modelConfig": {
+      "description": "Model to use: a string name (inherits provider from context) or an object with an explicit name and optional provider override.",
+      "oneOf": [
+        {
+          "$ref": "#/$defs/nonEmptyString"
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": [
+            "name"
+          ],
+          "properties": {
+            "provider": {
+              "$ref": "#/$defs/aiProvider"
+            },
+            "name": {
+              "$ref": "#/$defs/nonEmptyString"
+            }
+          }
+        }
+      ]
+    },
     "aiStageConfig": {
       "description": "AI configuration for a specific stage.",
       "type": "object",
       "additionalProperties": true,
       "required": [
-        "provider",
         "model",
         "inputPerMillion",
         "outputPerMillion"
       ],
       "properties": {
         "provider": {
+          "description": "Deprecated. Prefer specifying provider inside the model object.",
+          "deprecated": true,
           "$ref": "#/$defs/aiProvider"
         },
         "model": {
-          "description": "Model name passed to the selected provider.",
-          "$ref": "#/$defs/nonEmptyString"
+          "description": "Model name or { provider, name } object.",
+          "$ref": "#/$defs/modelConfig"
         },
         "inputPerMillion": {
           "description": "Estimated input token cost per million tokens.",
@@ -415,10 +439,17 @@
           "minimum": 0
         },
         "enabledSubagents": {
-          "description": "Subset of built-in subagents to enable.",
+          "description": "Built-in subagents to enable, optionally with model overrides.",
           "type": "array",
           "items": {
-            "$ref": "#/$defs/agenticSubagentType"
+            "oneOf": [
+              {
+                "$ref": "#/$defs/agenticSubagentType"
+              },
+              {
+                "$ref": "#/$defs/subagentOverride"
+              }
+            ]
           }
         },
         "customAgents": {
@@ -452,6 +483,22 @@
           "description": "Total token budget for all file contexts in one agentic run.",
           "type": "integer",
           "minimum": 1
+        }
+      }
+    },
+    "subagentOverride": {
+      "description": "Built-in subagent identifier with an explicit model override.",
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "$ref": "#/$defs/agenticSubagentType"
+        },
+        "model": {
+          "$ref": "#/$defs/modelConfig"
         }
       }
     },
@@ -501,15 +548,6 @@
       "items": {
         "$ref": "#/$defs/nonEmptyString"
       }
-    },
-    "agentModel": {
-      "description": "Optional model tier override for this custom agent.",
-      "type": "string",
-      "enum": [
-        "sonnet",
-        "opus",
-        "haiku"
-      ]
     },
     "contextMode": {
       "description": "How file context is sent: diff, full file content, or auto mode.",
@@ -885,6 +923,10 @@
       "$ref": "#/$defs/nonEmptyString",
       "type": "string",
       "minLength": 1
+    },
+    "agentModel": {
+      "description": "Optional model override for this custom agent.",
+      "$ref": "#/$defs/modelConfig"
     }
   }
 }

--- a/scripts/config-schema/post-process.ts
+++ b/scripts/config-schema/post-process.ts
@@ -176,6 +176,9 @@ export function buildInlineSet(defs: Defs): Set<string> {
     if (type === 'object' && !def.properties) {
       inlinable.add(key);
     }
+    if (type === 'object' && def.additionalProperties === false) {
+      inlinable.add(key);
+    }
     if (type === 'array') {
       inlinable.add(key);
     }

--- a/src/ai/providers/anthropic.ts
+++ b/src/ai/providers/anthropic.ts
@@ -3,7 +3,7 @@ import type Anthropic from '@anthropic-ai/sdk';
 import { estimateTokens } from '@/ai/shared/token-utils';
 import { ConfigService } from '@/config/config';
 import { envConfig } from '@/config/env';
-import type { AIStageConfig } from '@/shared/types';
+import type { ResolvedStageConfig } from '@/shared/types';
 import { logger } from '@/shared/utils/logger';
 
 import { AIProviderType } from './factory';
@@ -15,7 +15,7 @@ export class AnthropicProvider implements AIProvider {
   private initialized = false;
   private apiKey: string;
   private maxTokens = 8000;
-  private stageConfig: AIStageConfig;
+  private stageConfig: ResolvedStageConfig;
   private readonly tokenStats: TokenStats = {
     totalInputTokens: 0,
     totalOutputTokens: 0,
@@ -29,7 +29,7 @@ export class AnthropicProvider implements AIProvider {
   private cacheHits = 0;
   private cache1HourCreationTokens = 0;
 
-  constructor(stageConfig: AIStageConfig) {
+  constructor(stageConfig: ResolvedStageConfig) {
     this.stageConfig = stageConfig;
     this.apiKey = envConfig.get('anthropicApiKey') || '';
 

--- a/src/ai/providers/anthropic.ts
+++ b/src/ai/providers/anthropic.ts
@@ -131,7 +131,7 @@ export class AnthropicProvider implements AIProvider {
       systemPrompt,
     } = options;
 
-    logger.debug(`[anthropic] model=${model} prompt=${JSON.stringify(messages).slice(0, 200)}`);
+    logger.debug(`[anthropic] model=${model} messages=${messages.length}`);
 
     if (!this.client) {
       throw new Error('Anthropic client not initialized');

--- a/src/ai/providers/anthropic.ts
+++ b/src/ai/providers/anthropic.ts
@@ -131,6 +131,8 @@ export class AnthropicProvider implements AIProvider {
       systemPrompt,
     } = options;
 
+    logger.debug(`[anthropic] model=${model} prompt=${JSON.stringify(messages).slice(0, 200)}`);
+
     if (!this.client) {
       throw new Error('Anthropic client not initialized');
     }

--- a/src/ai/providers/bedrock.ts
+++ b/src/ai/providers/bedrock.ts
@@ -3,7 +3,7 @@ import type { BedrockRuntimeClient } from '@aws-sdk/client-bedrock-runtime';
 import { AIProviderType } from './factory';
 import type { AICompletionOptions, AIProvider, AIResponse, TokenStats } from './provider';
 import { envConfig } from '../../config/env';
-import type { AIStageConfig } from '../../shared/types';
+import type { ResolvedStageConfig } from '../../shared/types';
 import { logger } from '../../shared/utils/logger';
 import { estimateTokens } from '../shared/token-utils';
 
@@ -44,7 +44,7 @@ export class BedrockProvider implements AIProvider {
 
   private client: BedrockRuntimeClient | null = null;
   private initialized = false;
-  private readonly stageConfig: AIStageConfig;
+  private readonly stageConfig: ResolvedStageConfig;
   private readonly region: string;
   private readonly maxTokens = 4000;
 
@@ -60,7 +60,7 @@ export class BedrockProvider implements AIProvider {
   private cacheReadTokens = 0;
   private cacheHits = 0;
 
-  constructor(stageConfig: AIStageConfig) {
+  constructor(stageConfig: ResolvedStageConfig) {
     this.stageConfig = stageConfig;
     this.region = envConfig.get('awsRegion') || process.env.AWS_REGION || 'eu-west-1';
 

--- a/src/ai/providers/factory.ts
+++ b/src/ai/providers/factory.ts
@@ -4,6 +4,7 @@ import { GitHubModelsProvider } from './github';
 import { OpenAIProvider } from './openai';
 import type { AIProvider } from './provider';
 import { ConfigService } from '../../config/config';
+import type { ResolvedStageConfig } from '../../shared/types';
 
 export const AIProviderType = {
   ANTHROPIC: 'anthropic',
@@ -16,19 +17,17 @@ export class AIFactory {
   private static providers: Map<string, AIProvider> = new Map();
 
   static async createForStage(stage: string): Promise<AIProvider> {
-    const config = ConfigService.getInstance();
-    const stageConfig = config.getAIStageConfig(stage);
+    const stageConfig: ResolvedStageConfig =
+      ConfigService.getInstance().getResolvedStageConfig(stage);
     const providerKey = `${stageConfig.provider}-${stage}`;
 
-    // Return existing provider if available
     if (this.providers.has(providerKey)) {
-      const provider = this.providers.get(providerKey);
-      if (provider && provider.isAvailable()) {
-        return provider;
+      const existingProvider = this.providers.get(providerKey);
+      if (existingProvider && existingProvider.isAvailable()) {
+        return existingProvider;
       }
     }
 
-    // Create new provider
     let provider: AIProvider;
 
     switch (stageConfig.provider) {
@@ -65,7 +64,6 @@ export class AIFactory {
   }
 }
 
-// Global provider management
 let globalProvider: AIProvider | null = null;
 
 export async function initializeGlobalAIProviderForStage(stage: string): Promise<AIProvider> {

--- a/src/ai/providers/github.ts
+++ b/src/ai/providers/github.ts
@@ -1,10 +1,10 @@
 import { envConfig } from '@/config/env';
-import type { AIStageConfig } from '@/shared/types';
+import type { ResolvedStageConfig } from '@/shared/types';
 
 import { OpenAICompatibleProvider } from './openai-compatible-provider';
 
 export class GitHubModelsProvider extends OpenAICompatibleProvider {
-  constructor(stageConfig: AIStageConfig) {
+  constructor(stageConfig: ResolvedStageConfig) {
     super(stageConfig, {
       name: 'github',
       friendlyName: 'GitHub Models',

--- a/src/ai/providers/openai-compatible-provider.ts
+++ b/src/ai/providers/openai-compatible-provider.ts
@@ -3,7 +3,7 @@ import type { ChatCompletionCreateParams } from 'openai/resources/chat/completio
 
 import { estimateTokens } from '@/ai/shared/token-utils';
 import { envConfig } from '@/config/env';
-import type { AIStageConfig } from '@/shared/types';
+import type { ResolvedStageConfig } from '@/shared/types';
 import { logger } from '@/shared/utils/logger';
 
 import type { AICompletionOptions, AIProvider, AIResponse, TokenStats } from './provider';
@@ -36,7 +36,7 @@ export abstract class OpenAICompatibleProvider implements AIProvider {
   protected readonly apiKey: string;
   private readonly baseURL: string;
   private readonly maxTokens = 8000;
-  private readonly stageConfig: AIStageConfig;
+  private readonly stageConfig: ResolvedStageConfig;
   private readonly tokenStats: TokenStats = {
     totalInputTokens: 0,
     totalOutputTokens: 0,
@@ -48,7 +48,7 @@ export abstract class OpenAICompatibleProvider implements AIProvider {
   private cachedTokens = 0;
   private cacheHits = 0;
 
-  constructor(stageConfig: AIStageConfig, providerConfig: OpenAICompatibleProviderConfig) {
+  constructor(stageConfig: ResolvedStageConfig, providerConfig: OpenAICompatibleProviderConfig) {
     this.name = providerConfig.name;
     this.friendlyName = providerConfig.friendlyName;
     this.stageConfig = stageConfig;

--- a/src/ai/providers/openai-compatible-provider.ts
+++ b/src/ai/providers/openai-compatible-provider.ts
@@ -164,7 +164,7 @@ export abstract class OpenAICompatibleProvider implements AIProvider {
       systemPrompt,
     } = options;
 
-    logger.debug(`[${this.name}] model=${model} prompt=${JSON.stringify(messages).slice(0, 200)}`);
+    logger.debug(`[${this.name}] model=${model} messages=${messages.length}`);
 
     if (!this.client) {
       throw new Error(`${this.friendlyName} client not initialized`);

--- a/src/ai/providers/openai-compatible-provider.ts
+++ b/src/ai/providers/openai-compatible-provider.ts
@@ -164,6 +164,8 @@ export abstract class OpenAICompatibleProvider implements AIProvider {
       systemPrompt,
     } = options;
 
+    logger.debug(`[${this.name}] model=${model} prompt=${JSON.stringify(messages).slice(0, 200)}`);
+
     if (!this.client) {
       throw new Error(`${this.friendlyName} client not initialized`);
     }

--- a/src/ai/providers/openai.ts
+++ b/src/ai/providers/openai.ts
@@ -7,16 +7,20 @@ export class OpenAIProvider extends OpenAICompatibleProvider {
 
   constructor(stageConfig: ResolvedStageConfig) {
     const apiKey = envConfig.get('openaiApiKey') || '';
-    const baseURL = envConfig.get('openaiApiBase');
+    const rawBaseURL = envConfig.get('openaiApiBase');
+
+    if (rawBaseURL && !/^https?:\/\//i.test(rawBaseURL)) {
+      throw new Error(`OPENAI_BASE_URL must be a valid http/https URL, got: ${rawBaseURL}`);
+    }
 
     super(stageConfig, {
       name: 'openai',
       friendlyName: 'OpenAI',
       apiKey,
-      baseURL,
+      baseURL: rawBaseURL,
     });
 
-    this.isCustomEndpoint = !!baseURL;
+    this.isCustomEndpoint = !!rawBaseURL;
   }
 
   protected validateApiKey(): void {

--- a/src/ai/providers/openai.ts
+++ b/src/ai/providers/openai.ts
@@ -1,9 +1,9 @@
 import { OpenAICompatibleProvider } from './openai-compatible-provider';
 import { envConfig } from '../../config/env';
-import type { AIStageConfig } from '../../shared/types';
+import type { ResolvedStageConfig } from '../../shared/types';
 
 export class OpenAIProvider extends OpenAICompatibleProvider {
-  constructor(stageConfig: AIStageConfig) {
+  constructor(stageConfig: ResolvedStageConfig) {
     super(stageConfig, {
       name: 'openai',
       friendlyName: 'OpenAI',

--- a/src/ai/providers/openai.ts
+++ b/src/ai/providers/openai.ts
@@ -3,12 +3,20 @@ import { envConfig } from '../../config/env';
 import type { ResolvedStageConfig } from '../../shared/types';
 
 export class OpenAIProvider extends OpenAICompatibleProvider {
+  private readonly isCustomEndpoint: boolean;
+
   constructor(stageConfig: ResolvedStageConfig) {
+    const apiKey = envConfig.get('openaiApiKey') || '';
+    const baseURL = envConfig.get('openaiApiBase');
+
     super(stageConfig, {
       name: 'openai',
       friendlyName: 'OpenAI',
-      apiKey: envConfig.get('openaiApiKey') || '',
+      apiKey,
+      baseURL,
     });
+
+    this.isCustomEndpoint = !!baseURL;
   }
 
   protected validateApiKey(): void {
@@ -16,8 +24,7 @@ export class OpenAIProvider extends OpenAICompatibleProvider {
       throw new Error('OPENAI_API_KEY environment variable is required for openai provider');
     }
 
-    // Validate API key format (OpenAI keys should start with 'sk-')
-    if (!this.apiKey.startsWith('sk-')) {
+    if (!this.isCustomEndpoint && !this.apiKey.startsWith('sk-')) {
       throw new Error('Invalid OpenAI API key format');
     }
   }

--- a/src/cli/commands/all-command.ts
+++ b/src/cli/commands/all-command.ts
@@ -91,7 +91,7 @@ async function executeAllStagesWithTracing(
 
   await tracer.startActiveSpan('qualops/run', async (rootSpan) => {
     try {
-      const model = ConfigService.getInstance().getAIStageConfig('review').model;
+      const model = ConfigService.getInstance().getResolvedStageConfig('review').model;
       const prMeta = extractPRMetadata(config.sessionName);
       setTraceMetadataFromPR(rootSpan, prMeta, config.sessionName, model);
 

--- a/src/config/config-schema.ts
+++ b/src/config/config-schema.ts
@@ -13,7 +13,7 @@ const severityList = z.array(severity).min(1).meta({
   description: 'Non-empty array of severity levels.',
   uniqueItems: true,
 });
-const aiProvider = z
+export const aiProvider = z
   .enum(['anthropic', 'openai', 'bedrock', 'github'])
   .meta({ defName: 'aiProvider', description: 'Supported AI provider names.' });
 const confidenceScore = z.int().min(1).max(10).meta({
@@ -34,14 +34,31 @@ const outputFormat = z.enum(['json', 'html', 'markdown']).meta({
   description: 'Output format for reports and generated files.',
 });
 
+// --- Model config ---
+// A model can be specified as a plain string (model name, inherits provider from context)
+// or as an object with an explicit name and optional provider override.
+export const modelConfigSchema = z
+  .union([
+    nonEmptyString,
+    z.object({ provider: aiProvider.optional(), name: nonEmptyString }).strict(),
+  ])
+  .meta({
+    defName: 'modelConfig',
+    description:
+      'Model to use: a string name (inherits provider from context) or an object with an explicit name and optional provider override.',
+  });
+
 // --- AI stage config ---
 // .passthrough() because providers may have extra fields (e.g. topP, topK).
 // The `passthrough: true` meta tag is read by the schema validator to find
 // passthrough objects without poking at Zod internals.
 const aiStageConfigSchema = z
   .object({
-    provider: aiProvider,
-    model: nonEmptyString.meta({ description: 'Model name passed to the selected provider.' }),
+    provider: aiProvider.optional().meta({
+      deprecated: true,
+      description: 'Deprecated. Prefer specifying provider inside the model object.',
+    }),
+    model: modelConfigSchema.meta({ description: 'Model name or { provider, name } object.' }),
     inputPerMillion: z
       .number()
       .min(0)
@@ -180,13 +197,10 @@ export const customAgentDefinitionSchema = z
     tools: nonEmptyStringArray
       .optional()
       .meta({ description: 'Allowed tool names for the custom agent.' }),
-    model: z
-      .enum(['sonnet', 'opus', 'haiku'])
-      .meta({
-        defName: 'agentModel',
-        description: 'Optional model tier override for this custom agent.',
-      })
-      .optional(),
+    model: modelConfigSchema.optional().meta({
+      defName: 'agentModel',
+      description: 'Optional model override for this custom agent.',
+    }),
   })
   .strict()
   .meta({
@@ -202,6 +216,17 @@ export const agenticSubagentTypeSchema = z
     description: 'Built-in subagent identifiers supported in agentic mode.',
   });
 
+const subagentOverrideSchema = z
+  .object({
+    name: agenticSubagentTypeSchema,
+    model: modelConfigSchema.optional(),
+  })
+  .strict()
+  .meta({
+    defName: 'subagentOverride',
+    description: 'Built-in subagent identifier with an explicit model override.',
+  });
+
 export const agenticConfigSchema = z
   .object({
     maxTurns: z
@@ -215,9 +240,9 @@ export const agenticConfigSchema = z
       .optional()
       .meta({ description: 'Optional budget guardrail for agentic execution.' }),
     enabledSubagents: z
-      .array(agenticSubagentTypeSchema)
+      .array(z.union([agenticSubagentTypeSchema, subagentOverrideSchema]))
       .optional()
-      .meta({ description: 'Subset of built-in subagents to enable.' }),
+      .meta({ description: 'Built-in subagents to enable, optionally with model overrides.' }),
     customAgents: z
       .array(customAgentDefinitionSchema)
       .optional()

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -3,7 +3,14 @@ import { join } from 'node:path';
 
 import { envConfig } from './env';
 import { ConfigParseError, assertValidConfig, collectConfigWarnings } from './schema-validator';
-import type { AIStageConfig, Config } from '../shared/types';
+import type {
+  AIProviderName,
+  AIStageConfig,
+  Config,
+  ModelConfig,
+  ResolvedStageConfig,
+} from '../shared/types';
+import type { AgenticConfig } from '../shared/types/config';
 import { logger } from '../shared/utils/logger';
 
 export const FILE_NAMES = {
@@ -27,6 +34,8 @@ export const DEFAULT_CONFIG_PATH = '.qualops/.qualopsrc.json';
 export class ConfigService {
   private static instance: ConfigService | undefined;
   private static configPath = DEFAULT_CONFIG_PATH;
+  private static readonly DEFAULT_PROVIDER = 'anthropic';
+  private static readonly DEFAULT_MODEL = 'claude-sonnet-4-6';
   private config: Config;
   private rawConfig: Record<string, unknown>;
   private readonly defaultConfig: Config = {
@@ -170,6 +179,63 @@ export class ConfigService {
     return this.config.debug ?? envConfig.isDebug();
   }
 
+  /**
+   * Resolves the effective provider and model name. `model` overrides `stage`;
+   * both fall back to defaults.
+   */
+  resolveModel({ stage, model }: { stage?: AIStageConfig; model?: ModelConfig } = {}): {
+    provider: string;
+    model: string;
+  } {
+    return {
+      provider: this.resolveProvider(stage, model),
+      model: this.resolveModelName(stage, model),
+    };
+  }
+
+  private resolveProvider(stage?: AIStageConfig, model?: ModelConfig): string {
+    if (model !== undefined && model !== null && typeof model === 'object' && model.provider) {
+      return model.provider;
+    }
+    const stageModel = stage?.model;
+    if (stageModel && typeof stageModel === 'object' && stageModel.provider) {
+      return stageModel.provider;
+    }
+    return stage?.provider ?? ConfigService.DEFAULT_PROVIDER;
+  }
+
+  private resolveModelName(stage?: AIStageConfig, model?: ModelConfig): string {
+    if (model !== undefined && model !== null) {
+      return typeof model === 'string' ? model : model.name;
+    }
+    if (stage) {
+      const stageModel = stage.model;
+      return typeof stageModel === 'string' ? stageModel : stageModel.name;
+    }
+    return ConfigService.DEFAULT_MODEL;
+  }
+
+  /**
+   * Resolves the effective provider and model for a named agent, applying
+   * per-agent overrides from the agentic config before falling back to the
+   * stage config and finally the global defaults.
+   */
+  resolveAgentModel(
+    agentName: string,
+    agenticConfig: AgenticConfig,
+    stageConfig?: AIStageConfig,
+  ): { provider: string; model: string } {
+    const subagentOverride = (agenticConfig.enabledSubagents ?? []).find(
+      (e) => typeof e === 'object' && e.name === agentName,
+    );
+    const customAgent = (agenticConfig.customAgents ?? []).find((c) => c.name === agentName);
+    const model =
+      (typeof subagentOverride === 'object' ? subagentOverride.model : undefined) ??
+      customAgent?.model;
+
+    return this.resolveModel({ model, stage: stageConfig });
+  }
+
   getAIStageConfig(stage: string): AIStageConfig {
     const stageKey = `${stage}Stage` as keyof NonNullable<Config['ai']>;
     const stageConfig = this.config.ai?.[stageKey];
@@ -178,7 +244,7 @@ export class ConfigService {
       throw new Error(`AI configuration for stage "${stage}" not found in .qualopsrc.json`);
     }
 
-    const required = ['provider', 'model', 'inputPerMillion', 'outputPerMillion'];
+    const required = ['model', 'inputPerMillion', 'outputPerMillion'];
     const missing = required.filter((key) => !(key in stageConfig));
 
     if (missing.length > 0) {
@@ -186,6 +252,12 @@ export class ConfigService {
     }
 
     return stageConfig;
+  }
+
+  getResolvedStageConfig(stage: string): ResolvedStageConfig {
+    const raw = this.getAIStageConfig(stage);
+    const { provider, model } = this.resolveModel({ stage: raw });
+    return { ...raw, provider: provider as AIProviderName, model };
   }
 
   isIssueMarkdownEnabled(): boolean {

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -2,6 +2,7 @@ interface EnvironmentConfig {
   // Secrets
   anthropicApiKey?: string;
   openaiApiKey?: string;
+  openaiApiBase?: string;
   awsRegion?: string;
   awsAccessKeyId?: string;
   awsSecretAccessKey?: string;
@@ -64,6 +65,7 @@ class EnvironmentConfigService {
       // API Keys
       anthropicApiKey: process.env.ANTHROPIC_API_KEY,
       openaiApiKey: process.env.OPENAI_API_KEY,
+      openaiApiBase: process.env.OPENAI_BASE_URL,
       awsRegion: process.env.AWS_REGION,
       awsAccessKeyId: process.env.AWS_ACCESS_KEY_ID,
       awsSecretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,

--- a/src/scripts/resolve-issue.ts
+++ b/src/scripts/resolve-issue.ts
@@ -3,8 +3,7 @@
 import { readFile, writeFile } from 'fs/promises';
 import { resolve } from 'path';
 
-import Anthropic from '@anthropic-ai/sdk';
-
+import { AIFactory } from '../ai/providers/factory';
 import { logger } from '../shared/utils/logger';
 
 interface ParsedIssue {
@@ -115,11 +114,7 @@ async function resolveIssue(
     return;
   }
 
-  const anthropic = new Anthropic({
-    apiKey: process.env.ANTHROPIC_API_KEY,
-  });
-
-  logger.info(`\n🤖 Generating fix using Claude...`);
+  logger.info(`\n🤖 Generating fix...`);
 
   const prompt = `You are a code fixing assistant. You need to apply a fix to a TypeScript file.
 
@@ -138,18 +133,8 @@ ${sourceContent}
 
 Your task: Apply the fix to the code. Return ONLY the complete fixed file content, nothing else. No explanations, no markdown code blocks, just the raw TypeScript code.`;
 
-  const message = await anthropic.messages.create({
-    model: 'claude-sonnet-4-5-20250929',
-    max_tokens: 8000,
-    messages: [
-      {
-        role: 'user',
-        content: prompt,
-      },
-    ],
-  });
-
-  let fixedContent = message.content[0].type === 'text' ? message.content[0].text : '';
+  const provider = await AIFactory.createForStage('review');
+  let fixedContent = await provider.invoke(prompt, 8000);
 
   if (!fixedContent) {
     logger.error('❌ Failed to generate fix');
@@ -162,9 +147,6 @@ Your task: Apply the fix to the code. Return ONLY the complete fixed file conten
     .trim();
 
   logger.info(`\n✅ Fix generated successfully`);
-  logger.info(
-    `\nTokens used: ${message.usage.input_tokens} input, ${message.usage.output_tokens} output`,
-  );
 
   if (dryRun) {
     logger.info(`\n🔍 DRY RUN MODE - Changes not applied`);

--- a/src/scripts/resolve-issue.ts
+++ b/src/scripts/resolve-issue.ts
@@ -104,6 +104,10 @@ async function resolveIssue(
   logger.info(`   Confidence: ${issue.confidence}`);
 
   const filePath = resolve(monorepoRoot, issue.file);
+  if (!filePath.startsWith(monorepoRoot.replace(/\/?$/, '/'))) {
+    logger.error(`❌ Rejected path outside project root: ${issue.file}`);
+    return;
+  }
   logger.info(`\n📂 Reading source file: ${filePath}`);
 
   let sourceContent: string;

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -2,6 +2,10 @@ export * from './issue.model';
 export * from './pattern.model';
 export * from './session.model';
 
+import type { z } from 'zod';
+
+import type { aiProvider, modelConfigSchema } from '@/config/config-schema';
+
 export type FilePath = string;
 export type SessionId = string;
 
@@ -35,9 +39,21 @@ export type Metrics = {
   cacheMisses?: number;
 };
 
-export type AIProviderName = 'anthropic' | 'bedrock' | 'openai' | 'github';
+export type AIProviderName = z.infer<typeof aiProvider>;
+
+export type ModelConfig = z.infer<typeof modelConfigSchema>;
 
 export type AIStageConfig = {
+  provider?: AIProviderName; // deprecated fallback; prefer model: { provider, name }
+  model: ModelConfig;
+  inputPerMillion: number;
+  outputPerMillion: number;
+  temperature?: number;
+  maxTokens?: number;
+  [key: string]: unknown;
+};
+
+export type ResolvedStageConfig = {
   provider: AIProviderName;
   model: string;
   inputPerMillion: number;

--- a/src/stages/review/agentic/agentic-executor.ts
+++ b/src/stages/review/agentic/agentic-executor.ts
@@ -4,8 +4,13 @@ import { context } from '@opentelemetry/api';
 import { AgentLoader } from './loaders/agent-loader';
 import { buildUserPrompt } from './prompt-builder';
 import { parseIssuesFromResult } from './result-parser';
-import { createSubagentDefinitions, type AgentDefinition } from './subagents/definitions';
+import {
+  createSubagentDefinitions,
+  type AgentDefinition,
+  type ResolvedAgentDefinition,
+} from './subagents/definitions';
 import { createAgenticTools } from './tools';
+import { ConfigService } from '../../../config/config';
 import {
   getTracer,
   setAgenticSpanAttributes,
@@ -13,7 +18,7 @@ import {
   setObservationIO,
   setTokenUsage,
 } from '../../../observability';
-import type { ReviewIssue } from '../../../shared/types';
+import type { ReviewIssue, ResolvedStageConfig } from '../../../shared/types';
 import type { FileInfo, PipelineJob, AgenticConfig } from '../../../shared/types/config';
 import { logger } from '../../../shared/utils/logger';
 import { PromptLoader } from '../loaders/prompt-loader';
@@ -60,7 +65,10 @@ export class AgenticExecutor {
 
     const builtInAgents = createSubagentDefinitions(this.config);
     const customAgents = this.agentLoader.loadCustomAgents(this.config);
-    const allAgents: Record<string, AgentDefinition> = { ...builtInAgents, ...customAgents };
+
+    // Merge all agents (custom agents can override built-in) then apply model overrides
+    const mergedAgents: Record<string, AgentDefinition> = { ...builtInAgents, ...customAgents };
+    const allAgents = this.applyModelOverrides(mergedAgents);
 
     const agentNames = Object.keys(allAgents);
     logger.info(`[Agentic] Available agents: ${agentNames.join(', ')}`);
@@ -102,7 +110,7 @@ export class AgenticExecutor {
           mcpServers: {
             'qualops-agentic-tools': toolServer,
           },
-          agents: allAgents,
+          agents: allAgents as Record<string, ResolvedAgentDefinition>,
           maxTurns: this.config.maxTurns || 100,
           ...(this.config.maxBudgetUsd && { maxBudgetUsd: this.config.maxBudgetUsd }),
           ...(this.model && { model: this.model }),
@@ -172,6 +180,25 @@ export class AgenticExecutor {
 
     logger.info(`[Agentic] Review completed: ${issues.length} total issues`);
     return issues;
+  }
+
+  private applyModelOverrides(
+    agents: Record<string, AgentDefinition>,
+  ): Record<string, ResolvedAgentDefinition> {
+    const configService = ConfigService.getInstance();
+    let stageConfig: ResolvedStageConfig | undefined;
+    try {
+      stageConfig = configService.getResolvedStageConfig('review');
+    } catch {
+      // no review stage config — resolveAgentModel falls back to defaults
+    }
+
+    return Object.fromEntries(
+      Object.entries(agents).map(([name, def]) => {
+        const { model } = configService.resolveAgentModel(name, this.config, stageConfig);
+        return [name, { ...def, model }];
+      }),
+    );
   }
 
   private async buildSystemPrompt(_allAgents: Record<string, AgentDefinition>): Promise<string> {

--- a/src/stages/review/agentic/loaders/agent-loader.ts
+++ b/src/stages/review/agentic/loaders/agent-loader.ts
@@ -1,6 +1,7 @@
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { join, basename, resolve } from 'node:path';
 
+import type { ModelConfig } from '../../../../shared/types';
 import type { AgenticConfig, CustomAgentDefinition } from '../../../../shared/types/config';
 import { logger } from '../../../../shared/utils/logger';
 import type { AgentDefinition } from '../subagents/definitions';
@@ -8,7 +9,7 @@ import type { AgentDefinition } from '../subagents/definitions';
 interface MarkdownAgentFrontmatter {
   description?: string;
   tools?: string[];
-  model?: 'sonnet' | 'opus' | 'haiku';
+  model?: string;
 }
 
 export class AgentLoader {
@@ -59,6 +60,10 @@ export class AgentLoader {
   }
 
   private loadAgentFromMarkdown(filePath: string): AgentDefinition | null {
+    if (!resolve(filePath).startsWith(this.cwd)) {
+      logger.warn(`[AgentLoader] Rejected agent path outside project directory: ${filePath}`);
+      return null;
+    }
     try {
       const content = readFileSync(filePath, 'utf-8');
       const { frontmatter, body } = this.parseMarkdown(content);
@@ -72,7 +77,7 @@ export class AgentLoader {
         description: frontmatter.description || `Custom agent from ${basename(filePath)}`,
         prompt: body.trim(),
         tools: frontmatter.tools || ['Read', 'Grep', 'Glob'],
-        model: frontmatter.model || 'sonnet',
+        model: frontmatter.model,
       };
     } catch (error) {
       logger.error(
@@ -103,7 +108,7 @@ export class AgentLoader {
         if (key === 'description') {
           frontmatter.description = value.trim().replace(/^["']|["']$/g, '');
         } else if (key === 'model') {
-          frontmatter.model = value.trim() as 'sonnet' | 'opus' | 'haiku';
+          frontmatter.model = value.trim();
         } else if (key === 'tools') {
           // Handle array format: tools: [Read, Grep, Glob]
           const arrayMatch = value.match(/\[([^\]]+)\]/);
@@ -122,7 +127,7 @@ export class AgentLoader {
       description: custom.description,
       prompt: custom.prompt,
       tools: custom.tools || ['Read', 'Grep', 'Glob'],
-      model: custom.model || 'sonnet',
+      model: custom.model as ModelConfig | undefined,
     };
   }
 }

--- a/src/stages/review/agentic/subagents/definitions.ts
+++ b/src/stages/review/agentic/subagents/definitions.ts
@@ -1,11 +1,14 @@
+import type { ModelConfig } from '../../../../shared/types';
 import type { AgenticConfig, AgenticSubagentType } from '../../../../shared/types/config';
 
 export interface AgentDefinition {
   description: string;
   prompt: string;
   tools: string[];
-  model?: 'sonnet' | 'opus' | 'haiku';
+  model?: ModelConfig;
 }
+
+export type ResolvedAgentDefinition = Omit<AgentDefinition, 'model'> & { model?: string };
 
 const SUBAGENT_DEFINITIONS: Record<AgenticSubagentType, AgentDefinition> = {
   'dependency-tracer': {
@@ -43,7 +46,6 @@ If no dependency issues are found, return an empty array: []`,
       'mcp__qualops-agentic-tools__trace_imports',
       'mcp__qualops-agentic-tools__find_usages',
     ],
-    model: 'sonnet',
   },
 
   'breaking-change-detector': {
@@ -86,7 +88,6 @@ If no breaking changes are found, return an empty array: []`,
       'mcp__qualops-agentic-tools__find_interface_changes',
       'mcp__qualops-agentic-tools__find_usages',
     ],
-    model: 'sonnet',
   },
 
   'security-analyzer': {
@@ -131,7 +132,6 @@ If no security issues are found, return an empty array: []`,
       'mcp__qualops-agentic-tools__find_usages',
       'mcp__qualops-agentic-tools__trace_imports',
     ],
-    model: 'sonnet',
   },
 
   'pattern-validator': {
@@ -167,7 +167,6 @@ Return issues in this JSON format:
 
 If no pattern violations are found, return an empty array: []`,
     tools: ['Read', 'Grep', 'Glob'],
-    model: 'haiku',
   },
 };
 
@@ -176,8 +175,9 @@ export function createSubagentDefinitions(config: AgenticConfig): Record<string,
     config.enabledSubagents || (Object.keys(SUBAGENT_DEFINITIONS) as AgenticSubagentType[]);
   const definitions: Record<string, AgentDefinition> = {};
 
-  for (const type of enabled) {
-    const def = SUBAGENT_DEFINITIONS[type];
+  for (const entry of enabled) {
+    const type = typeof entry === 'string' ? entry : entry.name;
+    const def = SUBAGENT_DEFINITIONS[type as AgenticSubagentType];
     if (def) {
       definitions[type] = { ...def };
     }

--- a/src/stages/review/processors/pipeline-executor.ts
+++ b/src/stages/review/processors/pipeline-executor.ts
@@ -41,7 +41,7 @@ export class PipelineExecutor {
     this.validationResolver = new ValidationResolver(this.config, aiProvider);
     this.dedupResolver = new DeduplicationResolver(this.config, aiProvider);
     this.aiProvider = aiProvider;
-    this.model = ConfigService.getInstance().getAIStageConfig('review').model;
+    this.model = ConfigService.getInstance().getResolvedStageConfig('review').model;
   }
 
   async execute(files: FileInfo[]): Promise<ReviewIssue[]> {

--- a/tests/unit/ai/providers/factory.spec.ts
+++ b/tests/unit/ai/providers/factory.spec.ts
@@ -33,7 +33,7 @@ describe('AIFactory', () => {
     clearGlobalAIProvider();
 
     mockConfigInstance = {
-      getAIStageConfig: jest.fn(),
+      getResolvedStageConfig: jest.fn(),
     } as any;
 
     jest.spyOn(ConfigService, 'getInstance').mockReturnValue(mockConfigInstance);
@@ -68,11 +68,11 @@ describe('AIFactory', () => {
         inputPerMillion: 3,
         outputPerMillion: 15,
       };
-      mockConfigInstance.getAIStageConfig.mockReturnValueOnce(stageConfig);
+      mockConfigInstance.getResolvedStageConfig.mockReturnValueOnce(stageConfig);
 
       const provider = await AIFactory.createForStage('review');
 
-      expect(mockConfigInstance.getAIStageConfig).toHaveBeenCalledWith('review');
+      expect(mockConfigInstance.getResolvedStageConfig).toHaveBeenCalledWith('review');
       expect(mockAnthropicProvider).toHaveBeenCalledWith(stageConfig);
       expect(provider.initialize).toHaveBeenCalled();
       expect(provider.name).toBe(AIProviderType.ANTHROPIC);
@@ -85,11 +85,11 @@ describe('AIFactory', () => {
         inputPerMillion: 2.5,
         outputPerMillion: 10,
       };
-      mockConfigInstance.getAIStageConfig.mockReturnValueOnce(stageConfig);
+      mockConfigInstance.getResolvedStageConfig.mockReturnValueOnce(stageConfig);
 
       const provider = await AIFactory.createForStage('analyze');
 
-      expect(mockConfigInstance.getAIStageConfig).toHaveBeenCalledWith('analyze');
+      expect(mockConfigInstance.getResolvedStageConfig).toHaveBeenCalledWith('analyze');
       expect(mockBedrockProvider).toHaveBeenCalledWith(stageConfig);
       expect(provider.initialize).toHaveBeenCalled();
       expect(provider.name).toBe(AIProviderType.BEDROCK);
@@ -102,11 +102,11 @@ describe('AIFactory', () => {
         inputPerMillion: 5,
         outputPerMillion: 15,
       };
-      mockConfigInstance.getAIStageConfig.mockReturnValueOnce(stageConfig);
+      mockConfigInstance.getResolvedStageConfig.mockReturnValueOnce(stageConfig);
 
       const provider = await AIFactory.createForStage('fix');
 
-      expect(mockConfigInstance.getAIStageConfig).toHaveBeenCalledWith('fix');
+      expect(mockConfigInstance.getResolvedStageConfig).toHaveBeenCalledWith('fix');
       expect(mockOpenAIProvider).toHaveBeenCalledWith(stageConfig);
       expect(provider.initialize).toHaveBeenCalled();
       expect(provider.name).toBe(AIProviderType.OPENAI);
@@ -119,11 +119,11 @@ describe('AIFactory', () => {
         inputPerMillion: 5,
         outputPerMillion: 15,
       };
-      mockConfigInstance.getAIStageConfig.mockReturnValueOnce(stageConfig);
+      mockConfigInstance.getResolvedStageConfig.mockReturnValueOnce(stageConfig);
 
       const provider = await AIFactory.createForStage('other');
 
-      expect(mockConfigInstance.getAIStageConfig).toHaveBeenCalledWith('other');
+      expect(mockConfigInstance.getResolvedStageConfig).toHaveBeenCalledWith('other');
       expect(mockGitHubProvider).toHaveBeenCalledWith(stageConfig);
       expect(provider.initialize).toHaveBeenCalled();
       expect(provider.name).toBe(AIProviderType.GITHUB);
@@ -136,7 +136,7 @@ describe('AIFactory', () => {
         inputPerMillion: 1,
         outputPerMillion: 1,
       };
-      mockConfigInstance.getAIStageConfig.mockReturnValue(stageConfig as any);
+      mockConfigInstance.getResolvedStageConfig.mockReturnValue(stageConfig as any);
 
       await expect(AIFactory.createForStage('review')).rejects.toThrow(
         'Unknown AI provider: unknown-provider',
@@ -150,7 +150,7 @@ describe('AIFactory', () => {
         inputPerMillion: 3,
         outputPerMillion: 15,
       };
-      mockConfigInstance.getAIStageConfig.mockReturnValue(stageConfig);
+      mockConfigInstance.getResolvedStageConfig.mockReturnValue(stageConfig);
 
       const provider1 = await AIFactory.createForStage('review');
       const provider2 = await AIFactory.createForStage('review');
@@ -167,7 +167,7 @@ describe('AIFactory', () => {
         inputPerMillion: 3,
         outputPerMillion: 15,
       };
-      mockConfigInstance.getAIStageConfig.mockReturnValue(stageConfig);
+      mockConfigInstance.getResolvedStageConfig.mockReturnValue(stageConfig);
 
       const provider1 = await AIFactory.createForStage('review');
       (provider1.isAvailable as jest.Mock).mockReturnValue(false);
@@ -192,7 +192,7 @@ describe('AIFactory', () => {
         outputPerMillion: 15,
       };
 
-      mockConfigInstance.getAIStageConfig
+      mockConfigInstance.getResolvedStageConfig
         .mockReturnValueOnce(reviewConfig)
         .mockReturnValueOnce(analyzeConfig);
 
@@ -205,7 +205,7 @@ describe('AIFactory', () => {
     });
 
     it('should throw error when stage config is not found', async () => {
-      mockConfigInstance.getAIStageConfig.mockImplementation(() => {
+      mockConfigInstance.getResolvedStageConfig.mockImplementation(() => {
         throw new Error('AI configuration for stage "invalid" not found in .qualopsrc.json');
       });
 
@@ -228,7 +228,7 @@ describe('AIFactory', () => {
         outputPerMillion: 15,
       };
 
-      mockConfigInstance.getAIStageConfig
+      mockConfigInstance.getResolvedStageConfig
         .mockReturnValueOnce(anthropicConfig)
         .mockReturnValueOnce(openaiConfig)
         .mockReturnValueOnce(anthropicConfig);
@@ -250,7 +250,7 @@ describe('AIFactory', () => {
         inputPerMillion: 3,
         outputPerMillion: 15,
       };
-      mockConfigInstance.getAIStageConfig.mockReturnValue(stageConfig);
+      mockConfigInstance.getResolvedStageConfig.mockReturnValue(stageConfig);
 
       await AIFactory.createForStage('review');
       AIFactory.clear();
@@ -266,7 +266,7 @@ describe('AIFactory', () => {
         inputPerMillion: 5,
         outputPerMillion: 15,
       };
-      mockConfigInstance.getAIStageConfig.mockReturnValue(stageConfig);
+      mockConfigInstance.getResolvedStageConfig.mockReturnValue(stageConfig);
 
       const provider1 = await AIFactory.createForStage('fix');
       AIFactory.clear();
@@ -328,7 +328,7 @@ describe('AIFactory', () => {
           inputPerMillion: 3,
           outputPerMillion: 15,
         };
-        mockConfigInstance.getAIStageConfig.mockReturnValue(stageConfig);
+        mockConfigInstance.getResolvedStageConfig.mockReturnValue(stageConfig);
 
         const provider = await initializeGlobalAIProviderForStage('review');
 
@@ -343,7 +343,7 @@ describe('AIFactory', () => {
           inputPerMillion: 5,
           outputPerMillion: 15,
         };
-        mockConfigInstance.getAIStageConfig.mockReturnValue(stageConfig);
+        mockConfigInstance.getResolvedStageConfig.mockReturnValue(stageConfig);
 
         await initializeGlobalAIProviderForStage('analyze');
         const provider = getGlobalAIProvider();
@@ -366,7 +366,7 @@ describe('AIFactory', () => {
           outputPerMillion: 15,
         };
 
-        mockConfigInstance.getAIStageConfig
+        mockConfigInstance.getResolvedStageConfig
           .mockReturnValueOnce(anthropicConfig)
           .mockReturnValueOnce(openaiConfig);
 
@@ -393,7 +393,7 @@ describe('AIFactory', () => {
           inputPerMillion: 2.5,
           outputPerMillion: 10,
         };
-        mockConfigInstance.getAIStageConfig.mockReturnValue(stageConfig);
+        mockConfigInstance.getResolvedStageConfig.mockReturnValue(stageConfig);
 
         await initializeGlobalAIProviderForStage('judge');
         const provider = getGlobalAIProvider();
@@ -408,7 +408,7 @@ describe('AIFactory', () => {
           inputPerMillion: 3,
           outputPerMillion: 15,
         };
-        mockConfigInstance.getAIStageConfig.mockReturnValue(stageConfig);
+        mockConfigInstance.getResolvedStageConfig.mockReturnValue(stageConfig);
 
         await initializeGlobalAIProviderForStage('review');
         clearGlobalAIProvider();
@@ -427,7 +427,7 @@ describe('AIFactory', () => {
           inputPerMillion: 5,
           outputPerMillion: 15,
         };
-        mockConfigInstance.getAIStageConfig.mockReturnValue(stageConfig);
+        mockConfigInstance.getResolvedStageConfig.mockReturnValue(stageConfig);
 
         await initializeGlobalAIProviderForStage('fix');
         clearGlobalAIProvider();
@@ -442,7 +442,7 @@ describe('AIFactory', () => {
           inputPerMillion: 3,
           outputPerMillion: 15,
         };
-        mockConfigInstance.getAIStageConfig.mockReturnValue(stageConfig);
+        mockConfigInstance.getResolvedStageConfig.mockReturnValue(stageConfig);
 
         await initializeGlobalAIProviderForStage('review');
         clearGlobalAIProvider();

--- a/tests/unit/ai/providers/openai.spec.ts
+++ b/tests/unit/ai/providers/openai.spec.ts
@@ -21,6 +21,14 @@ describe('OpenAIProvider', () => {
     outputPerMillion: 10.0,
   };
 
+  function envGet(apiKey: string, baseURL?: string) {
+    return (key: string) => {
+      if (key === 'openaiApiKey') return apiKey;
+      if (key === 'openaiApiBase') return baseURL;
+      return undefined;
+    };
+  }
+
   beforeEach(async () => {
     jest.clearAllMocks();
 
@@ -28,10 +36,7 @@ describe('OpenAIProvider', () => {
       envConfig: MockEnvConfig;
     };
     mockEnvConfig = {
-      get: jest.fn((key: string) => {
-        if (key === 'openaiApiKey') return 'sk-test-key';
-        return undefined;
-      }),
+      get: jest.fn(envGet('sk-test-key')),
       isDevelopment: jest.fn(() => false),
     };
     envConfig.envConfig = mockEnvConfig;
@@ -43,19 +48,33 @@ describe('OpenAIProvider', () => {
   });
 
   it('should throw when OPENAI_API_KEY is missing', () => {
-    mockEnvConfig.get.mockReturnValue('');
+    mockEnvConfig.get.mockImplementation(envGet(''));
     expect(() => new OpenAIProvider(validStageConfig)).toThrow(
       'OPENAI_API_KEY environment variable is required for openai provider',
     );
   });
 
   it.each(['invalid-key', 'github_pat_abc'])('should throw for invalid key format "%s"', (key) => {
-    mockEnvConfig.get.mockReturnValue(key);
+    mockEnvConfig.get.mockImplementation(envGet(key));
     expect(() => new OpenAIProvider(validStageConfig)).toThrow('Invalid OpenAI API key format');
   });
 
   it.each(['sk-abc', 'sk-proj-abc123', 'sk-org-xyz'])('should accept key "%s"', (key) => {
-    mockEnvConfig.get.mockReturnValue(key);
+    mockEnvConfig.get.mockImplementation(envGet(key));
+    expect(() => new OpenAIProvider(validStageConfig)).not.toThrow();
+  });
+
+  it('should throw for invalid OPENAI_BASE_URL', () => {
+    mockEnvConfig.get.mockImplementation(envGet('sk-test', 'not-a-url'));
+    expect(() => new OpenAIProvider(validStageConfig)).toThrow(
+      'OPENAI_BASE_URL must be a valid http/https URL',
+    );
+  });
+
+  it('should accept a valid OPENAI_BASE_URL', () => {
+    mockEnvConfig.get.mockImplementation(
+      envGet('sk-test', 'https://my-resource.openai.azure.com/openai/deployments/gpt-4o'),
+    );
     expect(() => new OpenAIProvider(validStageConfig)).not.toThrow();
   });
 });

--- a/tests/unit/config/config.spec.ts
+++ b/tests/unit/config/config.spec.ts
@@ -44,12 +44,12 @@ const mockLogger = logger as jest.Mocked<typeof logger>;
 /**
  * Minimal config that satisfies real schema validation. Use as a base and
  * spread extra sections on top when tests need specific fields populated.
+ * Preferred style: model as object, no top-level provider.
  */
 const VALID_MINIMAL_CONFIG = {
   ai: {
     reviewStage: {
-      provider: 'anthropic',
-      model: 'claude-sonnet-4-5-20250929',
+      model: { provider: 'anthropic', name: 'claude-sonnet-4-5-20250929' },
       inputPerMillion: 3,
       outputPerMillion: 15,
     },
@@ -426,7 +426,7 @@ describe('ConfigService', () => {
       );
     });
 
-    it('should throw error for missing provider', () => {
+    it('should not throw error when provider is absent (provider is now optional)', () => {
       const aiConfig = {
         fixStage: {
           model: 'gpt-4',
@@ -437,9 +437,164 @@ describe('ConfigService', () => {
       const instance = ConfigService.getInstance();
 
       instance.set('ai', aiConfig as Config['ai']);
-      expect(() => instance.getAIStageConfig('fix')).toThrow(
-        'Missing required AI config for stage "fix": provider',
+      expect(() => instance.getAIStageConfig('fix')).not.toThrow();
+    });
+  });
+
+  describe('resolveModel', () => {
+    it('returns default provider and model when called with no arguments', () => {
+      const instance = ConfigService.getInstance();
+      const result = instance.resolveModel();
+      expect(result).toEqual({ provider: 'anthropic', model: 'claude-sonnet-4-6' });
+    });
+
+    it('resolves stage with object model', () => {
+      const instance = ConfigService.getInstance();
+      const result = instance.resolveModel({
+        stage: {
+          model: { provider: 'openai', name: 'gpt-4o' } as any,
+          inputPerMillion: 2.5,
+          outputPerMillion: 10,
+        },
+      });
+      expect(result).toEqual({ provider: 'openai', model: 'gpt-4o' });
+    });
+
+    it('resolves stage with string model + deprecated provider field', () => {
+      const instance = ConfigService.getInstance();
+      const result = instance.resolveModel({
+        stage: {
+          provider: 'bedrock',
+          model: 'anthropic.claude-3-sonnet',
+          inputPerMillion: 3,
+          outputPerMillion: 15,
+        },
+      });
+      expect(result).toEqual({ provider: 'bedrock', model: 'anthropic.claude-3-sonnet' });
+    });
+
+    it('resolves ModelConfig string override using stage provider as fallback', () => {
+      const instance = ConfigService.getInstance();
+      const stage = {
+        provider: 'openai' as const,
+        model: 'gpt-4',
+        inputPerMillion: 2.5,
+        outputPerMillion: 10,
+      };
+      const result = instance.resolveModel({ model: 'gpt-4o-mini', stage });
+      expect(result).toEqual({ provider: 'openai', model: 'gpt-4o-mini' });
+    });
+
+    it('resolves ModelConfig object override directly', () => {
+      const instance = ConfigService.getInstance();
+      const result = instance.resolveModel({
+        model: { provider: 'bedrock', name: 'anthropic.claude-3' },
+      });
+      expect(result).toEqual({ provider: 'bedrock', model: 'anthropic.claude-3' });
+    });
+
+    it('uses default provider when ModelConfig string has no fallback stage', () => {
+      const instance = ConfigService.getInstance();
+      const result = instance.resolveModel({ model: 'some-model' });
+      expect(result).toEqual({ provider: 'anthropic', model: 'some-model' });
+    });
+  });
+
+  describe('getResolvedStageConfig', () => {
+    it('resolves when stage model is object form { provider, name }', () => {
+      const instance = ConfigService.getInstance();
+      instance.set('ai', {
+        reviewStage: {
+          model: { provider: 'openai', name: 'gpt-4o' } as any,
+          inputPerMillion: 2.5,
+          outputPerMillion: 10,
+        },
+      });
+      const result = instance.getResolvedStageConfig('review');
+      expect(result.provider).toBe('openai');
+      expect(result.model).toBe('gpt-4o');
+    });
+
+    it('resolves with string model + deprecated provider field', () => {
+      const instance = ConfigService.getInstance();
+      instance.set('ai', {
+        reviewStage: {
+          provider: 'bedrock' as const,
+          model: 'anthropic.claude-3-sonnet',
+          inputPerMillion: 3,
+          outputPerMillion: 15,
+        },
+      });
+      const result = instance.getResolvedStageConfig('review');
+      expect(result.provider).toBe('bedrock');
+      expect(result.model).toBe('anthropic.claude-3-sonnet');
+    });
+
+    it('throws when stage config is missing (delegates to getAIStageConfig)', () => {
+      const instance = ConfigService.getInstance();
+      instance.set('ai', {});
+      expect(() => instance.getResolvedStageConfig('review')).toThrow(
+        'AI configuration for stage "review" not found in .qualopsrc.json',
       );
+    });
+  });
+
+  describe('resolveAgentModel', () => {
+    const stageConfig = {
+      provider: 'anthropic' as const,
+      model: 'claude-sonnet-4-6',
+      inputPerMillion: 3,
+      outputPerMillion: 15,
+    };
+
+    it('returns stage model when enabledSubagents is absent', () => {
+      const instance = ConfigService.getInstance();
+      const result = instance.resolveAgentModel('security-analyzer', {}, stageConfig);
+      expect(result).toEqual({ provider: 'anthropic', model: 'claude-sonnet-4-6' });
+    });
+
+    it('applies enabledSubagents object override', () => {
+      const instance = ConfigService.getInstance();
+      const result = instance.resolveAgentModel(
+        'security-analyzer',
+        {
+          enabledSubagents: [
+            'dependency-tracer',
+            { name: 'security-analyzer', model: { provider: 'openai', name: 'gpt-4o' } },
+          ],
+        },
+        stageConfig,
+      );
+      expect(result).toEqual({ provider: 'openai', model: 'gpt-4o' });
+    });
+
+    it('applies enabledSubagents string model override, inheriting provider from stage', () => {
+      const instance = ConfigService.getInstance();
+      const result = instance.resolveAgentModel(
+        'security-analyzer',
+        { enabledSubagents: [{ name: 'security-analyzer', model: 'claude-haiku-4-5' }] },
+        stageConfig,
+      );
+      expect(result).toEqual({ provider: 'anthropic', model: 'claude-haiku-4-5' });
+    });
+
+    it('applies customAgents model override when enabledSubagents is absent', () => {
+      const instance = ConfigService.getInstance();
+      const result = instance.resolveAgentModel(
+        'my-agent',
+        {
+          customAgents: [
+            {
+              name: 'my-agent',
+              model: { provider: 'openai', name: 'gpt-4o' },
+              description: 'test',
+              prompt: 'test',
+            },
+          ],
+        },
+        stageConfig,
+      );
+      expect(result).toEqual({ provider: 'openai', model: 'gpt-4o' });
     });
   });
 

--- a/tests/unit/config/schema-validator.spec.ts
+++ b/tests/unit/config/schema-validator.spec.ts
@@ -8,8 +8,28 @@ import {
   collectConfigWarnings,
 } from '@/config/schema-validator';
 
-// Minimal valid config for tests
+// Minimal valid config for tests — preferred style: model as object, no top-level provider
 const minimalValidConfig = {
+  ai: {
+    reviewStage: {
+      model: { provider: 'anthropic', name: 'claude-sonnet-4-5-20250929' },
+      inputPerMillion: 3,
+      outputPerMillion: 15,
+    },
+  },
+  review: {
+    pipeline: [
+      {
+        name: 'test-job',
+        enabled: true,
+        passes: [{ name: 'test-pass', enabled: true, prompt: 'test.md' }],
+      },
+    ],
+  },
+};
+
+// Legacy style: provider + string model (deprecated fallback, still accepted)
+const legacyStyleConfig = {
   ai: {
     reviewStage: {
       provider: 'anthropic',
@@ -81,6 +101,117 @@ describe('assertValidConfig', () => {
           },
         },
         review: minimalValidConfig.review,
+      };
+      expect(() => assertValidConfig(config)).not.toThrow();
+    });
+
+    it('accepts old-style provider + string model (deprecated fallback)', () => {
+      expect(() => assertValidConfig(legacyStyleConfig)).not.toThrow();
+    });
+
+    it('accepts model as object { provider, name } without top-level provider', () => {
+      const config = {
+        ai: {
+          reviewStage: {
+            model: { provider: 'openai', name: 'gpt-4o' },
+            inputPerMillion: 2.5,
+            outputPerMillion: 10,
+          },
+        },
+        review: minimalValidConfig.review,
+      };
+      expect(() => assertValidConfig(config)).not.toThrow();
+    });
+
+    it('accepts enabledSubagents as plain string array (backward compat)', () => {
+      const config = {
+        ...minimalValidConfig,
+        review: {
+          pipeline: [
+            {
+              name: 'agentic-job',
+              enabled: true,
+              mode: 'agentic',
+              agentic: {
+                enabledSubagents: ['security-analyzer', 'dependency-tracer'],
+              },
+            },
+          ],
+        },
+      };
+      expect(() => assertValidConfig(config)).not.toThrow();
+    });
+
+    it('accepts enabledSubagents with model override objects', () => {
+      const config = {
+        ...minimalValidConfig,
+        review: {
+          pipeline: [
+            {
+              name: 'agentic-job',
+              enabled: true,
+              mode: 'agentic',
+              agentic: {
+                enabledSubagents: [
+                  'dependency-tracer',
+                  { name: 'security-analyzer', model: { provider: 'openai', name: 'gpt-4o' } },
+                ],
+              },
+            },
+          ],
+        },
+      };
+      expect(() => assertValidConfig(config)).not.toThrow();
+    });
+
+    it('accepts customAgents model as { provider, name } object', () => {
+      const config = {
+        ...minimalValidConfig,
+        review: {
+          pipeline: [
+            {
+              name: 'agentic-job',
+              enabled: true,
+              mode: 'agentic',
+              agentic: {
+                customAgents: [
+                  {
+                    name: 'my-agent',
+                    description: 'Custom agent',
+                    prompt: 'Do things.',
+                    model: { provider: 'openai', name: 'gpt-4o' },
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      };
+      expect(() => assertValidConfig(config)).not.toThrow();
+    });
+
+    it('accepts customAgents model as plain string', () => {
+      const config = {
+        ...minimalValidConfig,
+        review: {
+          pipeline: [
+            {
+              name: 'agentic-job',
+              enabled: true,
+              mode: 'agentic',
+              agentic: {
+                customAgents: [
+                  {
+                    name: 'my-agent',
+                    description: 'Custom agent',
+                    prompt: 'Do things.',
+                    model: 'gpt-4o',
+                  },
+                ],
+              },
+            },
+          ],
+        },
       };
       expect(() => assertValidConfig(config)).not.toThrow();
     });
@@ -164,6 +295,26 @@ describe('assertValidConfig', () => {
             },
           },
           review: minimalValidConfig.review,
+        }),
+      ).toThrow(ConfigValidationError);
+    });
+
+    it('throws when subagent override model object is missing name', () => {
+      expect(() =>
+        assertValidConfig({
+          ...minimalValidConfig,
+          review: {
+            pipeline: [
+              {
+                name: 'agentic-job',
+                enabled: true,
+                mode: 'agentic',
+                agentic: {
+                  enabledSubagents: [{ name: 'security-analyzer', model: { provider: 'openai' } }],
+                },
+              },
+            ],
+          },
         }),
       ).toThrow(ConfigValidationError);
     });

--- a/tests/unit/stages/review/agentic/loaders/agent-loader.spec.ts
+++ b/tests/unit/stages/review/agentic/loaders/agent-loader.spec.ts
@@ -10,7 +10,7 @@ beforeAll(() => {
   mkdirSync(agentsDir, { recursive: true });
   writeFileSync(
     join(agentsDir, 'test-agent.md'),
-    '---\ndescription: A test agent\ntools: [Read, Grep]\nmodel: sonnet\n---\nYou are a test agent.',
+    '---\ndescription: A test agent\ntools: [Read, Grep]\n---\nYou are a test agent.',
   );
 });
 
@@ -54,7 +54,7 @@ describe('AgentLoader', () => {
       expect(agent.description).toBe('A test agent');
       expect(agent.prompt).toBe('You are a test agent.');
       expect(agent.tools).toEqual(['Read', 'Grep']);
-      expect(agent.model).toBe('sonnet');
+      expect(agent.model).toBeUndefined();
     });
 
     it('skips markdown files with empty body', () => {
@@ -93,7 +93,7 @@ describe('AgentLoader', () => {
       expect(result['inline-agent'].description).toBe('An inline agent');
       expect(result['inline-agent'].prompt).toBe('Do things.');
       expect(result['inline-agent'].tools).toEqual(['Read', 'Grep', 'Glob']);
-      expect(result['inline-agent'].model).toBe('sonnet');
+      expect(result['inline-agent'].model).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
Introduces `ModelConfig = string | { provider, name }` as the unified model specification type across config and agentic subagents, enabling OpenAI/Bedrock users to specify provider-namespaced models

Full cascade in `ConfigService.resolveModel()`: ModelConfig object >
ModelConfig string + stage provider > AIStageConfig object model > AIStageConfig string model + deprecated provider field > defaults. Built-in subagents no longer hardcode a model tier; they inherit the stage model and can be overridden per-entry in `enabledSubagents`. Top-level `provider` on stage configs is now deprecated in favour of `model: { provider, name }`.