### PR TITLE
feat: openAI agentic mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BASE_REF: ${{ github.base_ref }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          CLAUDE_CODE_EXECUTABLE: ${{ github.workspace }}/node_modules/@anthropic-ai/claude-agent-sdk-linux-x64/claude
         run: |
           node dist/cli.js all \
             --base "origin/$BASE_REF" \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgrade eslint from 9.x to 10.x, migrate `eslint-plugin-import` to `eslint-plugin-import-x`
 
 ### Added
+- Agentic mode now supports OpenAI and Azure OpenAI providers via `@openai/agents`. Set `provider: "openai"` in your stage config to use the OpenAI adapter; set `OPENAI_BASE_URL` to an Azure endpoint and the correct Azure client is used automatically.
 - You can now specify a model and provider together in stage config using `model: { provider: "openai", name: "gpt-4o" }` instead of relying on a separate top-level `provider` field.
 - OpenTelemetry observability instrumentation across the full review pipeline (file-by-file, agentic, and eval runs), with auto-detection for Langfuse and generic OTLP backends. All span attributes are sanitized to prevent credential leakage.
 - Agentic jobs now support a `prompt` field for file-based prompt instructions, combined with the existing inline `systemPrompt`

--- a/evals/src/qualops-bridge/provider.ts
+++ b/evals/src/qualops-bridge/provider.ts
@@ -150,18 +150,10 @@ async function runPipelineReview(
   return executor.execute(files);
 }
 
-// Only works with anthropic provider (requires Claude Agent SDK).
 async function runAgenticReview(
   files: FileInfo[],
   config: EvalConfig,
 ): Promise<ReviewIssue[]> {
-  if (config.provider && config.provider !== 'anthropic') {
-    throw new Error(
-      `Agentic mode requires anthropic provider, got: ${config.provider}. ` +
-        'The Claude Agent SDK only supports Anthropic models.',
-    );
-  }
-
   const configuredJobs = ConfigLoader.getInstance().getEnabledJobs();
   const agenticJobs = configuredJobs.filter((j) => j.job.mode === 'agentic');
 

--- a/evals/src/reviewer.js
+++ b/evals/src/reviewer.js
@@ -129,9 +129,9 @@ async function runReviewForItem(itemInput, ctx) {
   const evalConfig = {
     name: `langfuse:${config.model}:${config.mode}`,
     mode: config.mode,
+    model: config.model,
     provider: config.provider,
     configPath: config.configPath,
-    ...(config.modelOverride && { model: config.modelOverride }),
     ...(repoCwd && { cwd: repoCwd }),
   };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.2.1",
       "license": "MIT",
       "dependencies": {
-        "@anthropic-ai/claude-agent-sdk": "^0.2.75",
+        "@anthropic-ai/claude-agent-sdk": "0.2.121",
         "@anthropic-ai/sdk": "^0.93.0",
         "@aws-sdk/client-bedrock-runtime": "^3.1008.0",
         "@langfuse/otel": "^5.1.0",
@@ -53,6 +53,10 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.121",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.121"
       }
     },
     "node_modules/@anthropic-ai/claude-agent-sdk": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@langfuse/otel": "^5.1.0",
         "@octokit/rest": "^22.0.1",
         "@octokit/webhooks-types": "^7.6.1",
+        "@openai/agents": "^0.8.5",
         "@opentelemetry/api": "^1.9.1",
         "@opentelemetry/exporter-trace-otlp-http": "^0.215.0",
         "@opentelemetry/sdk-node": "^0.216.0",
@@ -3177,6 +3178,72 @@
       "integrity": "sha512-S8u2cJzklBC0FgTwWVLaM8tMrDuDMVE4xiTK4EYXM9GntyvrdbSoxqDQa+Fh57CCNApyIpyeqPhhFEmHPfrXgw==",
       "license": "MIT"
     },
+    "node_modules/@openai/agents": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@openai/agents/-/agents-0.8.5.tgz",
+      "integrity": "sha512-OFA7XVV1qXE8lzatvQj080KdSArt8utBExFXRfD5B/R7KT0D+AVaKwg6nLoW3Gxb30vRkIUQf+MaW/Wz+gO3Yg==",
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.8.5",
+        "@openai/agents-openai": "0.8.5",
+        "@openai/agents-realtime": "0.8.5",
+        "debug": "^4.4.0",
+        "openai": "^6.26.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@openai/agents-core": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@openai/agents-core/-/agents-core-0.8.5.tgz",
+      "integrity": "sha512-qs9mmN+D+UmqEZo3qrvhhIIXIOgSvJPic0v4a+ruq+eYgcQMk3PY8lLcsdQwJit6zf2Wyfv1q2cX5m3jzWZpKw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "openai": "^6.26.0"
+      },
+      "optionalDependencies": {
+        "@modelcontextprotocol/sdk": "^1.26.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@openai/agents-openai": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@openai/agents-openai/-/agents-openai-0.8.5.tgz",
+      "integrity": "sha512-cGYmyiVy8ecgf2Vch0L/ekeNo3xuZsuWnRsxyv+w9ai9dgxUifdEQ6G3dtsjMLtmXVHRVGoO7mVBr+tKcilntw==",
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.8.5",
+        "debug": "^4.4.0",
+        "openai": "^6.26.0"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@openai/agents-realtime": {
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/@openai/agents-realtime/-/agents-realtime-0.8.5.tgz",
+      "integrity": "sha512-JqKVsR33OvKtTxRp5Ylhw8WfNvJ49ZIhlhMZlSVKqwR2Ks6JuxqFJ0zM9p7JIbTQDSlAZnmnZJv1qlItaildiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@openai/agents-core": "0.8.5",
+        "@types/ws": "^8.18.1",
+        "debug": "^4.4.0",
+        "ws": "^8.18.1"
+      },
+      "peerDependencies": {
+        "zod": "^4.0.0"
+      }
+    },
     "node_modules/@opentelemetry/api": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
@@ -6265,6 +6332,15 @@
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -12209,6 +12285,27 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "generate:schema": "tsx scripts/generate-config-schema.ts"
   },
   "dependencies": {
-    "@anthropic-ai/claude-agent-sdk": "^0.2.75",
+    "@anthropic-ai/claude-agent-sdk": "0.2.121",
     "@anthropic-ai/sdk": "^0.93.0",
     "@aws-sdk/client-bedrock-runtime": "^3.1008.0",
     "@langfuse/otel": "^5.1.0",
@@ -98,6 +98,10 @@
     "glob": "^13.0.6",
     "openai": "^6.27.0",
     "zod": "^4.3.6"
+  },
+  "optionalDependencies": {
+    "@anthropic-ai/claude-agent-sdk-linux-x64": "0.2.121",
+    "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.2.121"
   },
   "devDependencies": {
     "@types/diff": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "@langfuse/otel": "^5.1.0",
     "@octokit/rest": "^22.0.1",
     "@octokit/webhooks-types": "^7.6.1",
+    "@openai/agents": "^0.8.5",
     "@opentelemetry/api": "^1.9.1",
     "@opentelemetry/exporter-trace-otlp-http": "^0.215.0",
     "@opentelemetry/sdk-node": "^0.216.0",

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -184,7 +184,7 @@ export class ConfigService {
    * both fall back to defaults.
    */
   resolveModel({ stage, model }: { stage?: AIStageConfig; model?: ModelConfig } = {}): {
-    provider: string;
+    provider: AIProviderName;
     model: string;
   } {
     return {
@@ -193,7 +193,7 @@ export class ConfigService {
     };
   }
 
-  private resolveProvider(stage?: AIStageConfig, model?: ModelConfig): string {
+  private resolveProvider(stage?: AIStageConfig, model?: ModelConfig): AIProviderName {
     if (model !== undefined && model !== null && typeof model === 'object' && model.provider) {
       return model.provider;
     }
@@ -257,7 +257,7 @@ export class ConfigService {
   getResolvedStageConfig(stage: string): ResolvedStageConfig {
     const raw = this.getAIStageConfig(stage);
     const { provider, model } = this.resolveModel({ stage: raw });
-    return { ...raw, provider: provider as AIProviderName, model };
+    return { ...raw, provider, model };
   }
 
   /**

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -260,6 +260,19 @@ export class ConfigService {
     return { ...raw, provider: provider as AIProviderName, model };
   }
 
+  /**
+   * Maps a resolved provider name to the agent adapter type to use.
+   * Returns `undefined` for providers that do not yet support agentic mode.
+   */
+  resolveAgentAdapterType(provider: AIProviderName): 'anthropic' | 'openai' | undefined {
+    const mapping: Partial<Record<AIProviderName, 'anthropic' | 'openai'>> = {
+      anthropic: 'anthropic',
+      openai: 'openai',
+      github: 'openai', // GitHub Models uses an OpenAI-compatible API
+    };
+    return mapping[provider];
+  }
+
   isIssueMarkdownEnabled(): boolean {
     return this.config.report?.generateIssueMarkdown ?? false;
   }

--- a/src/scripts/resolve-issue.ts
+++ b/src/scripts/resolve-issue.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node --env-file=.env --experimental-strip-types
 
 import { readFile, writeFile } from 'fs/promises';
-import { resolve } from 'path';
 
 import { AIFactory } from '../ai/providers/factory';
 import { logger } from '../shared/utils/logger';
+import { resolveWithinCwd } from '../shared/utils/security';
 
 interface ParsedIssue {
   id: string;
@@ -103,8 +103,8 @@ async function resolveIssue(
   logger.info(`   Description: ${issue.description}`);
   logger.info(`   Confidence: ${issue.confidence}`);
 
-  const filePath = resolve(monorepoRoot, issue.file);
-  if (!filePath.startsWith(monorepoRoot.replace(/\/?$/, '/'))) {
+  const filePath = resolveWithinCwd(monorepoRoot, issue.file);
+  if (!filePath) {
     logger.error(`❌ Rejected path outside project root: ${issue.file}`);
     return;
   }

--- a/src/shared/utils/security.ts
+++ b/src/shared/utils/security.ts
@@ -1,9 +1,33 @@
-import { basename } from 'node:path';
+import { basename, resolve, join } from 'node:path';
 
 /**
  * Security utilities for input validation and sanitization in qualops
  * This file contains only the security functions actively used in the codebase
  */
+
+/**
+ * Resolves `filePath` relative to `cwd` and returns the absolute path only if
+ * it stays within `cwd`. Returns null if the path escapes the project root.
+ *
+ * Handles the prefix-bypass edge case: `/project/repo-evil` is NOT within
+ * `/project/repo` even though it starts with the same string.
+ */
+export function resolveWithinCwd(cwd: string, filePath: string): string | null {
+  const full = filePath.startsWith('/') ? filePath : join(cwd, filePath);
+  const resolved = resolve(full);
+  const cwdResolved = resolve(cwd);
+  const cwdPrefix = cwdResolved.replace(/\/?$/, '/');
+  if (resolved !== cwdResolved && !resolved.startsWith(cwdPrefix)) return null;
+  return resolved;
+}
+
+/**
+ * Returns true if the string is a safe git ref — non-empty and not starting
+ * with '-', which would otherwise be interpreted as a flag by git.
+ */
+export function isSafeGitRef(ref: string): boolean {
+  return ref.length > 0 && !ref.startsWith('-');
+}
 
 /**
  * Validates that a filename doesn't contain path traversal sequences

--- a/src/stages/review/agentic/adapters/agent-adapter.ts
+++ b/src/stages/review/agentic/adapters/agent-adapter.ts
@@ -1,0 +1,24 @@
+import type { ResolvedAgentDefinition } from '../subagents/definitions';
+
+export interface AgentAdapterParams {
+  systemPrompt: string;
+  userPrompt: string;
+  agents: Record<string, ResolvedAgentDefinition>;
+  model: string;
+  cwd: string;
+  maxTurns: number;
+  maxBudgetUsd?: number;
+  onToolCall?: (turn: number, name: string, input: unknown) => void;
+}
+
+export interface AgentAdapterResult {
+  output: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  /** Set when the agent run did not complete successfully (e.g. 'error_max_turns'). */
+  errorSubtype?: string;
+}
+
+export interface AgentAdapter {
+  run(params: AgentAdapterParams): Promise<AgentAdapterResult>;
+}

--- a/src/stages/review/agentic/adapters/anthropic-adapter.ts
+++ b/src/stages/review/agentic/adapters/anthropic-adapter.ts
@@ -11,10 +11,13 @@ export class AnthropicAdapter implements AgentAdapter {
 
     const toolServer = createAgenticTools(cwd);
 
+    const executablePath = process.env.CLAUDE_CODE_EXECUTABLE;
+
     const result = query({
       prompt: userPrompt,
       options: {
         systemPrompt,
+        ...(executablePath && { pathToClaudeCodeExecutable: executablePath }),
         allowedTools: [
           'Read',
           'Grep',

--- a/src/stages/review/agentic/adapters/anthropic-adapter.ts
+++ b/src/stages/review/agentic/adapters/anthropic-adapter.ts
@@ -1,0 +1,87 @@
+import { query } from '@anthropic-ai/claude-agent-sdk';
+
+import { createAgenticTools } from '../tools';
+import type { AgentAdapter, AgentAdapterParams, AgentAdapterResult } from './agent-adapter';
+import { logger } from '../../../../shared/utils/logger';
+
+export class AnthropicAdapter implements AgentAdapter {
+  async run(params: AgentAdapterParams): Promise<AgentAdapterResult> {
+    const { systemPrompt, userPrompt, agents, model, cwd, maxTurns, maxBudgetUsd, onToolCall } =
+      params;
+
+    const toolServer = createAgenticTools(cwd);
+
+    const result = query({
+      prompt: userPrompt,
+      options: {
+        systemPrompt,
+        allowedTools: [
+          'Read',
+          'Grep',
+          'Glob',
+          'mcp__qualops-agentic-tools__find_usages',
+          'mcp__qualops-agentic-tools__git_diff_analysis',
+          'mcp__qualops-agentic-tools__list_changed_files',
+        ],
+        mcpServers: {
+          'qualops-agentic-tools': toolServer,
+        },
+        agents,
+        maxTurns,
+        ...(maxBudgetUsd && { maxBudgetUsd }),
+        ...(model && { model }),
+        cwd,
+        permissionMode: 'bypassPermissions',
+      },
+    });
+
+    let output = '';
+    let inputTokens: number | undefined;
+    let outputTokens: number | undefined;
+    let errorSubtype: string | undefined;
+    let turnIndex = 0;
+
+    for await (const message of result) {
+      logger.info(
+        `[Agentic/Anthropic] Message: type=${message.type}, subtype=${'subtype' in message ? message.subtype : 'N/A'}`,
+      );
+
+      if (message.type === 'assistant') {
+        turnIndex++;
+        const content = 'message' in message ? message.message?.content : null;
+        if (content && Array.isArray(content)) {
+          for (const block of content) {
+            if (block.type === 'text') {
+              logger.info(
+                `[Agentic/Anthropic] Assistant text (first 200 chars): ${block.text.substring(0, 200)}`,
+              );
+            } else if (block.type === 'tool_use') {
+              logger.info(`[Agentic/Anthropic] Tool call: ${block.name}`);
+              onToolCall?.(turnIndex, block.name, block.input);
+            }
+          }
+        }
+      }
+
+      if (message.type === 'result') {
+        if (message.subtype === 'success' && message.result) {
+          logger.info(
+            `[Agentic/Anthropic] Success result (first 500 chars): ${message.result.substring(0, 500)}`,
+          );
+          output = message.result;
+          const usage =
+            'usage' in message
+              ? (message.usage as { input_tokens?: number; output_tokens?: number } | undefined)
+              : undefined;
+          inputTokens = usage?.input_tokens;
+          outputTokens = usage?.output_tokens;
+        } else if (message.subtype !== 'success') {
+          errorSubtype = message.subtype;
+          logger.error(`[Agentic/Anthropic] Agent error: ${message.subtype}`);
+        }
+      }
+    }
+
+    return { output, inputTokens, outputTokens, errorSubtype };
+  }
+}

--- a/src/stages/review/agentic/adapters/index.ts
+++ b/src/stages/review/agentic/adapters/index.ts
@@ -1,0 +1,22 @@
+import type { AgentAdapter } from './agent-adapter';
+import { AnthropicAdapter } from './anthropic-adapter';
+import { OpenAIAdapter } from './openai-adapter';
+import { ConfigService } from '../../../../config/config';
+import type { AIProviderName } from '../../../../shared/types';
+
+const ADAPTERS: Array<{ type: 'anthropic' | 'openai'; ctor: new () => AgentAdapter }> = [
+  { type: 'anthropic', ctor: AnthropicAdapter },
+  { type: 'openai', ctor: OpenAIAdapter },
+];
+
+export function createAgentAdapter(provider: AIProviderName): AgentAdapter {
+  const adapterType = ConfigService.getInstance().resolveAgentAdapterType(provider);
+  if (!adapterType) {
+    throw new Error(`Agentic mode is not implemented for provider: ${provider}`);
+  }
+  const entry = ADAPTERS.find((a) => a.type === adapterType);
+  if (!entry) {
+    throw new Error(`No adapter registered for type: ${adapterType}`);
+  }
+  return new entry.ctor();
+}

--- a/src/stages/review/agentic/adapters/openai-adapter.ts
+++ b/src/stages/review/agentic/adapters/openai-adapter.ts
@@ -1,0 +1,268 @@
+import { Agent, getGlobalTraceProvider, run, setDefaultOpenAIClient, tool } from '@openai/agents';
+import { z } from 'zod';
+
+import type { AgentAdapter, AgentAdapterParams, AgentAdapterResult } from './agent-adapter';
+import { envConfig } from '../../../../config/env';
+import { logger } from '../../../../shared/utils/logger';
+import {
+  analyzeExports,
+  findInterfaceChanges,
+  findUsages,
+  gitDiffAnalysis,
+  globFiles,
+  grepFiles,
+  listChangedFiles,
+  readFile,
+  traceImports,
+} from '../tools/handlers';
+
+export class OpenAIAdapter implements AgentAdapter {
+  async run(params: AgentAdapterParams): Promise<AgentAdapterResult> {
+    const { systemPrompt, userPrompt, agents, model, cwd, maxTurns, onToolCall } = params;
+
+    await configureOpenAIClient();
+    getGlobalTraceProvider().setDisabled(true);
+
+    const tools = buildOpenAITools(cwd, onToolCall);
+
+    const handoffs = Object.entries(agents).map(([name, def]) => {
+      const agentTools = def.tools ? tools.filter((t) => def.tools!.includes(t.name)) : tools;
+      return new Agent({
+        name,
+        model: def.model ?? model,
+        instructions: def.prompt,
+        tools: agentTools,
+      });
+    });
+
+    const orchestrator = new Agent({
+      name: 'qualops-reviewer',
+      model,
+      instructions: systemPrompt,
+      tools,
+      handoffs,
+    });
+
+    logger.info(`[Agentic/OpenAI] Starting run with model=${model}, maxTurns=${maxTurns}`);
+
+    const result = await run(orchestrator, userPrompt, { maxTurns });
+
+    const output =
+      typeof result.finalOutput === 'string'
+        ? result.finalOutput
+        : result.finalOutput != null
+          ? JSON.stringify(result.finalOutput)
+          : '';
+
+    const usage = result.state.usage;
+
+    logger.info(
+      `[Agentic/OpenAI] Run complete. inputTokens=${usage.inputTokens}, outputTokens=${usage.outputTokens}`,
+    );
+
+    return {
+      output,
+      inputTokens: usage.inputTokens,
+      outputTokens: usage.outputTokens,
+    };
+  }
+}
+
+async function configureOpenAIClient(): Promise<void> {
+  const apiKey = envConfig.get('openaiApiKey') || '';
+  const baseURL = envConfig.get('openaiApiBase');
+
+  const { default: OpenAI, AzureOpenAI } = await import('openai');
+
+  // Azure URLs follow the pattern: https://{resource}.openai.azure.com/openai/deployments/{deployment}
+  // When detected, use AzureOpenAI with baseURL set to the resource root so that api-version
+  // is injected automatically. We pass baseURL explicitly to avoid conflicts with OPENAI_BASE_URL.
+  const azureMatch = baseURL?.match(
+    /^(https:\/\/[^/]+\.openai\.azure\.com)(\/openai\/deployments\/[^/?]+)?/,
+  );
+  if (azureMatch) {
+    const azureBaseURL = `${azureMatch[1]}/openai`;
+    setDefaultOpenAIClient(
+      new AzureOpenAI({ apiKey, baseURL: azureBaseURL, apiVersion: '2025-03-01-preview' }),
+    );
+  } else {
+    setDefaultOpenAIClient(new OpenAI({ apiKey, baseURL }));
+  }
+}
+
+function buildOpenAITools(cwd: string, onToolCall?: AgentAdapterParams['onToolCall']) {
+  let turnIndex = 0;
+
+  function trackCall(name: string, input: unknown) {
+    turnIndex++;
+    logger.info(`[Agentic/OpenAI] Tool call: ${name}`);
+    onToolCall?.(turnIndex, name, input);
+  }
+
+  return [
+    tool({
+      name: 'read_file',
+      description: 'Read the full contents of a file',
+      parameters: z.object({
+        filePath: z.string().describe('Path to the file (relative to cwd or absolute)'),
+      }),
+      execute: async ({ filePath }) => {
+        trackCall('read_file', { filePath });
+        return readFile(cwd, filePath);
+      },
+    }),
+
+    tool({
+      name: 'grep_files',
+      description: 'Search files for a regex pattern using ripgrep',
+      parameters: z.object({
+        pattern: z.string().describe('Regex pattern to search for'),
+        glob: z
+          .string()
+          .nullable()
+          .default(null)
+          .describe('Glob pattern to filter files (e.g. "*.ts"), or null'),
+        ignoreCase: z
+          .boolean()
+          .nullable()
+          .default(null)
+          .describe('Case-insensitive search, or null'),
+      }),
+      execute: async ({ pattern, glob, ignoreCase }) => {
+        trackCall('grep_files', { pattern, glob, ignoreCase });
+        return grepFiles(cwd, pattern, glob ?? undefined, ignoreCase ?? undefined);
+      },
+    }),
+
+    tool({
+      name: 'glob_files',
+      description: 'Find files matching a glob pattern',
+      parameters: z.object({
+        pattern: z.string().describe('Glob pattern to match files'),
+      }),
+      execute: async ({ pattern }) => {
+        trackCall('glob_files', { pattern });
+        return globFiles(cwd, pattern);
+      },
+    }),
+
+    tool({
+      name: 'find_usages',
+      description:
+        'Find all usages of a symbol (function, class, variable, type) across the codebase using ripgrep',
+      parameters: z.object({
+        symbol: z.string().describe('The symbol name to search for (exact word match)'),
+        scope: z
+          .string()
+          .nullable()
+          .default(null)
+          .describe('Limit search to this directory path, or null'),
+        fileType: z
+          .string()
+          .nullable()
+          .default(null)
+          .describe('File type filter (e.g., ts, js, tsx), or null'),
+      }),
+      execute: async ({ symbol, scope, fileType }) => {
+        trackCall('find_usages', { symbol, scope, fileType });
+        return findUsages(cwd, symbol, scope ?? undefined, fileType ?? undefined);
+      },
+    }),
+
+    tool({
+      name: 'trace_imports',
+      description:
+        'Trace import/export dependencies for a TypeScript file. Returns what the file imports and which files import it.',
+      parameters: z.object({
+        filePath: z.string().describe('Path to the file to analyze (relative to cwd)'),
+      }),
+      execute: async ({ filePath }) => {
+        trackCall('trace_imports', { filePath });
+        return traceImports(cwd, filePath);
+      },
+    }),
+
+    tool({
+      name: 'git_diff_analysis',
+      description:
+        'Get detailed git diff for a commit range or specific file. Shows added/removed/modified lines.',
+      parameters: z.object({
+        base: z.string().describe('Base commit or branch (e.g., main, HEAD~1)'),
+        head: z
+          .string()
+          .nullable()
+          .default(null)
+          .describe('Head commit or branch (defaults to HEAD), or null'),
+        file: z.string().nullable().default(null).describe('Specific file to diff, or null'),
+        stat: z.boolean().nullable().default(null).describe('Show diff stats only, or null'),
+      }),
+      execute: async ({ base, head, file, stat }) => {
+        trackCall('git_diff_analysis', { base, head, file, stat });
+        return gitDiffAnalysis(cwd, base, head ?? undefined, file ?? undefined, stat ?? undefined);
+      },
+    }),
+
+    tool({
+      name: 'analyze_exports',
+      description:
+        'Analyze public exports from a TypeScript file and optionally compare with a previous version to detect breaking changes.',
+      parameters: z.object({
+        filePath: z.string().describe('Path to the file to analyze'),
+        compareWithRef: z
+          .string()
+          .nullable()
+          .default(null)
+          .describe('Git ref to compare with (e.g., main, HEAD~1), or null'),
+      }),
+      execute: async ({ filePath, compareWithRef }) => {
+        trackCall('analyze_exports', { filePath, compareWithRef });
+        return analyzeExports(cwd, filePath, compareWithRef ?? undefined);
+      },
+    }),
+
+    tool({
+      name: 'find_interface_changes',
+      description: 'Find changes to TypeScript interfaces or types between two git refs',
+      parameters: z.object({
+        base: z.string().describe('Base git ref'),
+        head: z
+          .string()
+          .nullable()
+          .default(null)
+          .describe('Head git ref (defaults to HEAD), or null'),
+        interfaceName: z
+          .string()
+          .nullable()
+          .default(null)
+          .describe('Specific interface to check, or null'),
+      }),
+      execute: async ({ base, head, interfaceName }) => {
+        trackCall('find_interface_changes', { base, head, interfaceName });
+        return findInterfaceChanges(cwd, base, head ?? undefined, interfaceName ?? undefined);
+      },
+    }),
+
+    tool({
+      name: 'list_changed_files',
+      description:
+        'List all files changed between two git refs with change type (added/modified/deleted)',
+      parameters: z.object({
+        base: z.string().describe('Base git ref'),
+        head: z
+          .string()
+          .nullable()
+          .default(null)
+          .describe('Head git ref (defaults to HEAD), or null'),
+        filter: z
+          .string()
+          .nullable()
+          .default(null)
+          .describe('Filter by status: A=added, M=modified, D=deleted, or null'),
+      }),
+      execute: async ({ base, head, filter }) => {
+        trackCall('list_changed_files', { base, head, filter });
+        return listChangedFiles(cwd, base, head ?? undefined, filter ?? undefined);
+      },
+    }),
+  ];
+}

--- a/src/stages/review/agentic/agentic-executor.ts
+++ b/src/stages/review/agentic/agentic-executor.ts
@@ -1,6 +1,6 @@
-import { query } from '@anthropic-ai/claude-agent-sdk';
 import { context } from '@opentelemetry/api';
 
+import { createAgentAdapter } from './adapters';
 import { AgentLoader } from './loaders/agent-loader';
 import { buildUserPrompt } from './prompt-builder';
 import { parseIssuesFromResult } from './result-parser';
@@ -9,7 +9,6 @@ import {
   type AgentDefinition,
   type ResolvedAgentDefinition,
 } from './subagents/definitions';
-import { createAgenticTools } from './tools';
 import { ConfigService } from '../../../config/config';
 import {
   getTracer,
@@ -61,8 +60,6 @@ export class AgenticExecutor {
       return [];
     }
 
-    const toolServer = createAgenticTools(this.cwd);
-
     const builtInAgents = createSubagentDefinitions(this.config);
     const customAgents = this.agentLoader.loadCustomAgents(this.config);
 
@@ -73,8 +70,6 @@ export class AgenticExecutor {
     const agentNames = Object.keys(allAgents);
     logger.info(`[Agentic] Available agents: ${agentNames.join(', ')}`);
     logger.info(`[Agentic] Custom agents: ${Object.keys(customAgents).join(', ') || 'none'}`);
-
-    const _enabledSubagents = this.config.enabledSubagents || [];
 
     const systemPrompt = await this.buildSystemPrompt(allAgents);
     const userPrompt = buildUserPrompt(files, this.config);
@@ -95,78 +90,42 @@ export class AgenticExecutor {
     let turnIndex = 0;
 
     try {
-      const result = query({
-        prompt: userPrompt,
-        options: {
-          systemPrompt,
-          allowedTools: [
-            'Read',
-            'Grep',
-            'Glob',
-            'mcp__qualops-agentic-tools__find_usages',
-            'mcp__qualops-agentic-tools__git_diff_analysis',
-            'mcp__qualops-agentic-tools__list_changed_files',
-          ],
-          mcpServers: {
-            'qualops-agentic-tools': toolServer,
-          },
-          agents: allAgents as Record<string, ResolvedAgentDefinition>,
-          maxTurns: this.config.maxTurns || 100,
-          ...(this.config.maxBudgetUsd && { maxBudgetUsd: this.config.maxBudgetUsd }),
-          ...(this.model && { model: this.model }),
-          cwd: this.cwd,
-          permissionMode: 'bypassPermissions',
+      const stageConfig = ConfigService.getInstance().getResolvedStageConfig('review');
+      const adapter = createAgentAdapter(stageConfig.provider);
+
+      logger.info(`[Agentic] Using adapter for provider: ${stageConfig.provider}`);
+
+      const result = await adapter.run({
+        systemPrompt,
+        userPrompt,
+        agents: allAgents,
+        model: this.model,
+        cwd: this.cwd,
+        maxTurns: this.config.maxTurns || 100,
+        maxBudgetUsd: this.config.maxBudgetUsd,
+        onToolCall: (turn, name, input) => {
+          turnIndex = turn;
+          allToolCalls.push({ turn, name, input });
         },
       });
 
-      for await (const message of result) {
+      setTokenUsage(agenticSpan, {
+        model: this.model,
+        inputTokens: result.inputTokens,
+        outputTokens: result.outputTokens,
+      });
+      setObservationIO(agenticSpan, {
+        input: { systemPrompt, userPrompt, toolCalls: allToolCalls },
+        output: result.errorSubtype ? { error: result.errorSubtype } : result.output,
+      });
+
+      if (result.output) {
         logger.info(
-          `[Agentic] Message: type=${message.type}, subtype=${'subtype' in message ? message.subtype : 'N/A'}`,
+          `[Agentic] Success result (first 500 chars): ${result.output.substring(0, 500)}`,
         );
-
-        if (message.type === 'assistant') {
-          turnIndex++;
-          const content = 'message' in message ? message.message?.content : null;
-          if (content && Array.isArray(content)) {
-            for (const block of content) {
-              if (block.type === 'text') {
-                logger.info(
-                  `[Agentic] Assistant text (first 200 chars): ${block.text.substring(0, 200)}`,
-                );
-              } else if (block.type === 'tool_use') {
-                logger.info(`[Agentic] Tool call: ${block.name}`);
-                allToolCalls.push({ turn: turnIndex, name: block.name, input: block.input });
-              }
-            }
-          }
-        }
-
-        if (message.type === 'result') {
-          if (message.subtype === 'success' && message.result) {
-            logger.info(
-              `[Agentic] Success result (first 500 chars): ${message.result.substring(0, 500)}`,
-            );
-            const usage =
-              'usage' in message
-                ? (message.usage as { input_tokens?: number; output_tokens?: number } | undefined)
-                : undefined;
-            setTokenUsage(agenticSpan, {
-              model: this.model,
-              inputTokens: usage?.input_tokens,
-              outputTokens: usage?.output_tokens,
-            });
-            setObservationIO(agenticSpan, {
-              input: { systemPrompt, userPrompt, toolCalls: allToolCalls },
-              output: message.result,
-            });
-            const parsed = parseIssuesFromResult(message.result, files, this.job.name, this.cwd);
-            issues.push(...parsed);
-            logger.info(`[Agentic] Parsed ${parsed.length} issues from result`);
-          } else if (message.subtype !== 'success') {
-            setObservationIO(agenticSpan, { output: { error: message.subtype } });
-            logger.error(`[Agentic] Agent error: ${message.subtype}`);
-          }
-        }
+        const parsed = parseIssuesFromResult(result.output, files, this.job.name, this.cwd);
+        issues.push(...parsed);
+        logger.info(`[Agentic] Parsed ${parsed.length} issues from result`);
       }
     } catch (error) {
       logger.error(

--- a/src/stages/review/agentic/loaders/agent-loader.ts
+++ b/src/stages/review/agentic/loaders/agent-loader.ts
@@ -3,6 +3,7 @@ import { join, basename, resolve } from 'node:path';
 
 import type { AgenticConfig, CustomAgentDefinition } from '../../../../shared/types/config';
 import { logger } from '../../../../shared/utils/logger';
+import { resolveWithinCwd } from '../../../../shared/utils/security';
 import type { AgentDefinition } from '../subagents/definitions';
 
 interface MarkdownAgentFrontmatter {
@@ -31,9 +32,9 @@ export class AgentLoader {
 
     // Load from agents directory
     const agentsDir = config.agentsDir || '.qualops/agents';
-    const fullAgentsDir = resolve(this.cwd, agentsDir);
+    const fullAgentsDir = resolveWithinCwd(this.cwd, agentsDir);
 
-    if (!fullAgentsDir.startsWith(this.cwd)) {
+    if (!fullAgentsDir) {
       logger.warn(
         `[AgentLoader] agentsDir "${agentsDir}" resolves outside project directory. Path traversal is not allowed.`,
       );
@@ -59,7 +60,7 @@ export class AgentLoader {
   }
 
   private loadAgentFromMarkdown(filePath: string): AgentDefinition | null {
-    if (!resolve(filePath).startsWith(this.cwd)) {
+    if (!resolveWithinCwd(this.cwd, filePath)) {
       logger.warn(`[AgentLoader] Rejected agent path outside project directory: ${filePath}`);
       return null;
     }

--- a/src/stages/review/agentic/loaders/agent-loader.ts
+++ b/src/stages/review/agentic/loaders/agent-loader.ts
@@ -1,7 +1,6 @@
 import { readFileSync, readdirSync, existsSync } from 'node:fs';
 import { join, basename, resolve } from 'node:path';
 
-import type { ModelConfig } from '../../../../shared/types';
 import type { AgenticConfig, CustomAgentDefinition } from '../../../../shared/types/config';
 import { logger } from '../../../../shared/utils/logger';
 import type { AgentDefinition } from '../subagents/definitions';
@@ -127,7 +126,7 @@ export class AgentLoader {
       description: custom.description,
       prompt: custom.prompt,
       tools: custom.tools || ['Read', 'Grep', 'Glob'],
-      model: custom.model as ModelConfig | undefined,
+      model: custom.model,
     };
   }
 }

--- a/src/stages/review/agentic/subagents/definitions.ts
+++ b/src/stages/review/agentic/subagents/definitions.ts
@@ -177,9 +177,8 @@ export function createSubagentDefinitions(config: AgenticConfig): Record<string,
 
   for (const entry of enabled) {
     const type = typeof entry === 'string' ? entry : entry.name;
-    const def = SUBAGENT_DEFINITIONS[type as AgenticSubagentType];
-    if (def) {
-      definitions[type] = { ...def };
+    if (type in SUBAGENT_DEFINITIONS) {
+      definitions[type] = { ...SUBAGENT_DEFINITIONS[type as AgenticSubagentType] };
     }
   }
 

--- a/src/stages/review/agentic/tools/handlers.ts
+++ b/src/stages/review/agentic/tools/handlers.ts
@@ -1,22 +1,40 @@
-import { execSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
 import type { DependencyTrace, ExportComparison } from '../types';
 
+// ─── Safe command execution ────────────────────────────────────────────────────
+
+/**
+ * Runs a command without a shell, passing args as an array to avoid injection.
+ * Returns stdout on success, or throws with the stderr/status attached.
+ */
+function runSafe(cmd: string, args: string[], cwd: string, maxBuffer = 10 * 1024 * 1024): string {
+  const result = spawnSync(cmd, args, {
+    encoding: 'utf-8',
+    cwd,
+    maxBuffer,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    const err = new Error(result.stderr?.trim() || `Command exited with status ${result.status}`);
+    (err as NodeJS.ErrnoException & { status?: number }).status = result.status ?? undefined;
+    throw err;
+  }
+  return result.stdout;
+}
+
 // ─── Custom tools ─────────────────────────────────────────────────────────────
 
 export function findUsages(cwd: string, symbol: string, scope?: string, fileType?: string): string {
   const searchPath = scope || cwd;
-  const typeArg = fileType ? `--type ${fileType}` : '--type ts --type tsx';
+  const typeArgs = fileType ? ['--type', fileType] : ['--type', 'ts', '--type', 'tsx'];
 
   try {
     return (
-      execSync(`rg -n --word-regexp "${symbol}" ${searchPath} ${typeArg}`, {
-        encoding: 'utf-8',
-        cwd,
-        maxBuffer: 10 * 1024 * 1024,
-      }) || 'No usages found'
+      runSafe('rg', ['-n', '--word-regexp', symbol, searchPath, ...typeArgs], cwd) ||
+      'No usages found'
     );
   } catch (error) {
     const execError = error as { status?: number; message?: string };
@@ -49,17 +67,14 @@ export function gitDiffAnalysis(
   stat?: boolean,
 ): string {
   const headRef = head || 'HEAD';
-  const fileArg = file ? `-- ${file}` : '';
-  const statArg = stat ? '--stat' : '';
+
+  const args = ['diff'];
+  if (stat) args.push('--stat');
+  args.push(`${base}...${headRef}`);
+  if (file) args.push('--', file);
 
   try {
-    return (
-      execSync(`git diff ${statArg} ${base}...${headRef} ${fileArg}`, {
-        encoding: 'utf-8',
-        cwd,
-        maxBuffer: 10 * 1024 * 1024,
-      }) || 'No differences found'
-    );
+    return runSafe('git', args, cwd) || 'No differences found';
   } catch (error) {
     return `Error: ${(error as Error).message}`;
   }
@@ -79,10 +94,7 @@ export function analyzeExports(cwd: string, filePath: string, compareWithRef?: s
 
   if (compareWithRef) {
     try {
-      const oldContent = execSync(`git show ${compareWithRef}:${filePath}`, {
-        encoding: 'utf-8',
-        cwd,
-      });
+      const oldContent = runSafe('git', ['show', `${compareWithRef}:${filePath}`], cwd);
       const oldExports = extractExports(oldContent);
       comparison = compareExportSets(oldExports, currentExports);
     } catch {
@@ -101,16 +113,16 @@ export function findInterfaceChanges(
 ): string {
   const headRef = head || 'HEAD';
   const grepPattern = interfaceName
-    ? `"(interface|type)\\s+${interfaceName}"`
-    : '"(interface|type)\\s+\\w+"';
+    ? `(interface|type)\\s+${interfaceName}`
+    : '(interface|type)\\s+\\w+';
 
   try {
     return (
-      execSync(`git diff ${base}...${headRef} --unified=5 -G ${grepPattern} -- "*.ts" "*.tsx"`, {
-        encoding: 'utf-8',
+      runSafe(
+        'git',
+        ['diff', `${base}...${headRef}`, '--unified=5', `-G${grepPattern}`, '--', '*.ts', '*.tsx'],
         cwd,
-        maxBuffer: 10 * 1024 * 1024,
-      }) || 'No interface changes found'
+      ) || 'No interface changes found'
     );
   } catch (error) {
     return `Error: ${(error as Error).message}`;
@@ -124,15 +136,12 @@ export function listChangedFiles(
   filter?: string,
 ): string {
   const headRef = head || 'HEAD';
-  const filterArg = filter ? `--diff-filter=${filter}` : '';
+  const args = ['diff', '--name-status'];
+  if (filter) args.push(`--diff-filter=${filter}`);
+  args.push(`${base}...${headRef}`);
 
   try {
-    return (
-      execSync(`git diff --name-status ${filterArg} ${base}...${headRef}`, {
-        encoding: 'utf-8',
-        cwd,
-      }) || 'No changed files'
-    );
+    return runSafe('git', args, cwd) || 'No changed files';
   } catch (error) {
     return `Error: ${(error as Error).message}`;
   }
@@ -166,17 +175,13 @@ export function grepFiles(
   glob?: string,
   ignoreCase?: boolean,
 ): string {
-  const caseFlag = ignoreCase ? '-i' : '';
-  const globArg = glob ? `--glob "${glob}"` : '';
+  const args = ['-n'];
+  if (ignoreCase) args.push('-i');
+  if (glob) args.push('--glob', glob);
+  args.push(pattern, cwd);
 
   try {
-    return (
-      execSync(`rg -n ${caseFlag} ${globArg} "${pattern}" ${cwd}`, {
-        encoding: 'utf-8',
-        cwd,
-        maxBuffer: 10 * 1024 * 1024,
-      }) || 'No matches found'
-    );
+    return runSafe('rg', args, cwd) || 'No matches found';
   } catch (error) {
     const execError = error as { status?: number; message?: string };
     if (execError.status === 1) return 'No matches found';
@@ -186,11 +191,11 @@ export function grepFiles(
 
 export function globFiles(cwd: string, pattern: string): string {
   try {
-    const result = execSync(`find ${cwd} -path "${pattern}" -not -path "*/node_modules/*"`, {
-      encoding: 'utf-8',
+    const result = runSafe(
+      'find',
+      [cwd, '-path', pattern, '-not', '-path', '*/node_modules/*'],
       cwd,
-      maxBuffer: 10 * 1024 * 1024,
-    });
+    );
     return result.trim() || 'No files found';
   } catch (error) {
     return `Error: ${(error as Error).message}`;
@@ -245,12 +250,14 @@ function findImportingFiles(targetPath: string, cwd: string): string[] {
       ?.replace(/\.[^.]+$/, '') || '';
 
   try {
-    const result = execSync(`rg -l "${fileName}" --type ts ${cwd} 2>/dev/null || true`, {
+    const result = spawnSync('rg', ['-l', fileName, '--type', 'ts', cwd], {
       encoding: 'utf-8',
       cwd,
-      shell: '/bin/bash',
     });
-    return result
+    if (result.error) return [];
+    // exit code 1 = no matches (not an error)
+    if (result.status !== 0 && result.status !== 1) return [];
+    return (result.stdout ?? '')
       .trim()
       .split('\n')
       .filter((f) => f && f !== targetPath);

--- a/src/stages/review/agentic/tools/handlers.ts
+++ b/src/stages/review/agentic/tools/handlers.ts
@@ -1,0 +1,271 @@
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
+
+import type { DependencyTrace, ExportComparison } from '../types';
+
+// ─── Custom tools ─────────────────────────────────────────────────────────────
+
+export function findUsages(cwd: string, symbol: string, scope?: string, fileType?: string): string {
+  const searchPath = scope || cwd;
+  const typeArg = fileType ? `--type ${fileType}` : '--type ts --type tsx';
+
+  try {
+    return (
+      execSync(`rg -n --word-regexp "${symbol}" ${searchPath} ${typeArg}`, {
+        encoding: 'utf-8',
+        cwd,
+        maxBuffer: 10 * 1024 * 1024,
+      }) || 'No usages found'
+    );
+  } catch (error) {
+    const execError = error as { status?: number; message?: string };
+    if (execError.status === 1) return 'No usages found';
+    return `Error: ${execError.message || 'Unknown error'}`;
+  }
+}
+
+export function traceImports(cwd: string, filePath: string): string {
+  const fullPath = filePath.startsWith('/') ? filePath : `${cwd}/${filePath}`;
+
+  if (!existsSync(fullPath)) {
+    return `File not found: ${filePath}`;
+  }
+
+  const content = readFileSync(fullPath, 'utf-8');
+  const imports = extractImports(content);
+  const exports = extractExports(content);
+  const importedBy = findImportingFiles(filePath, cwd);
+
+  const result: DependencyTrace = { filePath, imports, importedBy, exports };
+  return JSON.stringify(result, null, 2);
+}
+
+export function gitDiffAnalysis(
+  cwd: string,
+  base: string,
+  head?: string,
+  file?: string,
+  stat?: boolean,
+): string {
+  const headRef = head || 'HEAD';
+  const fileArg = file ? `-- ${file}` : '';
+  const statArg = stat ? '--stat' : '';
+
+  try {
+    return (
+      execSync(`git diff ${statArg} ${base}...${headRef} ${fileArg}`, {
+        encoding: 'utf-8',
+        cwd,
+        maxBuffer: 10 * 1024 * 1024,
+      }) || 'No differences found'
+    );
+  } catch (error) {
+    return `Error: ${(error as Error).message}`;
+  }
+}
+
+export function analyzeExports(cwd: string, filePath: string, compareWithRef?: string): string {
+  const fullPath = filePath.startsWith('/') ? filePath : `${cwd}/${filePath}`;
+
+  if (!existsSync(fullPath)) {
+    return `File not found: ${filePath}`;
+  }
+
+  const currentContent = readFileSync(fullPath, 'utf-8');
+  const currentExports = extractExports(currentContent);
+
+  let comparison: ExportComparison | null = null;
+
+  if (compareWithRef) {
+    try {
+      const oldContent = execSync(`git show ${compareWithRef}:${filePath}`, {
+        encoding: 'utf-8',
+        cwd,
+      });
+      const oldExports = extractExports(oldContent);
+      comparison = compareExportSets(oldExports, currentExports);
+    } catch {
+      comparison = { added: currentExports, removed: [], modified: [] };
+    }
+  }
+
+  return JSON.stringify({ filePath, exports: currentExports, comparison }, null, 2);
+}
+
+export function findInterfaceChanges(
+  cwd: string,
+  base: string,
+  head?: string,
+  interfaceName?: string,
+): string {
+  const headRef = head || 'HEAD';
+  const grepPattern = interfaceName
+    ? `"(interface|type)\\s+${interfaceName}"`
+    : '"(interface|type)\\s+\\w+"';
+
+  try {
+    return (
+      execSync(`git diff ${base}...${headRef} --unified=5 -G ${grepPattern} -- "*.ts" "*.tsx"`, {
+        encoding: 'utf-8',
+        cwd,
+        maxBuffer: 10 * 1024 * 1024,
+      }) || 'No interface changes found'
+    );
+  } catch (error) {
+    return `Error: ${(error as Error).message}`;
+  }
+}
+
+export function listChangedFiles(
+  cwd: string,
+  base: string,
+  head?: string,
+  filter?: string,
+): string {
+  const headRef = head || 'HEAD';
+  const filterArg = filter ? `--diff-filter=${filter}` : '';
+
+  try {
+    return (
+      execSync(`git diff --name-status ${filterArg} ${base}...${headRef}`, {
+        encoding: 'utf-8',
+        cwd,
+      }) || 'No changed files'
+    );
+  } catch (error) {
+    return `Error: ${(error as Error).message}`;
+  }
+}
+
+// ─── Filesystem tools (for OpenAI adapter — Anthropic SDK provides these built-in) ──
+
+export function readFile(cwd: string, filePath: string): string {
+  const fullPath = filePath.startsWith('/') ? filePath : join(cwd, filePath);
+  const resolved = resolve(fullPath);
+
+  const cwdPrefix = cwd.endsWith('/') ? cwd : cwd + '/';
+  if (resolved !== cwd && !resolved.startsWith(cwdPrefix)) {
+    return `Error: Path outside project directory: ${filePath}`;
+  }
+
+  if (!existsSync(resolved)) {
+    return `File not found: ${filePath}`;
+  }
+
+  try {
+    return readFileSync(resolved, 'utf-8');
+  } catch (error) {
+    return `Error reading file: ${(error as Error).message}`;
+  }
+}
+
+export function grepFiles(
+  cwd: string,
+  pattern: string,
+  glob?: string,
+  ignoreCase?: boolean,
+): string {
+  const caseFlag = ignoreCase ? '-i' : '';
+  const globArg = glob ? `--glob "${glob}"` : '';
+
+  try {
+    return (
+      execSync(`rg -n ${caseFlag} ${globArg} "${pattern}" ${cwd}`, {
+        encoding: 'utf-8',
+        cwd,
+        maxBuffer: 10 * 1024 * 1024,
+      }) || 'No matches found'
+    );
+  } catch (error) {
+    const execError = error as { status?: number; message?: string };
+    if (execError.status === 1) return 'No matches found';
+    return `Error: ${execError.message || 'Unknown error'}`;
+  }
+}
+
+export function globFiles(cwd: string, pattern: string): string {
+  try {
+    const result = execSync(`find ${cwd} -path "${pattern}" -not -path "*/node_modules/*"`, {
+      encoding: 'utf-8',
+      cwd,
+      maxBuffer: 10 * 1024 * 1024,
+    });
+    return result.trim() || 'No files found';
+  } catch (error) {
+    return `Error: ${(error as Error).message}`;
+  }
+}
+
+// ─── Private helpers ──────────────────────────────────────────────────────────
+
+function extractImports(content: string): string[] {
+  const importRegex = /import\s+(?:(?:\{[^}]*\}|\*\s+as\s+\w+|\w+)\s+from\s+)?['"]([^'"]+)['"]/g;
+  const imports: string[] = [];
+  let match;
+  while ((match = importRegex.exec(content)) !== null) {
+    imports.push(match[1]);
+  }
+  return imports;
+}
+
+function extractExports(content: string): string[] {
+  const exports: string[] = [];
+
+  const namedExportRegex = /export\s*\{([^}]+)\}/g;
+  let match;
+  while ((match = namedExportRegex.exec(content)) !== null) {
+    const names = match[1].split(',').map((n) =>
+      n
+        .trim()
+        .split(/\s+as\s+/)[0]
+        .trim(),
+    );
+    exports.push(...names);
+  }
+
+  const directExportRegex =
+    /export\s+(?:const|let|var|function|class|interface|type|enum)\s+(\w+)/g;
+  while ((match = directExportRegex.exec(content)) !== null) {
+    exports.push(match[1]);
+  }
+
+  if (/export\s+default/.test(content)) {
+    exports.push('default');
+  }
+
+  return [...new Set(exports)];
+}
+
+function findImportingFiles(targetPath: string, cwd: string): string[] {
+  const fileName =
+    targetPath
+      .split('/')
+      .pop()
+      ?.replace(/\.[^.]+$/, '') || '';
+
+  try {
+    const result = execSync(`rg -l "${fileName}" --type ts ${cwd} 2>/dev/null || true`, {
+      encoding: 'utf-8',
+      cwd,
+      shell: '/bin/bash',
+    });
+    return result
+      .trim()
+      .split('\n')
+      .filter((f) => f && f !== targetPath);
+  } catch {
+    return [];
+  }
+}
+
+function compareExportSets(oldExports: string[], newExports: string[]): ExportComparison {
+  const oldSet = new Set(oldExports);
+  const newSet = new Set(newExports);
+
+  return {
+    added: newExports.filter((e) => !oldSet.has(e)),
+    removed: oldExports.filter((e) => !newSet.has(e)),
+    modified: [],
+  };
+}

--- a/src/stages/review/agentic/tools/handlers.ts
+++ b/src/stages/review/agentic/tools/handlers.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
-import { join, resolve } from 'node:path';
 
+import { resolveWithinCwd, isSafeGitRef } from '../../../../shared/utils/security';
 import type { DependencyTrace, ExportComparison } from '../types';
 
 // ─── Safe command execution ────────────────────────────────────────────────────
@@ -28,7 +28,12 @@ function runSafe(cmd: string, args: string[], cwd: string, maxBuffer = 10 * 1024
 // ─── Custom tools ─────────────────────────────────────────────────────────────
 
 export function findUsages(cwd: string, symbol: string, scope?: string, fileType?: string): string {
-  const searchPath = scope || cwd;
+  let searchPath = cwd;
+  if (scope) {
+    const resolved = resolveWithinCwd(cwd, scope);
+    if (!resolved) return `Error: scope path is outside project directory`;
+    searchPath = resolved;
+  }
   const typeArgs = fileType ? ['--type', fileType] : ['--type', 'ts', '--type', 'tsx'];
 
   try {
@@ -44,7 +49,8 @@ export function findUsages(cwd: string, symbol: string, scope?: string, fileType
 }
 
 export function traceImports(cwd: string, filePath: string): string {
-  const fullPath = filePath.startsWith('/') ? filePath : `${cwd}/${filePath}`;
+  const fullPath = resolveWithinCwd(cwd, filePath);
+  if (!fullPath) return `Error: Path outside project directory: ${filePath}`;
 
   if (!existsSync(fullPath)) {
     return `File not found: ${filePath}`;
@@ -66,7 +72,9 @@ export function gitDiffAnalysis(
   file?: string,
   stat?: boolean,
 ): string {
+  if (!isSafeGitRef(base)) return `Error: invalid git ref: ${base}`;
   const headRef = head || 'HEAD';
+  if (!isSafeGitRef(headRef)) return `Error: invalid git ref: ${headRef}`;
 
   const args = ['diff'];
   if (stat) args.push('--stat');
@@ -81,7 +89,8 @@ export function gitDiffAnalysis(
 }
 
 export function analyzeExports(cwd: string, filePath: string, compareWithRef?: string): string {
-  const fullPath = filePath.startsWith('/') ? filePath : `${cwd}/${filePath}`;
+  const fullPath = resolveWithinCwd(cwd, filePath);
+  if (!fullPath) return `Error: Path outside project directory: ${filePath}`;
 
   if (!existsSync(fullPath)) {
     return `File not found: ${filePath}`;
@@ -93,6 +102,8 @@ export function analyzeExports(cwd: string, filePath: string, compareWithRef?: s
   let comparison: ExportComparison | null = null;
 
   if (compareWithRef) {
+    if (!isSafeGitRef(compareWithRef)) return `Error: invalid git ref: ${compareWithRef}`;
+    // Use '--' separator then 'ref:path' as a single argument — no shell expansion risk
     try {
       const oldContent = runSafe('git', ['show', `${compareWithRef}:${filePath}`], cwd);
       const oldExports = extractExports(oldContent);
@@ -111,10 +122,13 @@ export function findInterfaceChanges(
   head?: string,
   interfaceName?: string,
 ): string {
+  if (!isSafeGitRef(base)) return `Error: invalid git ref: ${base}`;
   const headRef = head || 'HEAD';
-  const grepPattern = interfaceName
-    ? `(interface|type)\\s+${interfaceName}`
-    : '(interface|type)\\s+\\w+';
+  if (!isSafeGitRef(headRef)) return `Error: invalid git ref: ${headRef}`;
+
+  // Escape interfaceName so it is safe to embed in a regex (avoids ReDoS)
+  const safeName = interfaceName ? interfaceName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') : '\\w+';
+  const grepPattern = `(interface|type)\\s+${safeName}`;
 
   try {
     return (
@@ -135,7 +149,9 @@ export function listChangedFiles(
   head?: string,
   filter?: string,
 ): string {
+  if (!isSafeGitRef(base)) return `Error: invalid git ref: ${base}`;
   const headRef = head || 'HEAD';
+  if (!isSafeGitRef(headRef)) return `Error: invalid git ref: ${headRef}`;
   const args = ['diff', '--name-status'];
   if (filter) args.push(`--diff-filter=${filter}`);
   args.push(`${base}...${headRef}`);
@@ -150,11 +166,8 @@ export function listChangedFiles(
 // ─── Filesystem tools (for OpenAI adapter — Anthropic SDK provides these built-in) ──
 
 export function readFile(cwd: string, filePath: string): string {
-  const fullPath = filePath.startsWith('/') ? filePath : join(cwd, filePath);
-  const resolved = resolve(fullPath);
-
-  const cwdPrefix = cwd.endsWith('/') ? cwd : cwd + '/';
-  if (resolved !== cwd && !resolved.startsWith(cwdPrefix)) {
+  const resolved = resolveWithinCwd(cwd, filePath);
+  if (!resolved) {
     return `Error: Path outside project directory: ${filePath}`;
   }
 

--- a/src/stages/review/agentic/tools/index.ts
+++ b/src/stages/review/agentic/tools/index.ts
@@ -1,10 +1,14 @@
-import { execSync } from 'node:child_process';
-import { readFileSync, existsSync } from 'node:fs';
-
 import { tool, createSdkMcpServer } from '@anthropic-ai/claude-agent-sdk';
 import { z } from 'zod';
 
-import type { DependencyTrace, ExportComparison } from '../types';
+import {
+  findUsages,
+  traceImports,
+  gitDiffAnalysis,
+  analyzeExports,
+  findInterfaceChanges,
+  listChangedFiles,
+} from './handlers';
 
 export function createAgenticTools(cwd: string) {
   return createSdkMcpServer({
@@ -19,27 +23,9 @@ export function createAgenticTools(cwd: string) {
           scope: z.string().optional().describe('Limit search to this directory path'),
           fileType: z.string().optional().describe('File type filter (e.g., ts, js, tsx)'),
         },
-        async ({ symbol, scope, fileType }) => {
-          const searchPath = scope || cwd;
-          const typeArg = fileType ? `--type ${fileType}` : '--type ts --type tsx';
-
-          try {
-            const result = execSync(`rg -n --word-regexp "${symbol}" ${searchPath} ${typeArg}`, {
-              encoding: 'utf-8',
-              cwd,
-              maxBuffer: 10 * 1024 * 1024,
-            });
-            return { content: [{ type: 'text', text: result || 'No usages found' }] };
-          } catch (error) {
-            const execError = error as { status?: number; message?: string };
-            if (execError.status === 1) {
-              return { content: [{ type: 'text', text: 'No usages found' }] };
-            }
-            return {
-              content: [{ type: 'text', text: `Error: ${execError.message || 'Unknown error'}` }],
-            };
-          }
-        },
+        async ({ symbol, scope, fileType }) => ({
+          content: [{ type: 'text', text: findUsages(cwd, symbol, scope, fileType) }],
+        }),
       ),
 
       tool(
@@ -48,27 +34,9 @@ export function createAgenticTools(cwd: string) {
         {
           filePath: z.string().describe('Path to the file to analyze (relative to cwd)'),
         },
-        async ({ filePath }) => {
-          const fullPath = filePath.startsWith('/') ? filePath : `${cwd}/${filePath}`;
-
-          if (!existsSync(fullPath)) {
-            return { content: [{ type: 'text', text: `File not found: ${filePath}` }] };
-          }
-
-          const content = readFileSync(fullPath, 'utf-8');
-          const imports = extractImports(content);
-          const exports = extractExports(content);
-          const importedBy = findImportingFiles(filePath, cwd);
-
-          const result: DependencyTrace = {
-            filePath,
-            imports,
-            importedBy,
-            exports,
-          };
-
-          return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-        },
+        async ({ filePath }) => ({
+          content: [{ type: 'text', text: traceImports(cwd, filePath) }],
+        }),
       ),
 
       tool(
@@ -80,22 +48,9 @@ export function createAgenticTools(cwd: string) {
           file: z.string().optional().describe('Specific file to diff'),
           stat: z.boolean().optional().describe('Show diff stats only'),
         },
-        async ({ base, head, file, stat }) => {
-          const headRef = head || 'HEAD';
-          const fileArg = file ? `-- ${file}` : '';
-          const statArg = stat ? '--stat' : '';
-
-          try {
-            const diff = execSync(`git diff ${statArg} ${base}...${headRef} ${fileArg}`, {
-              encoding: 'utf-8',
-              cwd,
-              maxBuffer: 10 * 1024 * 1024,
-            });
-            return { content: [{ type: 'text', text: diff || 'No differences found' }] };
-          } catch (error) {
-            return { content: [{ type: 'text', text: `Error: ${(error as Error).message}` }] };
-          }
-        },
+        async ({ base, head, file, stat }) => ({
+          content: [{ type: 'text', text: gitDiffAnalysis(cwd, base, head, file, stat) }],
+        }),
       ),
 
       tool(
@@ -108,39 +63,9 @@ export function createAgenticTools(cwd: string) {
             .optional()
             .describe('Git ref to compare with (e.g., main, HEAD~1)'),
         },
-        async ({ filePath, compareWithRef }) => {
-          const fullPath = filePath.startsWith('/') ? filePath : `${cwd}/${filePath}`;
-
-          if (!existsSync(fullPath)) {
-            return { content: [{ type: 'text', text: `File not found: ${filePath}` }] };
-          }
-
-          const currentContent = readFileSync(fullPath, 'utf-8');
-          const currentExports = extractExports(currentContent);
-
-          let comparison: ExportComparison | null = null;
-
-          if (compareWithRef) {
-            try {
-              const oldContent = execSync(`git show ${compareWithRef}:${filePath}`, {
-                encoding: 'utf-8',
-                cwd,
-              });
-              const oldExports = extractExports(oldContent);
-              comparison = compareExports(oldExports, currentExports);
-            } catch {
-              comparison = { added: currentExports, removed: [], modified: [] };
-            }
-          }
-
-          const result = {
-            filePath,
-            exports: currentExports,
-            comparison,
-          };
-
-          return { content: [{ type: 'text', text: JSON.stringify(result, null, 2) }] };
-        },
+        async ({ filePath, compareWithRef }) => ({
+          content: [{ type: 'text', text: analyzeExports(cwd, filePath, compareWithRef) }],
+        }),
       ),
 
       tool(
@@ -151,22 +76,9 @@ export function createAgenticTools(cwd: string) {
           head: z.string().optional().describe('Head git ref (defaults to HEAD)'),
           interfaceName: z.string().optional().describe('Specific interface to check'),
         },
-        async ({ base, head, interfaceName }) => {
-          const headRef = head || 'HEAD';
-          const grepPattern = interfaceName
-            ? `"(interface|type)\\s+${interfaceName}"`
-            : '"(interface|type)\\s+\\w+"';
-
-          try {
-            const diff = execSync(
-              `git diff ${base}...${headRef} --unified=5 -G ${grepPattern} -- "*.ts" "*.tsx"`,
-              { encoding: 'utf-8', cwd, maxBuffer: 10 * 1024 * 1024 },
-            );
-            return { content: [{ type: 'text', text: diff || 'No interface changes found' }] };
-          } catch (error) {
-            return { content: [{ type: 'text', text: `Error: ${(error as Error).message}` }] };
-          }
-        },
+        async ({ base, head, interfaceName }) => ({
+          content: [{ type: 'text', text: findInterfaceChanges(cwd, base, head, interfaceName) }],
+        }),
       ),
 
       tool(
@@ -180,95 +92,10 @@ export function createAgenticTools(cwd: string) {
             .optional()
             .describe('Filter by status: A=added, M=modified, D=deleted'),
         },
-        async ({ base, head, filter }) => {
-          const headRef = head || 'HEAD';
-          const filterArg = filter ? `--diff-filter=${filter}` : '';
-
-          try {
-            const files = execSync(`git diff --name-status ${filterArg} ${base}...${headRef}`, {
-              encoding: 'utf-8',
-              cwd,
-            });
-            return { content: [{ type: 'text', text: files || 'No changed files' }] };
-          } catch (error) {
-            return { content: [{ type: 'text', text: `Error: ${(error as Error).message}` }] };
-          }
-        },
+        async ({ base, head, filter }) => ({
+          content: [{ type: 'text', text: listChangedFiles(cwd, base, head, filter) }],
+        }),
       ),
     ],
   });
-}
-
-function extractImports(content: string): string[] {
-  const importRegex = /import\s+(?:(?:\{[^}]*\}|\*\s+as\s+\w+|\w+)\s+from\s+)?['"]([^'"]+)['"]/g;
-  const imports: string[] = [];
-  let match;
-  while ((match = importRegex.exec(content)) !== null) {
-    imports.push(match[1]);
-  }
-  return imports;
-}
-
-function extractExports(content: string): string[] {
-  const exports: string[] = [];
-
-  // Named exports: export { name } or export { name as alias }
-  const namedExportRegex = /export\s*\{([^}]+)\}/g;
-  let match;
-  while ((match = namedExportRegex.exec(content)) !== null) {
-    const names = match[1].split(',').map((n) =>
-      n
-        .trim()
-        .split(/\s+as\s+/)[0]
-        .trim(),
-    );
-    exports.push(...names);
-  }
-
-  // Direct exports: export const/let/var/function/class/interface/type
-  const directExportRegex =
-    /export\s+(?:const|let|var|function|class|interface|type|enum)\s+(\w+)/g;
-  while ((match = directExportRegex.exec(content)) !== null) {
-    exports.push(match[1]);
-  }
-
-  // Default export
-  if (/export\s+default/.test(content)) {
-    exports.push('default');
-  }
-
-  return [...new Set(exports)];
-}
-
-function findImportingFiles(targetPath: string, cwd: string): string[] {
-  const fileName =
-    targetPath
-      .split('/')
-      .pop()
-      ?.replace(/\.[^.]+$/, '') || '';
-
-  try {
-    const result = execSync(`rg -l "${fileName}" --type ts ${cwd} 2>/dev/null || true`, {
-      encoding: 'utf-8',
-      cwd,
-      shell: '/bin/bash',
-    });
-    return result
-      .trim()
-      .split('\n')
-      .filter((f) => f && f !== targetPath);
-  } catch {
-    return [];
-  }
-}
-
-function compareExports(oldExports: string[], newExports: string[]): ExportComparison {
-  const oldSet = new Set(oldExports);
-  const newSet = new Set(newExports);
-
-  return {
-    added: newExports.filter((e) => !oldSet.has(e)),
-    removed: oldExports.filter((e) => !newSet.has(e)),
-    modified: [], // Would need AST analysis for signature changes
-  };
 }

--- a/tests/unit/config/config.spec.ts
+++ b/tests/unit/config/config.spec.ts
@@ -598,6 +598,31 @@ describe('ConfigService', () => {
     });
   });
 
+  describe('resolveAgentAdapterType', () => {
+    let instance: ConfigService;
+
+    beforeEach(() => {
+      (ConfigService as unknown as { instance: undefined }).instance = undefined;
+      instance = ConfigService.getInstance();
+    });
+
+    it('returns "anthropic" for anthropic provider', () => {
+      expect(instance.resolveAgentAdapterType('anthropic')).toBe('anthropic');
+    });
+
+    it('returns "openai" for openai provider', () => {
+      expect(instance.resolveAgentAdapterType('openai')).toBe('openai');
+    });
+
+    it('returns "openai" for github provider (uses OpenAI-compatible API)', () => {
+      expect(instance.resolveAgentAdapterType('github')).toBe('openai');
+    });
+
+    it('returns undefined for bedrock (not yet supported)', () => {
+      expect(instance.resolveAgentAdapterType('bedrock')).toBeUndefined();
+    });
+  });
+
   describe('validate', () => {
     it('should return empty array when config is valid', () => {
       const aiConfig = {

--- a/tests/unit/shared/utils/security.spec.ts
+++ b/tests/unit/shared/utils/security.spec.ts
@@ -3,9 +3,62 @@ import {
   hasValidUrlScheme,
   isClassificationResultArray,
   isPathTraversalSafe,
+  isSafeGitRef,
   isValidGitSha,
+  resolveWithinCwd,
   sanitizeFilename,
 } from '@/shared/utils/security';
+
+describe('isSafeGitRef', () => {
+  it('accepts normal branch names and shas', () => {
+    expect(isSafeGitRef('main')).toBe(true);
+    expect(isSafeGitRef('HEAD')).toBe(true);
+    expect(isSafeGitRef('HEAD~1')).toBe(true);
+    expect(isSafeGitRef('abc1234')).toBe(true);
+    expect(isSafeGitRef('feat/my-branch')).toBe(true);
+  });
+
+  it('rejects refs starting with -', () => {
+    expect(isSafeGitRef('-evil')).toBe(false);
+    expect(isSafeGitRef('--upload-pack=evil')).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    expect(isSafeGitRef('')).toBe(false);
+  });
+});
+
+describe('resolveWithinCwd', () => {
+  const cwd = '/project/repo';
+
+  it('resolves a relative path within cwd', () => {
+    expect(resolveWithinCwd(cwd, 'src/foo.ts')).toBe('/project/repo/src/foo.ts');
+  });
+
+  it('resolves an absolute path within cwd', () => {
+    expect(resolveWithinCwd(cwd, '/project/repo/src/foo.ts')).toBe('/project/repo/src/foo.ts');
+  });
+
+  it('returns null for path traversal via ..', () => {
+    expect(resolveWithinCwd(cwd, '../../etc/passwd')).toBeNull();
+  });
+
+  it('returns null for absolute path outside cwd', () => {
+    expect(resolveWithinCwd(cwd, '/etc/passwd')).toBeNull();
+  });
+
+  it('returns null for sibling directory (prefix-bypass)', () => {
+    expect(resolveWithinCwd(cwd, '/project/repo-evil/secret')).toBeNull();
+  });
+
+  it('accepts cwd itself', () => {
+    expect(resolveWithinCwd(cwd, '.')).toBe('/project/repo');
+  });
+
+  it('handles cwd with trailing slash', () => {
+    expect(resolveWithinCwd('/project/repo/', 'src/foo.ts')).toBe('/project/repo/src/foo.ts');
+  });
+});
 
 describe('isPathTraversalSafe', () => {
   it('should return false for empty filename', () => {

--- a/tests/unit/stages/review/agentic/adapters/anthropic-adapter.spec.ts
+++ b/tests/unit/stages/review/agentic/adapters/anthropic-adapter.spec.ts
@@ -1,0 +1,113 @@
+jest.mock('@anthropic-ai/claude-agent-sdk', () => ({
+  query: jest.fn(),
+}));
+jest.mock('@/stages/review/agentic/tools', () => ({
+  createAgenticTools: jest.fn(() => ({})),
+}));
+jest.mock('@/shared/utils/logger');
+
+import { query } from '@anthropic-ai/claude-agent-sdk';
+
+import type { AgentAdapterParams } from '@/stages/review/agentic/adapters/agent-adapter';
+import { AnthropicAdapter } from '@/stages/review/agentic/adapters/anthropic-adapter';
+
+const mockQuery = query as jest.MockedFunction<typeof query>;
+
+function makeParams(overrides: Partial<AgentAdapterParams> = {}): AgentAdapterParams {
+  return {
+    systemPrompt: 'You are a reviewer',
+    userPrompt: 'Review this code',
+    agents: {},
+    model: 'claude-test',
+    cwd: process.cwd(),
+    maxTurns: 10,
+    ...overrides,
+  };
+}
+
+describe('AnthropicAdapter', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it('returns output from a successful result message', async () => {
+    mockQuery.mockReturnValue(
+      (async function* () {
+        yield { type: 'result', subtype: 'success', result: '["issue1"]' };
+      })(),
+    );
+    const adapter = new AnthropicAdapter();
+    const result = await adapter.run(makeParams());
+    expect(result.output).toBe('["issue1"]');
+  });
+
+  it('extracts token counts from usage in result message', async () => {
+    mockQuery.mockReturnValue(
+      (async function* () {
+        yield {
+          type: 'result',
+          subtype: 'success',
+          result: '[]',
+          usage: { input_tokens: 100, output_tokens: 50 },
+        };
+      })(),
+    );
+    const adapter = new AnthropicAdapter();
+    const result = await adapter.run(makeParams());
+    expect(result.inputTokens).toBe(100);
+    expect(result.outputTokens).toBe(50);
+  });
+
+  it('returns empty output and errorSubtype when result subtype is not success', async () => {
+    mockQuery.mockReturnValue(
+      (async function* () {
+        yield { type: 'result', subtype: 'error_max_turns' };
+      })(),
+    );
+    const adapter = new AnthropicAdapter();
+    const result = await adapter.run(makeParams());
+    expect(result.output).toBe('');
+    expect(result.errorSubtype).toBe('error_max_turns');
+  });
+
+  it('invokes onToolCall for each tool_use block', async () => {
+    mockQuery.mockReturnValue(
+      (async function* () {
+        yield {
+          type: 'assistant',
+          message: {
+            content: [{ type: 'tool_use', name: 'Read', input: { path: 'src/foo.ts' } }],
+          },
+        };
+        yield { type: 'result', subtype: 'success', result: '[]' };
+      })(),
+    );
+    const onToolCall = jest.fn();
+    const adapter = new AnthropicAdapter();
+    await adapter.run(makeParams({ onToolCall }));
+    expect(onToolCall).toHaveBeenCalledWith(1, 'Read', { path: 'src/foo.ts' });
+  });
+
+  it('passes maxBudgetUsd to query when provided', async () => {
+    mockQuery.mockReturnValue(
+      (async function* () {
+        yield { type: 'result', subtype: 'success', result: '[]' };
+      })(),
+    );
+    const adapter = new AnthropicAdapter();
+    await adapter.run(makeParams({ maxBudgetUsd: 2.5 }));
+    const callOptions = (mockQuery.mock.calls[0][0] as { options: { maxBudgetUsd?: number } })
+      .options;
+    expect(callOptions.maxBudgetUsd).toBe(2.5);
+  });
+
+  it('rethrows when query async generator throws', async () => {
+    mockQuery.mockReturnValue(
+      (async function* () {
+        throw new Error('SDK failure');
+      })(),
+    );
+    const adapter = new AnthropicAdapter();
+    await expect(adapter.run(makeParams())).rejects.toThrow('SDK failure');
+  });
+});

--- a/tests/unit/stages/review/agentic/adapters/openai-adapter.spec.ts
+++ b/tests/unit/stages/review/agentic/adapters/openai-adapter.spec.ts
@@ -1,0 +1,227 @@
+jest.mock('@openai/agents', () => ({
+  Agent: jest.fn(),
+  run: jest.fn(),
+  setDefaultOpenAIClient: jest.fn(),
+  getGlobalTraceProvider: jest.fn(() => ({ setDisabled: jest.fn() })),
+  // Preserve the full opts so tests can inspect name + call execute
+  tool: jest.fn((opts: { name: string; execute: (args: unknown) => Promise<string> }) => opts),
+}));
+jest.mock('openai', () => {
+  const ctor = jest.fn(() => ({}));
+  ctor.default = ctor;
+  ctor.AzureOpenAI = jest.fn(() => ({}));
+  return ctor;
+});
+jest.mock('@/config/env', () => ({ envConfig: { get: jest.fn().mockReturnValue('') } }));
+jest.mock('@/stages/review/agentic/tools/handlers');
+jest.mock('@/shared/utils/logger');
+
+import { run as mockRun, Agent as MockAgent } from '@openai/agents';
+
+import type { AgentAdapterParams } from '@/stages/review/agentic/adapters/agent-adapter';
+import { OpenAIAdapter } from '@/stages/review/agentic/adapters/openai-adapter';
+import * as handlers from '@/stages/review/agentic/tools/handlers';
+
+const mockRunFn = mockRun as jest.MockedFunction<typeof mockRun>;
+const MockAgentCtor = MockAgent as jest.MockedClass<typeof MockAgent>;
+
+// Cast to jest mocks for all handler functions
+const h = handlers as jest.Mocked<typeof handlers>;
+
+const CWD = '/project/repo';
+
+function makeParams(overrides: Partial<AgentAdapterParams> = {}): AgentAdapterParams {
+  return {
+    systemPrompt: 'You are a reviewer',
+    userPrompt: 'Review this code',
+    agents: {},
+    model: 'gpt-5-mini',
+    cwd: CWD,
+    maxTurns: 10,
+    ...overrides,
+  };
+}
+
+function makeRunResult(finalOutput: string, inputTokens = 0, outputTokens = 0) {
+  return {
+    finalOutput,
+    state: { usage: { inputTokens, outputTokens } },
+  };
+}
+
+/** Capture tools built during a run() invocation by intercepting Agent constructor calls. */
+function capturedTools(): Array<{ name: string; execute: (args: unknown) => Promise<string> }> {
+  // The first Agent constructor call is the first handoff (or orchestrator if no handoffs).
+  // With no agents, only the orchestrator is created — its tools are captured from the last call.
+  const calls = MockAgentCtor.mock.calls;
+  if (!calls.length) return [];
+  const lastCall = calls[calls.length - 1][0] as { tools: any[] };
+  return lastCall?.tools ?? [];
+}
+
+describe('OpenAIAdapter — run()', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    MockAgentCtor.mockImplementation(() => ({}) as InstanceType<typeof MockAgent>);
+  });
+
+  it('returns output from run() finalOutput', async () => {
+    mockRunFn.mockResolvedValue(makeRunResult('["issue1"]') as any);
+    const result = await new OpenAIAdapter().run(makeParams());
+    expect(result.output).toBe('["issue1"]');
+  });
+
+  it('extracts token counts from state.usage', async () => {
+    mockRunFn.mockResolvedValue(makeRunResult('[]', 120, 60) as any);
+    const result = await new OpenAIAdapter().run(makeParams());
+    expect(result.inputTokens).toBe(120);
+    expect(result.outputTokens).toBe(60);
+  });
+
+  it('returns empty string when finalOutput is null', async () => {
+    mockRunFn.mockResolvedValue({
+      finalOutput: null,
+      state: { usage: { inputTokens: 0, outputTokens: 0 } },
+    } as any);
+    const result = await new OpenAIAdapter().run(makeParams());
+    expect(result.output).toBe('');
+  });
+
+  it('serialises non-string finalOutput to JSON', async () => {
+    mockRunFn.mockResolvedValue({
+      finalOutput: { key: 'val' },
+      state: { usage: { inputTokens: 0, outputTokens: 0 } },
+    } as any);
+    const result = await new OpenAIAdapter().run(makeParams());
+    expect(result.output).toBe('{"key":"val"}');
+  });
+
+  it('passes maxTurns to run()', async () => {
+    mockRunFn.mockResolvedValue(makeRunResult('[]') as any);
+    await new OpenAIAdapter().run(makeParams({ maxTurns: 42 }));
+    expect((mockRunFn.mock.calls[0][2] as { maxTurns: number }).maxTurns).toBe(42);
+  });
+
+  it('creates one orchestrator when agents is empty', async () => {
+    mockRunFn.mockResolvedValue(makeRunResult('[]') as any);
+    await new OpenAIAdapter().run(makeParams());
+    expect(MockAgentCtor).toHaveBeenCalledTimes(1);
+  });
+
+  it('creates orchestrator + handoff agent for each entry in agents', async () => {
+    mockRunFn.mockResolvedValue(makeRunResult('[]') as any);
+    await new OpenAIAdapter().run(
+      makeParams({
+        agents: {
+          'security-analyzer': {
+            description: 'Security',
+            prompt: 'Check security',
+            tools: ['find_usages'],
+          },
+        },
+      }),
+    );
+    expect(MockAgentCtor).toHaveBeenCalledTimes(2);
+  });
+
+  it('rethrows when run() throws', async () => {
+    mockRunFn.mockRejectedValue(new Error('OpenAI failure'));
+    await expect(new OpenAIAdapter().run(makeParams())).rejects.toThrow('OpenAI failure');
+  });
+});
+
+describe('OpenAIAdapter — tools', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    MockAgentCtor.mockImplementation((opts: any) => opts as InstanceType<typeof MockAgent>);
+    mockRunFn.mockResolvedValue(makeRunResult('[]') as any);
+  });
+
+  async function getToolExecute(name: string) {
+    await new OpenAIAdapter().run(makeParams());
+    const tool = capturedTools().find((t) => t.name === name);
+    if (!tool) throw new Error(`Tool "${name}" not found`);
+    return tool.execute.bind(tool);
+  }
+
+  it('read_file tool calls readFile handler', async () => {
+    h.readFile.mockReturnValue('file contents');
+    const execute = await getToolExecute('read_file');
+    const result = await execute({ filePath: 'src/foo.ts' });
+    expect(h.readFile).toHaveBeenCalledWith(CWD, 'src/foo.ts');
+    expect(result).toBe('file contents');
+  });
+
+  it('grep_files tool calls grepFiles handler', async () => {
+    h.grepFiles.mockReturnValue('match');
+    const execute = await getToolExecute('grep_files');
+    const result = await execute({ pattern: 'foo', glob: '*.ts', ignoreCase: true });
+    expect(h.grepFiles).toHaveBeenCalledWith(CWD, 'foo', '*.ts', true);
+    expect(result).toBe('match');
+  });
+
+  it('glob_files tool calls globFiles handler', async () => {
+    h.globFiles.mockReturnValue('/project/repo/src/foo.ts');
+    const execute = await getToolExecute('glob_files');
+    const result = await execute({ pattern: '**/*.ts' });
+    expect(h.globFiles).toHaveBeenCalledWith(CWD, '**/*.ts');
+    expect(result).toBe('/project/repo/src/foo.ts');
+  });
+
+  it('find_usages tool calls findUsages handler', async () => {
+    h.findUsages.mockReturnValue('usages');
+    const execute = await getToolExecute('find_usages');
+    const result = await execute({ symbol: 'myFn' });
+    expect(h.findUsages).toHaveBeenCalledWith(CWD, 'myFn', undefined, undefined);
+    expect(result).toBe('usages');
+  });
+
+  it('trace_imports tool calls traceImports handler', async () => {
+    h.traceImports.mockReturnValue('{}');
+    const execute = await getToolExecute('trace_imports');
+    const result = await execute({ filePath: 'src/foo.ts' });
+    expect(h.traceImports).toHaveBeenCalledWith(CWD, 'src/foo.ts');
+    expect(result).toBe('{}');
+  });
+
+  it('git_diff_analysis tool calls gitDiffAnalysis handler', async () => {
+    h.gitDiffAnalysis.mockReturnValue('diff output');
+    const execute = await getToolExecute('git_diff_analysis');
+    const result = await execute({ base: 'main' });
+    expect(h.gitDiffAnalysis).toHaveBeenCalledWith(CWD, 'main', undefined, undefined, undefined);
+    expect(result).toBe('diff output');
+  });
+
+  it('analyze_exports tool calls analyzeExports handler', async () => {
+    h.analyzeExports.mockReturnValue('{}');
+    const execute = await getToolExecute('analyze_exports');
+    const result = await execute({ filePath: 'src/foo.ts' });
+    expect(h.analyzeExports).toHaveBeenCalledWith(CWD, 'src/foo.ts', undefined);
+    expect(result).toBe('{}');
+  });
+
+  it('find_interface_changes tool calls findInterfaceChanges handler', async () => {
+    h.findInterfaceChanges.mockReturnValue('changes');
+    const execute = await getToolExecute('find_interface_changes');
+    const result = await execute({ base: 'main' });
+    expect(h.findInterfaceChanges).toHaveBeenCalledWith(CWD, 'main', undefined, undefined);
+    expect(result).toBe('changes');
+  });
+
+  it('list_changed_files tool calls listChangedFiles handler', async () => {
+    h.listChangedFiles.mockReturnValue('M foo.ts');
+    const execute = await getToolExecute('list_changed_files');
+    const result = await execute({ base: 'main' });
+    expect(h.listChangedFiles).toHaveBeenCalledWith(CWD, 'main', undefined, undefined);
+    expect(result).toBe('M foo.ts');
+  });
+
+  it('onToolCall is invoked with turn and tool name', async () => {
+    h.readFile.mockReturnValue('contents');
+    const onToolCall = jest.fn();
+    await new OpenAIAdapter().run(makeParams({ onToolCall }));
+    const execute = capturedTools().find((t) => t.name === 'read_file')?.execute;
+    await execute?.({ filePath: 'src/foo.ts' });
+    expect(onToolCall).toHaveBeenCalledWith(1, 'read_file', { filePath: 'src/foo.ts' });
+  });
+});

--- a/tests/unit/stages/review/agentic/agentic-executor.spec.ts
+++ b/tests/unit/stages/review/agentic/agentic-executor.spec.ts
@@ -2,23 +2,22 @@ import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 
 // buildSystemPrompt is private — test it via the public execute() interface
-// by mocking the query function and capturing the systemPrompt it receives.
+// by mocking the adapter and capturing the systemPrompt it receives.
 
-jest.mock('@anthropic-ai/claude-agent-sdk', () => ({
-  query: jest.fn(),
-}));
-jest.mock('@/stages/review/agentic/tools', () => ({
-  createAgenticTools: jest.fn(() => ({})),
+jest.mock('@/stages/review/agentic/adapters', () => ({
+  createAgentAdapter: jest.fn(),
 }));
 jest.mock('@/shared/utils/logger');
 
-import { query } from '@anthropic-ai/claude-agent-sdk';
-
 import type { PipelineJob } from '@/shared/types/config';
-import { logger } from '@/shared/utils/logger';
+import { createAgentAdapter } from '@/stages/review/agentic/adapters';
+import type {
+  AgentAdapter,
+  AgentAdapterParams,
+} from '@/stages/review/agentic/adapters/agent-adapter';
 import { AgenticExecutor } from '@/stages/review/agentic/agentic-executor';
 
-const mockQuery = query as jest.MockedFunction<typeof query>;
+const mockCreateAgentAdapter = createAgentAdapter as jest.MockedFunction<typeof createAgentAdapter>;
 
 // AgenticExecutor resolves prompts relative to process.cwd()/.qualops/prompts
 const promptsDir = resolve(process.cwd(), '.qualops/prompts/__agentic_executor_test__');
@@ -45,37 +44,41 @@ function makeJob(agenticOverrides: Record<string, unknown> = {}): PipelineJob {
   } as unknown as PipelineJob;
 }
 
-function capturedSystemPrompt(): string {
-  const calls = mockQuery.mock.calls;
-  const lastCall = calls[calls.length - 1];
-  return (lastCall[0] as { options: { systemPrompt: string } }).options.systemPrompt;
+let capturedParams: AgentAdapterParams | null = null;
+
+function mockAdapterWithResult(result: string): AgentAdapter {
+  capturedParams = null;
+  return {
+    run: jest.fn(async (params: AgentAdapterParams) => {
+      capturedParams = params;
+      return { output: result };
+    }),
+  };
+}
+
+function setupMockAdapter(result = '[]') {
+  mockCreateAgentAdapter.mockReturnValue(mockAdapterWithResult(result));
 }
 
 async function runExecutor(job: PipelineJob): Promise<void> {
-  // query returns an async iterable; emit a single result message so execute() finishes
-  mockQuery.mockReturnValue(
-    (async function* () {
-      yield { type: 'result', subtype: 'success', result: '[]' };
-    })(),
-  );
-
-  const executor = new AgenticExecutor(job);
+  setupMockAdapter();
+  const executor = new AgenticExecutor(job, undefined, 'test-model');
   await executor.execute([{ path: 'src/foo.ts', content: 'const x = 1;' }]);
 }
 
 describe('AgenticExecutor — execute()', () => {
   beforeEach(() => {
-    mockQuery.mockReset();
+    mockCreateAgentAdapter.mockReset();
   });
 
   it('returns empty array immediately when no files provided', async () => {
-    const executor = new AgenticExecutor(makeJob());
+    const executor = new AgenticExecutor(makeJob(), undefined, 'test-model');
     const result = await executor.execute([]);
     expect(result).toEqual([]);
-    expect(mockQuery).not.toHaveBeenCalled();
+    expect(mockCreateAgentAdapter).not.toHaveBeenCalled();
   });
 
-  it('parses issues from a successful result message', async () => {
+  it('parses issues from a successful result', async () => {
     const issue = {
       type: 'security',
       severity: 'high',
@@ -85,62 +88,58 @@ describe('AgenticExecutor — execute()', () => {
       suggestion: 'Use parameterized queries',
       confidence: 9,
     };
-    mockQuery.mockReturnValue(
-      (async function* () {
-        yield { type: 'result', subtype: 'success', result: JSON.stringify([issue]) };
-      })(),
-    );
-    const executor = new AgenticExecutor(makeJob());
+    setupMockAdapter(JSON.stringify([issue]));
+    const executor = new AgenticExecutor(makeJob(), undefined, 'test-model');
     const result = await executor.execute([{ path: 'src/db.ts', content: 'query(input)' }]);
     expect(result).toHaveLength(1);
     expect(result[0].description).toBe('SQL injection');
   });
 
-  it('logs error and continues when result subtype is not success', async () => {
-    mockQuery.mockReturnValue(
-      (async function* () {
-        yield { type: 'result', subtype: 'error_max_turns' };
-      })(),
-    );
-    const executor = new AgenticExecutor(makeJob());
-    await executor.execute([{ path: 'src/foo.ts', content: 'x' }]);
-    expect(logger.error).toHaveBeenCalledWith(expect.stringContaining('error_max_turns'));
+  it('returns empty array when adapter returns no output', async () => {
+    mockCreateAgentAdapter.mockReturnValue({ run: jest.fn(async () => ({ output: '' })) });
+    const executor = new AgenticExecutor(makeJob(), undefined, 'test-model');
+    const result = await executor.execute([{ path: 'src/foo.ts', content: 'x' }]);
+    expect(result).toEqual([]);
   });
 
-  it('rethrows when query throws', async () => {
-    mockQuery.mockReturnValue(
-      (async function* () {
+  it('rethrows when adapter throws', async () => {
+    mockCreateAgentAdapter.mockReturnValue({
+      run: jest.fn(async () => {
         throw new Error('API failure');
-      })(),
-    );
-    const executor = new AgenticExecutor(makeJob());
+      }),
+    });
+    const executor = new AgenticExecutor(makeJob(), undefined, 'test-model');
     await expect(executor.execute([{ path: 'src/foo.ts', content: 'x' }])).rejects.toThrow(
       'API failure',
     );
+  });
+
+  it('passes resolved provider to createAgentAdapter', async () => {
+    setupMockAdapter();
+    const executor = new AgenticExecutor(makeJob(), undefined, 'test-model');
+    await executor.execute([{ path: 'src/foo.ts', content: 'x' }]);
+    expect(mockCreateAgentAdapter).toHaveBeenCalledWith(expect.any(String));
   });
 });
 
 describe('AgenticExecutor — systemPrompt / prompt composition', () => {
   beforeEach(() => {
-    mockQuery.mockReset();
+    mockCreateAgentAdapter.mockReset();
   });
 
   it('uses default prompt when neither systemPrompt nor prompt is set', async () => {
     await runExecutor(makeJob());
-    const sp = capturedSystemPrompt();
-    expect(sp).toContain('You are a code reviewer');
+    expect(capturedParams?.systemPrompt).toContain('You are a code reviewer');
   });
 
   it('injects inline systemPrompt into the system message', async () => {
     await runExecutor(makeJob({ systemPrompt: 'Inline instructions.' }));
-    const sp = capturedSystemPrompt();
-    expect(sp).toContain('Inline instructions.');
+    expect(capturedParams?.systemPrompt).toContain('Inline instructions.');
   });
 
   it('loads prompt from file and injects it into the system message', async () => {
     await runExecutor(makeJob({ prompt: '__agentic_executor_test__/custom.md' }));
-    const sp = capturedSystemPrompt();
-    expect(sp).toContain('From file: custom instructions.');
+    expect(capturedParams?.systemPrompt).toContain('From file: custom instructions.');
   });
 
   it('prepends systemPrompt before file prompt when both are set', async () => {
@@ -150,7 +149,7 @@ describe('AgenticExecutor — systemPrompt / prompt composition', () => {
         prompt: '__agentic_executor_test__/custom.md',
       }),
     );
-    const sp = capturedSystemPrompt();
+    const sp = capturedParams?.systemPrompt ?? '';
     const inlinePos = sp.indexOf('Inline first.');
     const filePos = sp.indexOf('From file: custom instructions.');
     expect(inlinePos).toBeGreaterThanOrEqual(0);
@@ -160,7 +159,6 @@ describe('AgenticExecutor — systemPrompt / prompt composition', () => {
 
   it('accepts promptConfig object form for prompt', async () => {
     await runExecutor(makeJob({ prompt: { file: '__agentic_executor_test__/custom.md' } }));
-    const sp = capturedSystemPrompt();
-    expect(sp).toContain('From file: custom instructions.');
+    expect(capturedParams?.systemPrompt).toContain('From file: custom instructions.');
   });
 });

--- a/tests/unit/stages/review/agentic/tools/handlers.spec.ts
+++ b/tests/unit/stages/review/agentic/tools/handlers.spec.ts
@@ -1,7 +1,7 @@
-jest.mock('node:child_process', () => ({ execSync: jest.fn() }));
+jest.mock('node:child_process', () => ({ spawnSync: jest.fn() }));
 jest.mock('node:fs', () => ({ existsSync: jest.fn(), readFileSync: jest.fn() }));
 
-import { execSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { existsSync, readFileSync } from 'node:fs';
 
 import {
@@ -16,11 +16,31 @@ import {
   traceImports,
 } from '@/stages/review/agentic/tools/handlers';
 
-const mockExecSync = execSync as jest.MockedFunction<typeof execSync>;
+const mockSpawnSync = spawnSync as jest.MockedFunction<typeof spawnSync>;
 const mockExistsSync = existsSync as jest.MockedFunction<typeof existsSync>;
 const mockReadFileSync = readFileSync as jest.MockedFunction<typeof readFileSync>;
 
 const CWD = '/project/repo';
+
+function spawnOk(stdout: string) {
+  return { stdout, stderr: '', status: 0, error: undefined, pid: 0, output: [], signal: null };
+}
+
+function spawnFail(stderr: string, status = 2) {
+  return { stdout: '', stderr, status, error: undefined, pid: 0, output: [], signal: null };
+}
+
+function spawnError(message: string) {
+  return {
+    stdout: '',
+    stderr: '',
+    status: null,
+    error: new Error(message),
+    pid: 0,
+    output: [],
+    signal: null,
+  };
+}
 
 beforeEach(() => {
   jest.clearAllMocks();
@@ -30,40 +50,36 @@ beforeEach(() => {
 
 describe('findUsages', () => {
   it('returns rg output on success', () => {
-    mockExecSync.mockReturnValue('src/foo.ts:5:const myFn = ' as any);
+    mockSpawnSync.mockReturnValue(spawnOk('src/foo.ts:5:const myFn = ') as any);
     expect(findUsages(CWD, 'myFn')).toBe('src/foo.ts:5:const myFn = ');
   });
 
   it('returns "No usages found" when rg exits with status 1', () => {
-    mockExecSync.mockImplementation(() => {
-      const e: any = new Error();
-      e.status = 1;
-      throw e;
-    });
+    mockSpawnSync.mockReturnValue(spawnFail('', 1) as any);
     expect(findUsages(CWD, 'myFn')).toBe('No usages found');
   });
 
   it('returns error message on other failures', () => {
-    mockExecSync.mockImplementation(() => {
-      throw new Error('rg not found');
-    });
-    expect(findUsages(CWD, 'myFn')).toBe('Error: rg not found');
+    mockSpawnSync.mockReturnValue(spawnError('rg not found') as any);
+    expect(findUsages(CWD, 'myFn')).toMatch(/rg not found/);
   });
 
   it('uses scope when provided', () => {
-    mockExecSync.mockReturnValue('' as any);
+    mockSpawnSync.mockReturnValue(spawnOk('') as any);
     findUsages(CWD, 'myFn', '/project/repo/src');
-    expect(mockExecSync).toHaveBeenCalledWith(
-      expect.stringContaining('/project/repo/src'),
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      'rg',
+      expect.arrayContaining(['/project/repo/src']),
       expect.anything(),
     );
   });
 
   it('uses custom fileType when provided', () => {
-    mockExecSync.mockReturnValue('' as any);
+    mockSpawnSync.mockReturnValue(spawnOk('') as any);
     findUsages(CWD, 'myFn', undefined, 'js');
-    expect(mockExecSync).toHaveBeenCalledWith(
-      expect.stringContaining('--type js'),
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      'rg',
+      expect.arrayContaining(['--type', 'js']),
       expect.anything(),
     );
   });
@@ -80,7 +96,7 @@ describe('traceImports', () => {
   it('returns JSON with imports and exports', () => {
     mockExistsSync.mockReturnValue(true);
     mockReadFileSync.mockReturnValue(`import { foo } from './foo';\nexport const bar = 1;` as any);
-    mockExecSync.mockReturnValue('' as any);
+    mockSpawnSync.mockReturnValue(spawnOk('') as any);
     const result = JSON.parse(traceImports(CWD, 'src/mod.ts'));
     expect(result.imports).toContain('./foo');
     expect(result.exports).toContain('bar');
@@ -91,26 +107,28 @@ describe('traceImports', () => {
 
 describe('gitDiffAnalysis', () => {
   it('returns diff output', () => {
-    mockExecSync.mockReturnValue('+ added line\n' as any);
+    mockSpawnSync.mockReturnValue(spawnOk('+ added line\n') as any);
     expect(gitDiffAnalysis(CWD, 'main')).toBe('+ added line\n');
   });
 
   it('returns "No differences found" on empty output', () => {
-    mockExecSync.mockReturnValue('' as any);
+    mockSpawnSync.mockReturnValue(spawnOk('') as any);
     expect(gitDiffAnalysis(CWD, 'main')).toBe('No differences found');
   });
 
   it('returns error string on failure', () => {
-    mockExecSync.mockImplementation(() => {
-      throw new Error('not a git repo');
-    });
+    mockSpawnSync.mockReturnValue(spawnFail('not a git repo') as any);
     expect(gitDiffAnalysis(CWD, 'main')).toBe('Error: not a git repo');
   });
 
   it('passes --stat flag when stat=true', () => {
-    mockExecSync.mockReturnValue('1 file changed' as any);
+    mockSpawnSync.mockReturnValue(spawnOk('1 file changed') as any);
     gitDiffAnalysis(CWD, 'main', undefined, undefined, true);
-    expect(mockExecSync).toHaveBeenCalledWith(expect.stringContaining('--stat'), expect.anything());
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      'git',
+      expect.arrayContaining(['--stat']),
+      expect.anything(),
+    );
   });
 });
 
@@ -134,7 +152,7 @@ describe('analyzeExports', () => {
   it('includes comparison when compareWithRef is provided', () => {
     mockExistsSync.mockReturnValue(true);
     mockReadFileSync.mockReturnValue('export const foo = 1;' as any);
-    mockExecSync.mockReturnValue('export const oldFn = () => {};' as any);
+    mockSpawnSync.mockReturnValue(spawnOk('export const oldFn = () => {};') as any);
     const result = JSON.parse(analyzeExports(CWD, 'src/mod.ts', 'main'));
     expect(result.comparison).toBeTruthy();
     expect(result.comparison.added).toContain('foo');
@@ -144,9 +162,7 @@ describe('analyzeExports', () => {
   it('uses added=currentExports when git show fails', () => {
     mockExistsSync.mockReturnValue(true);
     mockReadFileSync.mockReturnValue('export const foo = 1;' as any);
-    mockExecSync.mockImplementation(() => {
-      throw new Error('git error');
-    });
+    mockSpawnSync.mockReturnValue(spawnFail('git error') as any);
     const result = JSON.parse(analyzeExports(CWD, 'src/mod.ts', 'main'));
     expect(result.comparison.added).toContain('foo');
     expect(result.comparison.removed).toEqual([]);
@@ -157,26 +173,28 @@ describe('analyzeExports', () => {
 
 describe('findInterfaceChanges', () => {
   it('returns diff output', () => {
-    mockExecSync.mockReturnValue('interface Foo {}' as any);
+    mockSpawnSync.mockReturnValue(spawnOk('interface Foo {}') as any);
     expect(findInterfaceChanges(CWD, 'main')).toBe('interface Foo {}');
   });
 
   it('returns "No interface changes found" on empty output', () => {
-    mockExecSync.mockReturnValue('' as any);
+    mockSpawnSync.mockReturnValue(spawnOk('') as any);
     expect(findInterfaceChanges(CWD, 'main')).toBe('No interface changes found');
   });
 
   it('returns error string on failure', () => {
-    mockExecSync.mockImplementation(() => {
-      throw new Error('git error');
-    });
+    mockSpawnSync.mockReturnValue(spawnFail('git error') as any);
     expect(findInterfaceChanges(CWD, 'main')).toBe('Error: git error');
   });
 
   it('scopes to specific interface when interfaceName is provided', () => {
-    mockExecSync.mockReturnValue('interface Foo {}' as any);
+    mockSpawnSync.mockReturnValue(spawnOk('interface Foo {}') as any);
     findInterfaceChanges(CWD, 'main', undefined, 'Foo');
-    expect(mockExecSync).toHaveBeenCalledWith(expect.stringContaining('Foo'), expect.anything());
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      'git',
+      expect.arrayContaining([expect.stringContaining('Foo')]),
+      expect.anything(),
+    );
   });
 });
 
@@ -184,27 +202,26 @@ describe('findInterfaceChanges', () => {
 
 describe('listChangedFiles', () => {
   it('returns file list output', () => {
-    mockExecSync.mockReturnValue('M src/foo.ts\nA src/bar.ts\n' as any);
+    mockSpawnSync.mockReturnValue(spawnOk('M src/foo.ts\nA src/bar.ts\n') as any);
     expect(listChangedFiles(CWD, 'main')).toBe('M src/foo.ts\nA src/bar.ts\n');
   });
 
   it('returns "No changed files" on empty output', () => {
-    mockExecSync.mockReturnValue('' as any);
+    mockSpawnSync.mockReturnValue(spawnOk('') as any);
     expect(listChangedFiles(CWD, 'main')).toBe('No changed files');
   });
 
   it('returns error string on failure', () => {
-    mockExecSync.mockImplementation(() => {
-      throw new Error('git error');
-    });
+    mockSpawnSync.mockReturnValue(spawnFail('git error') as any);
     expect(listChangedFiles(CWD, 'main')).toBe('Error: git error');
   });
 
   it('passes diff-filter when filter is provided', () => {
-    mockExecSync.mockReturnValue('A src/new.ts\n' as any);
+    mockSpawnSync.mockReturnValue(spawnOk('A src/new.ts\n') as any);
     listChangedFiles(CWD, 'main', undefined, 'A');
-    expect(mockExecSync).toHaveBeenCalledWith(
-      expect.stringContaining('--diff-filter=A'),
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      'git',
+      expect.arrayContaining(['--diff-filter=A']),
       expect.anything(),
     );
   });
@@ -249,37 +266,36 @@ describe('readFile', () => {
 
 describe('grepFiles', () => {
   it('returns matching lines', () => {
-    mockExecSync.mockReturnValue('src/foo.ts:1:const x' as any);
+    mockSpawnSync.mockReturnValue(spawnOk('src/foo.ts:1:const x') as any);
     expect(grepFiles(CWD, 'const x')).toBe('src/foo.ts:1:const x');
   });
 
   it('returns "No matches found" when rg exits with status 1', () => {
-    mockExecSync.mockImplementation(() => {
-      const e: any = new Error();
-      e.status = 1;
-      throw e;
-    });
+    mockSpawnSync.mockReturnValue(spawnFail('', 1) as any);
     expect(grepFiles(CWD, 'nope')).toBe('No matches found');
   });
 
   it('returns error on other failures', () => {
-    mockExecSync.mockImplementation(() => {
-      throw new Error('rg error');
-    });
-    expect(grepFiles(CWD, 'x')).toBe('Error: rg error');
+    mockSpawnSync.mockReturnValue(spawnError('rg error') as any);
+    expect(grepFiles(CWD, 'x')).toMatch(/rg error/);
   });
 
   it('adds -i flag when ignoreCase is true', () => {
-    mockExecSync.mockReturnValue('' as any);
+    mockSpawnSync.mockReturnValue(spawnOk('') as any);
     grepFiles(CWD, 'foo', undefined, true);
-    expect(mockExecSync).toHaveBeenCalledWith(expect.stringContaining('-i'), expect.anything());
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      'rg',
+      expect.arrayContaining(['-i']),
+      expect.anything(),
+    );
   });
 
   it('adds --glob flag when glob is provided', () => {
-    mockExecSync.mockReturnValue('' as any);
+    mockSpawnSync.mockReturnValue(spawnOk('') as any);
     grepFiles(CWD, 'foo', '*.ts');
-    expect(mockExecSync).toHaveBeenCalledWith(
-      expect.stringContaining('--glob "*.ts"'),
+    expect(mockSpawnSync).toHaveBeenCalledWith(
+      'rg',
+      expect.arrayContaining(['--glob', '*.ts']),
       expect.anything(),
     );
   });
@@ -289,19 +305,17 @@ describe('grepFiles', () => {
 
 describe('globFiles', () => {
   it('returns matched file paths', () => {
-    mockExecSync.mockReturnValue('/project/repo/src/foo.ts\n' as any);
+    mockSpawnSync.mockReturnValue(spawnOk('/project/repo/src/foo.ts\n') as any);
     expect(globFiles(CWD, '**/*.ts')).toBe('/project/repo/src/foo.ts');
   });
 
   it('returns "No files found" on empty output', () => {
-    mockExecSync.mockReturnValue('\n' as any);
+    mockSpawnSync.mockReturnValue(spawnOk('\n') as any);
     expect(globFiles(CWD, '**/*.xyz')).toBe('No files found');
   });
 
   it('returns error string on failure', () => {
-    mockExecSync.mockImplementation(() => {
-      throw new Error('find error');
-    });
+    mockSpawnSync.mockReturnValue(spawnFail('find error') as any);
     expect(globFiles(CWD, '**/*.ts')).toBe('Error: find error');
   });
 });

--- a/tests/unit/stages/review/agentic/tools/handlers.spec.ts
+++ b/tests/unit/stages/review/agentic/tools/handlers.spec.ts
@@ -74,6 +74,18 @@ describe('findUsages', () => {
     );
   });
 
+  it('rejects scope path outside cwd', () => {
+    const result = findUsages(CWD, 'myFn', '/etc/passwd');
+    expect(result).toMatch(/outside project directory/);
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+  });
+
+  it('rejects scope path with traversal', () => {
+    const result = findUsages(CWD, 'myFn', '../../etc');
+    expect(result).toMatch(/outside project directory/);
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+  });
+
   it('uses custom fileType when provided', () => {
     mockSpawnSync.mockReturnValue(spawnOk('') as any);
     findUsages(CWD, 'myFn', undefined, 'js');
@@ -88,6 +100,17 @@ describe('findUsages', () => {
 // ─── traceImports ─────────────────────────────────────────────────────────────
 
 describe('traceImports', () => {
+  it('rejects path traversal outside cwd', () => {
+    const result = traceImports(CWD, '../../etc/passwd');
+    expect(result).toMatch(/outside project directory/);
+    expect(mockExistsSync).not.toHaveBeenCalled();
+  });
+
+  it('rejects absolute path outside cwd', () => {
+    const result = traceImports(CWD, '/etc/passwd');
+    expect(result).toMatch(/outside project directory/);
+  });
+
   it('returns "File not found" when file does not exist', () => {
     mockExistsSync.mockReturnValue(false);
     expect(traceImports(CWD, 'src/missing.ts')).toBe('File not found: src/missing.ts');
@@ -106,6 +129,18 @@ describe('traceImports', () => {
 // ─── gitDiffAnalysis ──────────────────────────────────────────────────────────
 
 describe('gitDiffAnalysis', () => {
+  it('rejects base ref starting with -', () => {
+    const result = gitDiffAnalysis(CWD, '--upload-pack=evil');
+    expect(result).toMatch(/invalid git ref/);
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+  });
+
+  it('rejects head ref starting with -', () => {
+    const result = gitDiffAnalysis(CWD, 'main', '--evil');
+    expect(result).toMatch(/invalid git ref/);
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+  });
+
   it('returns diff output', () => {
     mockSpawnSync.mockReturnValue(spawnOk('+ added line\n') as any);
     expect(gitDiffAnalysis(CWD, 'main')).toBe('+ added line\n');
@@ -135,6 +170,20 @@ describe('gitDiffAnalysis', () => {
 // ─── analyzeExports ───────────────────────────────────────────────────────────
 
 describe('analyzeExports', () => {
+  it('rejects path traversal outside cwd', () => {
+    const result = analyzeExports(CWD, '../../etc/passwd');
+    expect(result).toMatch(/outside project directory/);
+    expect(mockExistsSync).not.toHaveBeenCalled();
+  });
+
+  it('rejects compareWithRef starting with -', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('export const foo = 1;' as any);
+    const result = analyzeExports(CWD, 'src/mod.ts', '--evil');
+    expect(result).toMatch(/invalid git ref/);
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+  });
+
   it('returns "File not found" when file does not exist', () => {
     mockExistsSync.mockReturnValue(false);
     expect(analyzeExports(CWD, 'src/missing.ts')).toBe('File not found: src/missing.ts');
@@ -172,6 +221,21 @@ describe('analyzeExports', () => {
 // ─── findInterfaceChanges ─────────────────────────────────────────────────────
 
 describe('findInterfaceChanges', () => {
+  it('rejects base ref starting with -', () => {
+    const result = findInterfaceChanges(CWD, '--evil');
+    expect(result).toMatch(/invalid git ref/);
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+  });
+
+  it('escapes special regex chars in interfaceName to prevent ReDoS', () => {
+    mockSpawnSync.mockReturnValue(spawnOk('') as any);
+    findInterfaceChanges(CWD, 'main', undefined, 'Foo(Bar)+');
+    const call = mockSpawnSync.mock.calls[0];
+    const gArg = (call[1] as string[]).find((a) => a.startsWith('-G'));
+    // Special chars should be escaped, not passed raw
+    expect(gArg).toContain('Foo\\(Bar\\)\\+');
+  });
+
   it('returns diff output', () => {
     mockSpawnSync.mockReturnValue(spawnOk('interface Foo {}') as any);
     expect(findInterfaceChanges(CWD, 'main')).toBe('interface Foo {}');
@@ -201,6 +265,12 @@ describe('findInterfaceChanges', () => {
 // ─── listChangedFiles ─────────────────────────────────────────────────────────
 
 describe('listChangedFiles', () => {
+  it('rejects base ref starting with -', () => {
+    const result = listChangedFiles(CWD, '--evil');
+    expect(result).toMatch(/invalid git ref/);
+    expect(mockSpawnSync).not.toHaveBeenCalled();
+  });
+
   it('returns file list output', () => {
     mockSpawnSync.mockReturnValue(spawnOk('M src/foo.ts\nA src/bar.ts\n') as any);
     expect(listChangedFiles(CWD, 'main')).toBe('M src/foo.ts\nA src/bar.ts\n');

--- a/tests/unit/stages/review/agentic/tools/handlers.spec.ts
+++ b/tests/unit/stages/review/agentic/tools/handlers.spec.ts
@@ -1,0 +1,307 @@
+jest.mock('node:child_process', () => ({ execSync: jest.fn() }));
+jest.mock('node:fs', () => ({ existsSync: jest.fn(), readFileSync: jest.fn() }));
+
+import { execSync } from 'node:child_process';
+import { existsSync, readFileSync } from 'node:fs';
+
+import {
+  analyzeExports,
+  findInterfaceChanges,
+  findUsages,
+  gitDiffAnalysis,
+  globFiles,
+  grepFiles,
+  listChangedFiles,
+  readFile,
+  traceImports,
+} from '@/stages/review/agentic/tools/handlers';
+
+const mockExecSync = execSync as jest.MockedFunction<typeof execSync>;
+const mockExistsSync = existsSync as jest.MockedFunction<typeof existsSync>;
+const mockReadFileSync = readFileSync as jest.MockedFunction<typeof readFileSync>;
+
+const CWD = '/project/repo';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+// ─── findUsages ───────────────────────────────────────────────────────────────
+
+describe('findUsages', () => {
+  it('returns rg output on success', () => {
+    mockExecSync.mockReturnValue('src/foo.ts:5:const myFn = ' as any);
+    expect(findUsages(CWD, 'myFn')).toBe('src/foo.ts:5:const myFn = ');
+  });
+
+  it('returns "No usages found" when rg exits with status 1', () => {
+    mockExecSync.mockImplementation(() => {
+      const e: any = new Error();
+      e.status = 1;
+      throw e;
+    });
+    expect(findUsages(CWD, 'myFn')).toBe('No usages found');
+  });
+
+  it('returns error message on other failures', () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error('rg not found');
+    });
+    expect(findUsages(CWD, 'myFn')).toBe('Error: rg not found');
+  });
+
+  it('uses scope when provided', () => {
+    mockExecSync.mockReturnValue('' as any);
+    findUsages(CWD, 'myFn', '/project/repo/src');
+    expect(mockExecSync).toHaveBeenCalledWith(
+      expect.stringContaining('/project/repo/src'),
+      expect.anything(),
+    );
+  });
+
+  it('uses custom fileType when provided', () => {
+    mockExecSync.mockReturnValue('' as any);
+    findUsages(CWD, 'myFn', undefined, 'js');
+    expect(mockExecSync).toHaveBeenCalledWith(
+      expect.stringContaining('--type js'),
+      expect.anything(),
+    );
+  });
+});
+
+// ─── traceImports ─────────────────────────────────────────────────────────────
+
+describe('traceImports', () => {
+  it('returns "File not found" when file does not exist', () => {
+    mockExistsSync.mockReturnValue(false);
+    expect(traceImports(CWD, 'src/missing.ts')).toBe('File not found: src/missing.ts');
+  });
+
+  it('returns JSON with imports and exports', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(`import { foo } from './foo';\nexport const bar = 1;` as any);
+    mockExecSync.mockReturnValue('' as any);
+    const result = JSON.parse(traceImports(CWD, 'src/mod.ts'));
+    expect(result.imports).toContain('./foo');
+    expect(result.exports).toContain('bar');
+  });
+});
+
+// ─── gitDiffAnalysis ──────────────────────────────────────────────────────────
+
+describe('gitDiffAnalysis', () => {
+  it('returns diff output', () => {
+    mockExecSync.mockReturnValue('+ added line\n' as any);
+    expect(gitDiffAnalysis(CWD, 'main')).toBe('+ added line\n');
+  });
+
+  it('returns "No differences found" on empty output', () => {
+    mockExecSync.mockReturnValue('' as any);
+    expect(gitDiffAnalysis(CWD, 'main')).toBe('No differences found');
+  });
+
+  it('returns error string on failure', () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error('not a git repo');
+    });
+    expect(gitDiffAnalysis(CWD, 'main')).toBe('Error: not a git repo');
+  });
+
+  it('passes --stat flag when stat=true', () => {
+    mockExecSync.mockReturnValue('1 file changed' as any);
+    gitDiffAnalysis(CWD, 'main', undefined, undefined, true);
+    expect(mockExecSync).toHaveBeenCalledWith(expect.stringContaining('--stat'), expect.anything());
+  });
+});
+
+// ─── analyzeExports ───────────────────────────────────────────────────────────
+
+describe('analyzeExports', () => {
+  it('returns "File not found" when file does not exist', () => {
+    mockExistsSync.mockReturnValue(false);
+    expect(analyzeExports(CWD, 'src/missing.ts')).toBe('File not found: src/missing.ts');
+  });
+
+  it('returns exports JSON for existing file', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('export const foo = 1;\nexport default class Bar {}' as any);
+    const result = JSON.parse(analyzeExports(CWD, 'src/mod.ts'));
+    expect(result.exports).toContain('foo');
+    expect(result.exports).toContain('default');
+    expect(result.comparison).toBeNull();
+  });
+
+  it('includes comparison when compareWithRef is provided', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('export const foo = 1;' as any);
+    mockExecSync.mockReturnValue('export const oldFn = () => {};' as any);
+    const result = JSON.parse(analyzeExports(CWD, 'src/mod.ts', 'main'));
+    expect(result.comparison).toBeTruthy();
+    expect(result.comparison.added).toContain('foo');
+    expect(result.comparison.removed).toContain('oldFn');
+  });
+
+  it('uses added=currentExports when git show fails', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('export const foo = 1;' as any);
+    mockExecSync.mockImplementation(() => {
+      throw new Error('git error');
+    });
+    const result = JSON.parse(analyzeExports(CWD, 'src/mod.ts', 'main'));
+    expect(result.comparison.added).toContain('foo');
+    expect(result.comparison.removed).toEqual([]);
+  });
+});
+
+// ─── findInterfaceChanges ─────────────────────────────────────────────────────
+
+describe('findInterfaceChanges', () => {
+  it('returns diff output', () => {
+    mockExecSync.mockReturnValue('interface Foo {}' as any);
+    expect(findInterfaceChanges(CWD, 'main')).toBe('interface Foo {}');
+  });
+
+  it('returns "No interface changes found" on empty output', () => {
+    mockExecSync.mockReturnValue('' as any);
+    expect(findInterfaceChanges(CWD, 'main')).toBe('No interface changes found');
+  });
+
+  it('returns error string on failure', () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error('git error');
+    });
+    expect(findInterfaceChanges(CWD, 'main')).toBe('Error: git error');
+  });
+
+  it('scopes to specific interface when interfaceName is provided', () => {
+    mockExecSync.mockReturnValue('interface Foo {}' as any);
+    findInterfaceChanges(CWD, 'main', undefined, 'Foo');
+    expect(mockExecSync).toHaveBeenCalledWith(expect.stringContaining('Foo'), expect.anything());
+  });
+});
+
+// ─── listChangedFiles ─────────────────────────────────────────────────────────
+
+describe('listChangedFiles', () => {
+  it('returns file list output', () => {
+    mockExecSync.mockReturnValue('M src/foo.ts\nA src/bar.ts\n' as any);
+    expect(listChangedFiles(CWD, 'main')).toBe('M src/foo.ts\nA src/bar.ts\n');
+  });
+
+  it('returns "No changed files" on empty output', () => {
+    mockExecSync.mockReturnValue('' as any);
+    expect(listChangedFiles(CWD, 'main')).toBe('No changed files');
+  });
+
+  it('returns error string on failure', () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error('git error');
+    });
+    expect(listChangedFiles(CWD, 'main')).toBe('Error: git error');
+  });
+
+  it('passes diff-filter when filter is provided', () => {
+    mockExecSync.mockReturnValue('A src/new.ts\n' as any);
+    listChangedFiles(CWD, 'main', undefined, 'A');
+    expect(mockExecSync).toHaveBeenCalledWith(
+      expect.stringContaining('--diff-filter=A'),
+      expect.anything(),
+    );
+  });
+});
+
+// ─── readFile ─────────────────────────────────────────────────────────────────
+
+describe('readFile', () => {
+  it('reads a file within cwd', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue('file contents' as any);
+    expect(readFile(CWD, 'src/foo.ts')).toBe('file contents');
+  });
+
+  it('rejects a path that resolves outside cwd via prefix exploit', () => {
+    // /project/repo-evil starts with /project/repo but is a sibling dir
+    const result = readFile('/project/repo', '/project/repo-evil/secret.txt');
+    expect(result).toBe('Error: Path outside project directory: /project/repo-evil/secret.txt');
+  });
+
+  it('rejects path traversal via ..', () => {
+    const result = readFile(CWD, '../outside.txt');
+    expect(result).toBe('Error: Path outside project directory: ../outside.txt');
+  });
+
+  it('returns "File not found" when file does not exist', () => {
+    mockExistsSync.mockReturnValue(false);
+    const result = readFile(CWD, 'src/missing.ts');
+    expect(result).toBe('File not found: src/missing.ts');
+  });
+
+  it('returns error message when readFileSync throws', () => {
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockImplementation(() => {
+      throw new Error('EACCES');
+    });
+    expect(readFile(CWD, 'src/foo.ts')).toBe('Error reading file: EACCES');
+  });
+});
+
+// ─── grepFiles ────────────────────────────────────────────────────────────────
+
+describe('grepFiles', () => {
+  it('returns matching lines', () => {
+    mockExecSync.mockReturnValue('src/foo.ts:1:const x' as any);
+    expect(grepFiles(CWD, 'const x')).toBe('src/foo.ts:1:const x');
+  });
+
+  it('returns "No matches found" when rg exits with status 1', () => {
+    mockExecSync.mockImplementation(() => {
+      const e: any = new Error();
+      e.status = 1;
+      throw e;
+    });
+    expect(grepFiles(CWD, 'nope')).toBe('No matches found');
+  });
+
+  it('returns error on other failures', () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error('rg error');
+    });
+    expect(grepFiles(CWD, 'x')).toBe('Error: rg error');
+  });
+
+  it('adds -i flag when ignoreCase is true', () => {
+    mockExecSync.mockReturnValue('' as any);
+    grepFiles(CWD, 'foo', undefined, true);
+    expect(mockExecSync).toHaveBeenCalledWith(expect.stringContaining('-i'), expect.anything());
+  });
+
+  it('adds --glob flag when glob is provided', () => {
+    mockExecSync.mockReturnValue('' as any);
+    grepFiles(CWD, 'foo', '*.ts');
+    expect(mockExecSync).toHaveBeenCalledWith(
+      expect.stringContaining('--glob "*.ts"'),
+      expect.anything(),
+    );
+  });
+});
+
+// ─── globFiles ────────────────────────────────────────────────────────────────
+
+describe('globFiles', () => {
+  it('returns matched file paths', () => {
+    mockExecSync.mockReturnValue('/project/repo/src/foo.ts\n' as any);
+    expect(globFiles(CWD, '**/*.ts')).toBe('/project/repo/src/foo.ts');
+  });
+
+  it('returns "No files found" on empty output', () => {
+    mockExecSync.mockReturnValue('\n' as any);
+    expect(globFiles(CWD, '**/*.xyz')).toBe('No files found');
+  });
+
+  it('returns error string on failure', () => {
+    mockExecSync.mockImplementation(() => {
+      throw new Error('find error');
+    });
+    expect(globFiles(CWD, '**/*.ts')).toBe('Error: find error');
+  });
+});


### PR DESCRIPTION
## What's new

Agentic review mode now works with **OpenAI and Azure OpenAI** in addition to Anthropic Claude. Previously, running `qualops review` in agentic mode would silently ignore any non-Anthropic provider config and always use Claude. Now the provider you configure is actually used.

### Using OpenAI

Set your review stage provider to `openai` in `.qualopsrc.json`:

```json
{
  "ai": {
    "reviewStage": {
      "model": { "name": "gpt-4o", "provider": "openai" },
      "inputPerMillion": 2.5,
      "outputPerMillion": 10.0
    }
  }
}
```

And set `OPENAI_API_KEY` in your environment.

### Using Azure OpenAI

Same config as above, but also set `OPENAI_BASE_URL` to your Azure deployment endpoint:

```
OPENAI_BASE_URL=https://<resource>.openai.azure.com/openai/deployments/<deployment>
```

The correct Azure client is configured automatically when an Azure endpoint is detected.

### Anthropic

No changes needed — existing configs continue to work as before.

---

Builds on top of #133 (flexible provider/model selection).