### PR TITLE
fix: skip sk- key format check when a custom base URL is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Azure OpenAI keys (non-`sk-` format) no longer fail validation when `OPENAI_BASE_URL` is set. The `sk-` prefix check is now correctly skipped for custom endpoints.
+
 ## [0.2.4] - 2026-06-04
 
 ### Added

--- a/src/ai/providers/openai-compatible-provider.ts
+++ b/src/ai/providers/openai-compatible-provider.ts
@@ -24,11 +24,13 @@ interface OpenAICompatibleProviderConfig {
   friendlyName: 'GitHub Models' | 'OpenAI' | (string & {});
   apiKey?: string;
   baseURL?: string;
+  skipKeyFormatValidation?: boolean;
 }
 
 export abstract class OpenAICompatibleProvider extends BaseAIProvider {
   readonly name: OpenAICompatibleProviderConfig['name'];
   protected readonly apiKey: string;
+  protected readonly skipKeyFormatValidation: boolean;
   private readonly friendlyName: OpenAICompatibleProviderConfig['friendlyName'];
   private readonly baseURL: string | undefined;
   private client: OpenAI | null = null;
@@ -40,6 +42,7 @@ export abstract class OpenAICompatibleProvider extends BaseAIProvider {
     this.friendlyName = providerConfig.friendlyName;
     this.apiKey = providerConfig.apiKey ?? '';
     this.baseURL = providerConfig.baseURL;
+    this.skipKeyFormatValidation = providerConfig.skipKeyFormatValidation ?? false;
 
     this.validateApiKey();
     this.validateConfiguration();

--- a/src/ai/providers/openai.ts
+++ b/src/ai/providers/openai.ts
@@ -13,14 +13,17 @@ export class OpenAIProvider extends OpenAICompatibleProvider {
       throw new Error(`OPENAI_BASE_URL must be a valid http/https URL, got: ${rawBaseURL}`);
     }
 
+    const isCustomEndpoint = !!rawBaseURL;
+
     super(stageConfig, {
       name: 'openai',
       friendlyName: 'OpenAI',
       apiKey,
       baseURL: rawBaseURL,
+      skipKeyFormatValidation: isCustomEndpoint,
     });
 
-    this.isCustomEndpoint = !!rawBaseURL;
+    this.isCustomEndpoint = isCustomEndpoint;
   }
 
   protected validateApiKey(): void {
@@ -28,7 +31,7 @@ export class OpenAIProvider extends OpenAICompatibleProvider {
       throw new Error('OPENAI_API_KEY environment variable is required for openai provider');
     }
 
-    if (!this.isCustomEndpoint && !this.apiKey.startsWith('sk-')) {
+    if (!this.skipKeyFormatValidation && !this.apiKey.startsWith('sk-')) {
       throw new Error('Invalid OpenAI API key format');
     }
   }

--- a/tests/unit/ai/providers/openai.spec.ts
+++ b/tests/unit/ai/providers/openai.spec.ts
@@ -77,4 +77,14 @@ describe('OpenAIProvider', () => {
     );
     expect(() => new OpenAIProvider(validStageConfig)).not.toThrow();
   });
+
+  it('should accept a non-sk- key when OPENAI_BASE_URL is set (Azure OpenAI)', () => {
+    mockEnvConfig.get.mockImplementation(
+      envGet(
+        'azure-api-key-abc123',
+        'https://my-resource.openai.azure.com/openai/deployments/gpt-4o',
+      ),
+    );
+    expect(() => new OpenAIProvider(validStageConfig)).not.toThrow();
+  });
 });


### PR DESCRIPTION
Fix: Azure OpenAI keys were rejected even when configured correctly

Users with Azure OpenAI set up (OPENAI_BASE_URL + a non-sk- API key) would get Invalid OpenAI API key format on every run, despite their config being valid. The sk- prefix check was supposed to be skipped for custom endpoints, but due to a subtle initialization bug it always ran. This fix ensures the check is correctly bypassed when a custom base URL is provided.