### PR TITLE
Populate site content from repo sources

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,10 @@ on:
       - 'website/**'
       - 'CHANGELOG.md'
       - 'CONTRIBUTING.md'
+      - 'docs/**'
+      - 'examples/**'
+      - '.qualops/examples/**'
+      - 'action.yml'
       - '.github/workflows/docs.yml'
   workflow_dispatch:
 

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -3,9 +3,18 @@ dist/
 # generated types
 .astro/
 
-# synced from repo-root markdown by scripts/sync-root-docs.mjs
+# synced from elsewhere in the repo by scripts/sync-root-docs.mjs
 src/content/docs/changelog.md
 src/content/docs/contributing.md
+src/content/docs/github-action/setup.md
+src/content/docs/examples/agents/comment-rewriter.md
+src/content/docs/examples/agents/migration-checker.md
+src/content/docs/examples/agents/rxjs-migration.md
+src/content/docs/examples/agents/angular-signals.md
+src/content/docs/examples/claude-code-command.md
+
+# generated from action.yml by scripts/gen-action-docs.mjs
+src/content/docs/github-action/inputs.mdx
 
 # dependencies
 node_modules/

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -12,6 +12,7 @@ export default defineConfig({
 			title: 'QualOps',
 			description: 'AI-powered code review for your PRs.',
 			lastUpdated: true,
+			customCss: ['./src/styles/custom.css'],
 			social: [
 				{
 					icon: 'github',
@@ -68,7 +69,16 @@ export default defineConfig({
 					label: 'Examples',
 					items: [
 						{ label: 'Configurations', slug: 'examples/configurations' },
-						{ label: 'Custom agents', slug: 'examples/custom-agents' },
+						{
+							label: 'Custom agents',
+							items: [
+								{ label: 'Overview', slug: 'examples/custom-agents' },
+								{ label: 'Comment rewriter', slug: 'examples/agents/comment-rewriter' },
+								{ label: 'Migration checker', slug: 'examples/agents/migration-checker' },
+								{ label: 'RxJS migration', slug: 'examples/agents/rxjs-migration' },
+								{ label: 'Angular Signals', slug: 'examples/agents/angular-signals' },
+							],
+						},
 						{ label: 'Claude Code command', slug: 'examples/claude-code-command' },
 					],
 				},

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -11,6 +11,12 @@
         "@astrojs/starlight": "^0.39.0",
         "astro": "^6.2.2",
         "sharp": "^0.34.5"
+      },
+      "devDependencies": {
+        "yaml": "^2.8.4"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@astrojs/compiler": {
@@ -6224,6 +6230,22 @@
       "resolved": "https://registry.npmjs.org/xxhash-wasm/-/xxhash-wasm-1.1.0.tgz",
       "integrity": "sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==",
       "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.4.tgz",
+      "integrity": "sha512-ml/JPOj9fOQK8RNnWojA67GbZ0ApXAUlN2UQclwv2eVgTgn7O9gg9o7paZWKMp4g0H3nTLtS9LVzhkpOFIKzog==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
     },
     "node_modules/yargs-parser": {
       "version": "22.0.0",

--- a/website/package.json
+++ b/website/package.json
@@ -3,7 +3,7 @@
   "type": "module",
   "version": "0.0.1",
   "scripts": {
-    "sync": "node scripts/sync-root-docs.mjs",
+    "sync": "node scripts/sync-root-docs.mjs && node scripts/gen-action-docs.mjs",
     "predev": "npm run sync",
     "prebuild": "npm run sync",
     "dev": "astro dev",
@@ -19,5 +19,8 @@
   },
   "engines": {
     "node": ">=22.12.0"
+  },
+  "devDependencies": {
+    "yaml": "^2.8.4"
   }
 }

--- a/website/scripts/gen-action-docs.mjs
+++ b/website/scripts/gen-action-docs.mjs
@@ -1,0 +1,71 @@
+// Generates the GitHub Action inputs/outputs reference page from the canonical
+// action.yml at the repo root. Output is gitignored; the action.yml is the
+// single source of truth.
+
+import { readFile, writeFile, mkdir } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parse as parseYaml } from 'yaml';
+
+const websiteDir = resolve(fileURLToPath(import.meta.url), '../..');
+const repoRoot = resolve(websiteDir, '..');
+const actionPath = join(repoRoot, 'action.yml');
+const targetPath = join(websiteDir, 'src', 'content', 'docs', 'github-action', 'inputs.mdx');
+
+function escape(value) {
+  if (value == null) return '';
+  return String(value).replace(/\|/g, '\\|').replace(/\r?\n/g, ' ').trim();
+}
+
+function inputsTable(inputs) {
+  if (!inputs || Object.keys(inputs).length === 0) return '_No inputs defined._\n';
+  const rows = Object.entries(inputs).map(([name, spec]) => {
+    const required = spec.required ? '**yes**' : 'no';
+    const defaultValue = spec.default ? `\`${escape(spec.default)}\`` : '—';
+    return `| \`${name}\` | ${escape(spec.description)} | ${required} | ${defaultValue} |`;
+  });
+  return ['| Input | Description | Required | Default |', '|---|---|---|---|', ...rows].join('\n');
+}
+
+function outputsTable(outputs) {
+  if (!outputs || Object.keys(outputs).length === 0) return '_No outputs defined._\n';
+  const rows = Object.entries(outputs).map(
+    ([name, spec]) => `| \`${name}\` | ${escape(spec.description)} |`,
+  );
+  return ['| Output | Description |', '|---|---|', ...rows].join('\n');
+}
+
+async function generate() {
+  if (!existsSync(actionPath)) {
+    throw new Error(`gen-action-docs: action.yml not found at ${actionPath}`);
+  }
+  const raw = await readFile(actionPath, 'utf8');
+  const action = parseYaml(raw);
+
+  const body = `---
+title: Action inputs & outputs
+description: Reference for every input and output exposed by the QualOps GitHub Action. Generated from action.yml.
+editUrl: https://github.com/eggai-tech/qualops/edit/main/action.yml
+---
+
+${action.description ? `> ${action.description}\n\n` : ''}This page is generated from [\`action.yml\`](https://github.com/eggai-tech/qualops/blob/main/action.yml). Edit that file, not this page.
+
+## Inputs
+
+${inputsTable(action.inputs)}
+
+## Outputs
+
+${outputsTable(action.outputs)}
+`;
+
+  await mkdir(dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, body);
+  console.log(`generated action.yml -> ${targetPath.replace(websiteDir + '/', '')}`);
+}
+
+generate().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/website/scripts/sync-root-docs.mjs
+++ b/website/scripts/sync-root-docs.mjs
@@ -1,9 +1,13 @@
-// Copies authoritative markdown files from the repo root into the Starlight
-// content directory, prepending the frontmatter Starlight requires. The output
-// files are gitignored — only the source files in the repo root are committed.
+// Copies authoritative markdown files from elsewhere in the repo into the
+// Starlight content directory, normalising them so Starlight can render them:
+//   - prepends the frontmatter Starlight requires (title, description, editUrl)
+//   - optionally strips a pre-existing frontmatter block (showing it as an
+//     adjacent `yaml` code block when relevant)
+//   - optionally strips a leading H1 line so we don't render two H1s
 //
-// Run via `prebuild` and `predev` in package.json. Update the SOURCES array
-// when adding more synced root documents.
+// Output files are gitignored — only the source files are committed. Run via
+// `predev` and `prebuild` in package.json. To add a new synced page, append to
+// SOURCES; no other changes are needed.
 
 import { readFile, writeFile, mkdir } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
@@ -15,47 +19,131 @@ const repoRoot = resolve(websiteDir, '..');
 const contentDir = join(websiteDir, 'src', 'content', 'docs');
 
 const SOURCES = [
-	{
-		from: 'CHANGELOG.md',
-		to: 'changelog.md',
-		title: 'Changelog',
-		description: 'All notable changes to QualOps. Synced from CHANGELOG.md in the repository root.',
-	},
-	{
-		from: 'CONTRIBUTING.md',
-		to: 'contributing.md',
-		title: 'Contributing',
-		description: 'How to contribute to QualOps. Synced from CONTRIBUTING.md in the repository root.',
-	},
+  {
+    from: 'CHANGELOG.md',
+    to: 'changelog.md',
+    title: 'Changelog',
+    description: 'All notable changes to QualOps. Synced from CHANGELOG.md in the repository root.',
+  },
+  {
+    from: 'CONTRIBUTING.md',
+    to: 'contributing.md',
+    title: 'Contributing',
+    description:
+      'How to contribute to QualOps. Synced from CONTRIBUTING.md in the repository root.',
+  },
+  {
+    from: 'docs/github-setup.md',
+    to: 'github-action/setup.md',
+    title: 'GitHub Action setup',
+    description:
+      'Configure secrets, permissions, and the QualOps GitHub Action workflow for your repository.',
+    stripFirstH1: true,
+  },
+  {
+    from: 'examples/agents/comment-rewriter.md',
+    to: 'examples/agents/comment-rewriter.md',
+    title: 'Comment rewriter agent',
+    description:
+      'Reviews code comments and inline documentation quality, flagging missing or outdated docs.',
+    stripFrontmatter: 'show-as-yaml',
+  },
+  {
+    from: 'examples/agents/migration-checker.md',
+    to: 'examples/agents/migration-checker.md',
+    title: 'Migration checker agent',
+    description:
+      'Reviews database migration patterns for safety, reversibility, and lock-time impact.',
+    stripFrontmatter: 'show-as-yaml',
+  },
+  {
+    from: 'examples/agents/rxjs-migration.md',
+    to: 'examples/agents/rxjs-migration.md',
+    title: 'RxJS migration agent',
+    description: 'Identifies deprecated RxJS patterns and suggests modern alternatives.',
+    stripFrontmatter: 'show-as-yaml',
+  },
+  {
+    from: 'examples/agents/angular-signals.md',
+    to: 'examples/agents/angular-signals.md',
+    title: 'Angular Signals agent',
+    description:
+      'Identifies Angular code that could migrate to the Signals reactivity model and flags anti-patterns.',
+    stripFrontmatter: 'show-as-yaml',
+  },
+  {
+    from: 'examples/claude-commands/setup-qualops.md',
+    to: 'examples/claude-code-command.md',
+    title: 'Claude Code: /setup-qualops',
+    description:
+      'Interactively configure QualOps from inside Claude Code using the bundled slash command.',
+  },
 ];
 
+// Wrap a value in YAML double quotes, escaping any embedded quotes/backslashes.
+// Necessary for titles/descriptions that may contain colons (e.g. "Claude
+// Code: /setup-qualops") which YAML would otherwise mis-tokenise as keys.
+function yamlString(value) {
+  return `"${String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
 function frontmatter({ title, description, sourcePath }) {
-	const editUrl = `https://github.com/eggai-tech/qualops/edit/main/${sourcePath}`;
-	return [
-		'---',
-		`title: ${title}`,
-		`description: ${description}`,
-		`editUrl: ${editUrl}`,
-		'---',
-		'',
-	].join('\n');
+  const editUrl = `https://github.com/eggai-tech/qualops/edit/main/${sourcePath}`;
+  return [
+    '---',
+    `title: ${yamlString(title)}`,
+    `description: ${yamlString(description)}`,
+    `editUrl: ${editUrl}`,
+    '---',
+    '',
+  ].join('\n');
+}
+
+const FRONTMATTER_RE = /^---\n([\s\S]*?)\n---\n+/;
+const LEADING_H1_RE = /^\s*# .+\r?\n+/;
+
+function processBody(raw, { stripFrontmatter, stripFirstH1 }) {
+  let body = raw;
+  let strippedFrontmatter = '';
+  const fmMatch = FRONTMATTER_RE.exec(body);
+  if (fmMatch) {
+    strippedFrontmatter = fmMatch[1];
+    if (stripFrontmatter) body = body.slice(fmMatch[0].length);
+  }
+  if (stripFirstH1) body = body.replace(LEADING_H1_RE, '');
+
+  if (stripFrontmatter === 'show-as-yaml' && strippedFrontmatter) {
+    const trimmed = body.replace(/\s+$/, '');
+    body =
+      trimmed +
+      '\n\n## Agent metadata\n\n' +
+      'These fields are read by the Claude Agent SDK when the agent is loaded:\n\n' +
+      '```yaml\n' +
+      strippedFrontmatter +
+      '\n```\n';
+  }
+  return body;
 }
 
 async function sync() {
-	for (const { from, to, title, description } of SOURCES) {
-		const sourcePath = join(repoRoot, from);
-		if (!existsSync(sourcePath)) {
-			throw new Error(`sync-root-docs: source file not found: ${relative(repoRoot, sourcePath)}`);
-		}
-		const body = await readFile(sourcePath, 'utf8');
-		const targetPath = join(contentDir, to);
-		await mkdir(dirname(targetPath), { recursive: true });
-		await writeFile(targetPath, frontmatter({ title, description, sourcePath: from }) + body);
-		console.log(`synced ${from} -> ${relative(websiteDir, targetPath)}`);
-	}
+  for (const src of SOURCES) {
+    const sourcePath = join(repoRoot, src.from);
+    if (!existsSync(sourcePath)) {
+      throw new Error(`sync-root-docs: source file not found: ${relative(repoRoot, sourcePath)}`);
+    }
+    const raw = await readFile(sourcePath, 'utf8');
+    const body = processBody(raw, src);
+    const targetPath = join(contentDir, src.to);
+    await mkdir(dirname(targetPath), { recursive: true });
+    await writeFile(
+      targetPath,
+      frontmatter({ title: src.title, description: src.description, sourcePath: src.from }) + body,
+    );
+    console.log(`synced ${src.from} -> ${relative(websiteDir, targetPath)}`);
+  }
 }
 
 sync().catch((err) => {
-	console.error(err);
-	process.exit(1);
+  console.error(err);
+  process.exit(1);
 });

--- a/website/src/content/docs/cli/usage.mdx
+++ b/website/src/content/docs/cli/usage.mdx
@@ -4,5 +4,5 @@ description: Coming soon — CLI commands, flags, and common workflows.
 ---
 
 :::caution[Coming soon]
-This page will be written in the next docs PR. For now, run `qualops --help` or see the [Quick start](../getting-started/quick-start/).
+This page will be written in the next docs PR. For now, run `qualops --help` or see the [Quick start](../../getting-started/quick-start/).
 :::

--- a/website/src/content/docs/examples/claude-code-command.mdx
+++ b/website/src/content/docs/examples/claude-code-command.mdx
@@ -1,8 +1,0 @@
----
-title: Claude Code command
-description: Coming soon — using /setup-qualops in Claude Code.
----
-
-:::caution[Coming soon]
-Run `npx @eggai/qualops init-claude` to install the `/setup-qualops` slash command. See [`examples/claude-commands/setup-qualops.md`](https://github.com/eggai-tech/qualops/blob/main/examples/claude-commands/setup-qualops.md).
-:::

--- a/website/src/content/docs/examples/configurations.mdx
+++ b/website/src/content/docs/examples/configurations.mdx
@@ -1,13 +1,40 @@
 ---
 title: Example configurations
-description: Coming soon — curated index over .qualops/examples/.
+description: Reference .qualopsrc.json configurations for common project types — copy one into your project's .qualops/ folder and adapt.
 ---
 
-:::caution[Coming soon]
-We'll surface each example configuration with a short blurb here. For now, browse them directly in the repo:
+import { Card, CardGrid } from '@astrojs/starlight/components';
 
-- [`github`](https://github.com/eggai-tech/qualops/tree/main/.qualops/examples/github) — basic GitHub Actions setup
-- [`python-quality`](https://github.com/eggai-tech/qualops/tree/main/.qualops/examples/python-quality) — Python / FastAPI quality review
-- [`security-auditor`](https://github.com/eggai-tech/qualops/tree/main/.qualops/examples/security-auditor) — agentic security audit
-- [`angular-nx-monorepo`](https://github.com/eggai-tech/qualops/tree/main/.qualops/examples/angular-nx-monorepo) — Angular + NgRx + Nx monorepo
-:::
+These are working `.qualopsrc.json` configurations from the [`.qualops/examples/`](https://github.com/eggai-tech/qualops/tree/main/.qualops/examples) folder. Each one targets a different project type or review focus. Copy the JSON into your repository's `.qualops/.qualopsrc.json` and adapt as needed.
+
+<CardGrid>
+	<Card title="GitHub Actions starter" icon="github">
+		Full-featured config plus three sample workflows (basic, advanced, npm-pinned). The right starting point for most repositories adopting QualOps via the Action.
+
+		**Files:** [`.qualopsrc.json`](https://github.com/eggai-tech/qualops/blob/main/.qualops/examples/github/.qualopsrc.json) · [workflows/](https://github.com/eggai-tech/qualops/tree/main/.qualops/examples/github/workflows) · [README](https://github.com/eggai-tech/qualops/blob/main/.qualops/examples/github/README.md)
+	</Card>
+	<Card title="Python quality" icon="seti:python">
+		FastAPI / async-Python focus. Demonstrates the `--config` flag with a custom configuration file and tuned review prompts for Python idioms.
+
+		**File:** [`python-quality.qualopsrc.json`](https://github.com/eggai-tech/qualops/blob/main/.qualops/examples/python-quality/python-quality.qualopsrc.json)
+	</Card>
+	<Card title="Security auditor" icon="seti:lock">
+		Agentic mode tuned for security reviews — cross-file vulnerability tracing, OWASP-aligned prompts, and a stricter validation pass.
+
+		**Files:** [`security-auditor.qualopsrc.json`](https://github.com/eggai-tech/qualops/blob/main/.qualops/examples/security-auditor/security-auditor.qualopsrc.json) · [prompts/](https://github.com/eggai-tech/qualops/tree/main/.qualops/examples/security-auditor/prompts)
+	</Card>
+	<Card title="Angular Nx monorepo" icon="seti:tsconfig">
+		Multi-app Nx workspace targeting NgRx SignalStore migrations. Demonstrates custom agentic prompts, deduplication rules, and per-pass fix prompts.
+
+		**Files:** [`signalstore-migration.qualopsrc.json`](https://github.com/eggai-tech/qualops/blob/main/.qualops/examples/angular-nx-monorepo/signalstore-migration.qualopsrc.json) · [prompts/](https://github.com/eggai-tech/qualops/tree/main/.qualops/examples/angular-nx-monorepo/prompts)
+	</Card>
+</CardGrid>
+
+## How to use one of these
+
+1. Copy the relevant `.qualopsrc.json` (or rename it to `.qualopsrc.json`) into a `.qualops/` directory at the root of your project.
+2. If the example has an accompanying `prompts/` directory, copy that too — the config references prompts by relative path.
+3. Make sure the API key environment variable for your provider (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or AWS credentials) is set in CI.
+4. Adapt: tune `review.minConfidence`, `review.maxFilesBeforeReset`, and the framework-specific prompts to your codebase.
+
+For the field-by-field reference, see [Configuration → Reference](../../configuration/reference/).

--- a/website/src/content/docs/examples/configurations.mdx
+++ b/website/src/content/docs/examples/configurations.mdx
@@ -1,40 +1,16 @@
 ---
 title: Example configurations
-description: Reference .qualopsrc.json configurations for common project types — copy one into your project's .qualops/ folder and adapt.
+description: QualOps runs with sensible defaults out of the box — example .qualopsrc.json configurations are available in the repository for when you need to customize.
 ---
 
-import { Card, CardGrid } from '@astrojs/starlight/components';
+## Run with the defaults
 
-These are working `.qualopsrc.json` configurations from the [`.qualops/examples/`](https://github.com/eggai-tech/qualops/tree/main/.qualops/examples) folder. Each one targets a different project type or review focus. Copy the JSON into your repository's `.qualops/.qualopsrc.json` and adapt as needed.
+QualOps is designed to run with a **good default configuration out of the box**, with no `.qualopsrc.json` required. For most projects, the easiest way to adopt QualOps is to set your provider API key in CI and let the defaults handle the rest — you only need to add a config file once you want to tune behavior for your codebase.
 
-<CardGrid>
-	<Card title="GitHub Actions starter" icon="github">
-		Full-featured config plus three sample workflows (basic, advanced, npm-pinned). The right starting point for most repositories adopting QualOps via the Action.
+If you're getting started, see the [Quick start](../../getting-started/quick-start/) — no configuration step needed.
 
-		**Files:** [`.qualopsrc.json`](https://github.com/eggai-tech/qualops/blob/main/.qualops/examples/github/.qualopsrc.json) · [workflows/](https://github.com/eggai-tech/qualops/tree/main/.qualops/examples/github/workflows) · [README](https://github.com/eggai-tech/qualops/blob/main/.qualops/examples/github/README.md)
-	</Card>
-	<Card title="Python quality" icon="seti:python">
-		FastAPI / async-Python focus. Demonstrates the `--config` flag with a custom configuration file and tuned review prompts for Python idioms.
+## Reference examples
 
-		**File:** [`python-quality.qualopsrc.json`](https://github.com/eggai-tech/qualops/blob/main/.qualops/examples/python-quality/python-quality.qualopsrc.json)
-	</Card>
-	<Card title="Security auditor" icon="seti:lock">
-		Agentic mode tuned for security reviews — cross-file vulnerability tracing, OWASP-aligned prompts, and a stricter validation pass.
+Working `.qualopsrc.json` examples live in the repository at [`.qualops/examples/`](https://github.com/eggai-tech/qualops/tree/main/.qualops/examples) and cover a few different project types and review focuses. Browse them when you need a starting point for customization.
 
-		**Files:** [`security-auditor.qualopsrc.json`](https://github.com/eggai-tech/qualops/blob/main/.qualops/examples/security-auditor/security-auditor.qualopsrc.json) · [prompts/](https://github.com/eggai-tech/qualops/tree/main/.qualops/examples/security-auditor/prompts)
-	</Card>
-	<Card title="Angular Nx monorepo" icon="seti:tsconfig">
-		Multi-app Nx workspace targeting NgRx SignalStore migrations. Demonstrates custom agentic prompts, deduplication rules, and per-pass fix prompts.
-
-		**Files:** [`signalstore-migration.qualopsrc.json`](https://github.com/eggai-tech/qualops/blob/main/.qualops/examples/angular-nx-monorepo/signalstore-migration.qualopsrc.json) · [prompts/](https://github.com/eggai-tech/qualops/tree/main/.qualops/examples/angular-nx-monorepo/prompts)
-	</Card>
-</CardGrid>
-
-## How to use one of these
-
-1. Copy the relevant `.qualopsrc.json` (or rename it to `.qualopsrc.json`) into a `.qualops/` directory at the root of your project.
-2. If the example has an accompanying `prompts/` directory, copy that too — the config references prompts by relative path.
-3. Make sure the API key environment variable for your provider (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, or AWS credentials) is set in CI.
-4. Adapt: tune `review.minConfidence`, `review.maxFilesBeforeReset`, and the framework-specific prompts to your codebase.
-
-For the field-by-field reference, see [Configuration → Reference](../../configuration/reference/).
+For the field-by-field reference of every option, see [Configuration → Reference](../../configuration/reference/).

--- a/website/src/content/docs/examples/custom-agents.mdx
+++ b/website/src/content/docs/examples/custom-agents.mdx
@@ -1,8 +1,36 @@
 ---
 title: Custom agents
-description: Coming soon — reusable agentic prompts for your project.
+description: Reusable agentic-mode prompts you can drop into your repository's .qualops/agents/ folder.
 ---
 
-:::caution[Coming soon]
-Browse the four example agent prompts under [`examples/agents/`](https://github.com/eggai-tech/qualops/tree/main/examples/agents): `comment-rewriter`, `migration-checker`, `rxjs-migration`, `angular-signals`.
-:::
+In [agentic review mode](../../review-modes/agentic/), the Claude Agent SDK can dispatch to specialised subagents that focus on one concern (security, migrations, comment quality, etc.). QualOps ships four custom agent prompts you can copy into your own project under `.qualops/agents/<name>.md` and reference from `.qualopsrc.json`.
+
+## Examples
+
+- [Comment rewriter](../agents/comment-rewriter/) — flags missing JSDoc, outdated comments, and unhelpful documentation
+- [Migration checker](../agents/migration-checker/) — reviews database migrations for safety and reversibility
+- [RxJS migration](../agents/rxjs-migration/) — identifies deprecated RxJS patterns and suggests modern alternatives
+- [Angular Signals](../agents/angular-signals/) — finds Angular code that could migrate to the Signals reactivity model
+
+Each page shows the full agent prompt as well as the metadata (`description`, `tools`, `model`) the Claude Agent SDK reads when loading the agent.
+
+## Wiring into your config
+
+In `.qualopsrc.json`, point an agentic job at one of these:
+
+```json
+{
+  "jobs": {
+    "rxjs-audit": {
+      "mode": "agentic",
+      "agentic": {
+        "maxTurns": 15,
+        "enabledSubagents": ["rxjs-migration"],
+        "systemPrompt": "Focus on RxJS 7+ migration in the changed files only."
+      }
+    }
+  }
+}
+```
+
+The agent file must live at `.qualops/agents/rxjs-migration.md` for the runtime to find it. The original markdown for each example above is at [`examples/agents/`](https://github.com/eggai-tech/qualops/tree/main/examples/agents) in the repository — copy as-is or adapt.

--- a/website/src/content/docs/getting-started/installation.mdx
+++ b/website/src/content/docs/getting-started/installation.mdx
@@ -4,5 +4,5 @@ description: Coming soon — installing QualOps as a GitHub Action, an npm CLI, 
 ---
 
 :::caution[Coming soon]
-This page hasn't been written yet. In the meantime, see the [Quick start](./quick-start/) for installation instructions.
+This page hasn't been written yet. In the meantime, see the [Quick start](../quick-start/) for installation instructions.
 :::

--- a/website/src/content/docs/getting-started/quick-start.mdx
+++ b/website/src/content/docs/getting-started/quick-start.mdx
@@ -35,7 +35,7 @@ jobs:
 
 Then add `ANTHROPIC_API_KEY` to your repository secrets (Settings → Secrets → Actions). On every PR, QualOps will analyze the diff, post a summary comment, and add inline annotations through the Checks API.
 
-For full setup details — secrets, permissions, troubleshooting — see [GitHub Action → Setup](../github-action/setup/).
+For full setup details — secrets, permissions, troubleshooting — see [GitHub Action → Setup](../../github-action/setup/).
 
 ## Local CLI
 
@@ -50,10 +50,10 @@ qualops --base=main --head=HEAD
 qualops --files="src/**/*.ts"
 ```
 
-You'll need an `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY` / AWS credentials, depending on your provider) in the environment. See [AI providers](../ai-providers/) for the full list.
+You'll need an `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY` / AWS credentials, depending on your provider) in the environment. See [AI providers](../../ai-providers/) for the full list.
 
 ## Next steps
 
-- Read the [Configuration reference](../configuration/reference/) to tune the review pipeline
-- Pick between [file-by-file and agentic review modes](../review-modes/file-by-file/)
-- Browse [example configurations](../examples/configurations/) for Angular, Python, and security audits
+- Read the [Configuration reference](../../configuration/reference/) to tune the review pipeline
+- Pick between [file-by-file and agentic review modes](../../review-modes/file-by-file/)
+- Browse [example configurations](../../examples/configurations/) for Angular, Python, and security audits

--- a/website/src/content/docs/github-action/inputs.mdx
+++ b/website/src/content/docs/github-action/inputs.mdx
@@ -1,8 +1,0 @@
----
-title: Action inputs & outputs
-description: Coming soon — generated reference of action.yml inputs and outputs.
----
-
-:::caution[Coming soon]
-This page will be auto-generated from [`action.yml`](https://github.com/eggai-tech/qualops/blob/main/action.yml) in the next docs PR.
-:::

--- a/website/src/content/docs/github-action/setup.mdx
+++ b/website/src/content/docs/github-action/setup.mdx
@@ -1,8 +1,0 @@
----
-title: GitHub Action setup
-description: Coming soon — full GitHub Action setup guide with secrets, permissions, and troubleshooting.
----
-
-:::caution[Coming soon]
-This page will be populated in the next docs PR. In the meantime, see [`docs/github-setup.md`](https://github.com/eggai-tech/qualops/blob/main/docs/github-setup.md) in the repository for the full setup guide.
-:::

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -1,0 +1,31 @@
+/* Color-pulse on the splash hero's primary CTA (the Quick start button).
+   Brightness + saturation animate the button itself (works in both light and
+   dark themes without picking exact colors), and a soft outer glow amplifies
+   the effect. The secondary "View on GitHub" button is rendered as
+   .sl-link-button.minimal, so it is not affected. */
+@keyframes qualops-pulse-bg {
+	0%, 100% {
+		filter: brightness(1) saturate(1);
+		box-shadow: 0 0 0 0 transparent;
+	}
+	50% {
+		filter: brightness(1.25) saturate(1.35);
+		box-shadow: 0 0 22px 3px color-mix(in srgb, var(--sl-color-accent) 65%, transparent);
+	}
+}
+
+.sl-link-button.primary {
+	animation: qualops-pulse-bg 1.6s ease-in-out infinite;
+	transition: transform 0.15s ease;
+}
+
+.sl-link-button.primary:hover {
+	transform: translateY(-1px);
+	animation-play-state: paused;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.sl-link-button.primary {
+		animation: none;
+	}
+}


### PR DESCRIPTION
## Summary

- Replaces the "Coming soon" stubs with real content synced from the repo
- Extends `sync-root-docs.mjs` to handle frontmatter-bearing sources and adds a small `gen-action-docs.mjs` that parses `action.yml` at build time, so the site never drifts from the canonical sources.
- Workflow path filter widened to `docs/**`, `examples/**`, `.qualops/examples/**`, and `action.yml`; adds a subtle pulse  animation on the splash-hero CTA; fixes 12 relative links across the docs that were one path segment too shallow.
