### PR TITLE
Chore report evals as experiments in langfuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Upgraded eval Langfuse SDK from `langfuse@3.38.20` to `@langfuse/client@5.4.1`. Eval runs are now registered as Langfuse experiments via `datasetRunItems.create()` with a consistent `runName`, grouping all items from a single eval run under one experiment entry in the Langfuse UI.
+
 ### Fixed
 - Agentic adapters now use SDK-native structured output (same `detectCapabilities()` path as the file-by-file pipeline) instead of heuristic JSON text parsing. `AnthropicAdapter` passes `outputFormat: {type: "json_schema"}`, `OpenAIAdapter` uses `outputType`, and `ConfigurableAgentAdapter` uses `output: {structured: true}` — all gated on `isUnstructured()`. The text fallback path is kept for unstructured models and now restores the pre-QUALOPS-18 trailing-comma fix. Runs that return non-empty non-JSON output now throw instead of silently producing zero findings.
 - `--diff-filter` parameter in `listChangedFiles` agentic tool now validated against the allowed git diff-filter character set (`[ACDMRTUXB*]`), consistent with how `base`/`head` refs are validated via `isSafeGitRef`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Agentic adapters now use SDK-native structured output (same `detectCapabilities()` path as the file-by-file pipeline) instead of heuristic JSON text parsing. `AnthropicAdapter` passes `outputFormat: {type: "json_schema"}`, `OpenAIAdapter` uses `outputType`, and `ConfigurableAgentAdapter` uses `output: {structured: true}` — all gated on `isUnstructured()`. The text fallback path is kept for unstructured models and now restores the pre-QUALOPS-18 trailing-comma fix. Runs that return non-empty non-JSON output now throw instead of silently producing zero findings.
 - `--diff-filter` parameter in `listChangedFiles` agentic tool now validated against the allowed git diff-filter character set (`[ACDMRTUXB*]`), consistent with how `base`/`head` refs are validated via `isSafeGitRef`.
+- `AIProviderType` enum in `factory.ts` was missing `OPENAI_COMPATIBLE`, causing the `openai-compatible` switch case to use a raw string literal and bypass the exhaustive `never` check in the `default` branch.
 
 ## [0.2.6] - 2026-06-17
 

--- a/evals/src/run-eval.spec.ts
+++ b/evals/src/run-eval.spec.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-jest.mock('langfuse', () => ({ Langfuse: jest.fn() }));
+jest.mock('@langfuse/client', () => ({ LangfuseClient: jest.fn() }));
 
 import { parseDiffLines } from './reviewer';
 import { resolveDatasets, resolvePreset, listPresets } from './config';

--- a/evals/src/run-eval.ts
+++ b/evals/src/run-eval.ts
@@ -315,6 +315,7 @@ async function linkDatasetRunItem(
         provider: config.provider,
         preset: config.presetLabel,
         configPath: config.configPath,
+        durationMs,
       },
     });
   } catch (err) {

--- a/evals/src/run-eval.ts
+++ b/evals/src/run-eval.ts
@@ -28,8 +28,10 @@ import fs from 'fs';
 import dotenv from 'dotenv';
 import { ROOT_CONTEXT, SpanStatusCode } from '@opentelemetry/api';
 import type { Tracer, Span } from '@opentelemetry/api';
-import { Langfuse } from 'langfuse';
-import type { ApiDatasetItem } from 'langfuse';
+import { LangfuseClient } from '@langfuse/client';
+import type { FetchedDataset } from '@langfuse/client';
+
+type DatasetItem = FetchedDataset['items'][number];
 dotenv.config({ path: path.join(__dirname, '../../.env') });
 
 import {
@@ -118,15 +120,15 @@ interface NormalizedItem {
   referenceExpected: Issue[];
 }
 
-function normalizeApiItem(item: ApiDatasetItem): NormalizedItem {
+function normalizeApiItem(item: DatasetItem): NormalizedItem {
   const itemInput: ItemInput = item.input || {};
-  const itemExpected = item.expectedOutput || {};
+  const itemExpected = (item.expectedOutput as Record<string, unknown>) || {};
   return {
     id: item.id as string,
     langfuseItemId: item.id as string,
     input: itemInput,
-    referenceBugs: itemExpected.referenceBugs || [],
-    referenceExpected: itemExpected.referenceExpected || [],
+    referenceBugs: (itemExpected.referenceBugs as Issue[]) || [],
+    referenceExpected: (itemExpected.referenceExpected as Issue[]) || [],
   };
 }
 
@@ -152,7 +154,7 @@ function attachTraceAttributes(rootSpan: Span, itemInput: ItemInput, caseId: str
 }
 
 async function runEvalItem(
-  langfuse: Langfuse,
+  langfuse: LangfuseClient,
   item: NormalizedItem,
   itemIndex: number,
   total: number,
@@ -294,7 +296,7 @@ async function runReviewSpan(
 }
 
 async function linkDatasetRunItem(
-  langfuse: Langfuse,
+  langfuse: LangfuseClient,
   datasetItemId: string,
   traceId: string,
   durationMs: number,
@@ -302,7 +304,7 @@ async function linkDatasetRunItem(
   caseId: string,
 ) {
   try {
-    await langfuse.api.datasetRunItemsCreate({
+    await langfuse.api.datasetRunItems.create({
       datasetItemId,
       traceId,
       runName: config.experimentName,
@@ -330,7 +332,7 @@ async function linkDatasetRunItem(
 }
 
 interface ScoreEvalItemOpts {
-  langfuse: Langfuse;
+  langfuse: LangfuseClient;
   traceId: string;
   genSpanId: string | undefined;
   caseId: string;
@@ -361,7 +363,7 @@ async function computeScores(
 }
 
 function publishScores(
-  langfuse: Langfuse,
+  langfuse: LangfuseClient,
   traceId: string,
   genSpanId: string | undefined,
   caseId: string,
@@ -369,11 +371,11 @@ function publishScores(
   goldenDetails: CrbGoldenCommentDetails[] | null,
 ): void {
   for (const score of scores) {
-    langfuse.score({ traceId, observationId: genSpanId, name: score.name, value: score.value!, comment: score.comment, dataType: 'NUMERIC' });
+    langfuse.score.create({ traceId, observationId: genSpanId, name: score.name, value: score.value!, comment: score.comment, dataType: 'NUMERIC' });
   }
   if (!goldenDetails) return;
   for (const gd of goldenDetails) {
-    langfuse.score({
+    langfuse.score.create({
       traceId,
       observationId: genSpanId,
       name: `${caseId}:golden-${gd.goldenIndex}`,
@@ -449,7 +451,7 @@ function crbSliceToItem(slice: CrbSlice): NormalizedItem {
 }
 
 async function runItems(
-  langfuse: Langfuse,
+  langfuse: LangfuseClient,
   items: NormalizedItem[],
   datasetName: string,
   tracer: Tracer,
@@ -495,7 +497,7 @@ async function runItems(
   return results;
 }
 
-async function runDataset(langfuse: Langfuse, datasetName: string, tracer: Tracer) {
+async function runDataset(langfuse: LangfuseClient, datasetName: string, tracer: Tracer) {
   console.log(`\n═══ Dataset: ${datasetName} ═══`);
 
   // CRB datasets are served from local slices — no Langfuse fetch needed.
@@ -515,8 +517,9 @@ async function runDataset(langfuse: Langfuse, datasetName: string, tracer: Trace
   }
 
   // Non-CRB datasets are fetched from Langfuse.
+  let fetchedDataset: Awaited<ReturnType<typeof langfuse.dataset.get>>;
   try {
-    await langfuse.api.datasetsGet(encodeURIComponent(datasetName));
+    fetchedDataset = await langfuse.dataset.get(datasetName);
   } catch (err) {
     const error = err as Error;
     const errorCode = classifyError(error);
@@ -534,20 +537,11 @@ async function runDataset(langfuse: Langfuse, datasetName: string, tracer: Trace
     return { total: 0, errors: 1 };
   }
 
-  let allApiItems: ApiDatasetItem[] = [];
-  let page = 1;
-  while (true) {
-    const resp = await langfuse.api.datasetItemsList({ datasetName, page, limit: 100 });
-    allApiItems.push(...(resp.data || []));
-    if (!resp.meta?.totalPages || page >= resp.meta.totalPages) break;
-    page++;
-  }
-
-  const items = allApiItems.map(normalizeApiItem);
+  const items = fetchedDataset.items.map(normalizeApiItem);
   return runItems(langfuse, items, datasetName, tracer);
 }
 
-function createLangfuseClient(): { langfuse: Langfuse; host: string } {
+function createLangfuseClient(): { langfuse: LangfuseClient; host: string } {
   const secretKey = process.env.LANGFUSE_SECRET_KEY;
   const publicKey = process.env.LANGFUSE_PUBLIC_KEY;
   const host = process.env.LANGFUSE_BASE_URL || 'https://cloud.langfuse.com';
@@ -555,7 +549,7 @@ function createLangfuseClient(): { langfuse: Langfuse; host: string } {
     console.error('Error: LANGFUSE_SECRET_KEY and LANGFUSE_PUBLIC_KEY must be set in .env');
     process.exit(1);
   }
-  const langfuse = new Langfuse({ secretKey, publicKey, baseUrl: host, flushAt: 20, flushInterval: 5000 });
+  const langfuse = new LangfuseClient({ secretKey, publicKey, baseUrl: host });
   return { langfuse, host };
 }
 
@@ -602,7 +596,7 @@ async function main(): Promise<void> {
   }
 
   await shutdownTracing();
-  await langfuse.shutdownAsync();
+  await langfuse.shutdown();
 
   const logFile = runLog.write();
   printRunSummary(datasets, totals, logFile, host);

--- a/evals/src/run-eval.ts
+++ b/evals/src/run-eval.ts
@@ -306,7 +306,14 @@ async function linkDatasetRunItem(
       datasetItemId,
       traceId,
       runName: config.experimentName,
-      metadata: { durationMs },
+      runDescription: `${config.model} · ${config.mode} · ${config.presetLabel}`,
+      metadata: {
+        model: config.model,
+        mode: config.mode,
+        provider: config.provider,
+        preset: config.presetLabel,
+        configPath: config.configPath,
+      },
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/evals/src/upload-datasets.spec.ts
+++ b/evals/src/upload-datasets.spec.ts
@@ -1,6 +1,6 @@
 'use strict';
 
-jest.mock('langfuse', () => ({ Langfuse: jest.fn() }));
+jest.mock('@langfuse/client', () => ({ LangfuseClient: jest.fn() }));
 
 import { buildQualOpsItem, crbSliceToCrbItem } from './upload-datasets';
 import { buildCrbExpectedPair } from './config';

--- a/evals/src/upload-datasets.ts
+++ b/evals/src/upload-datasets.ts
@@ -24,7 +24,7 @@ try {
   // rely on shell env
 }
 
-import { Langfuse } from 'langfuse';
+import { LangfuseClient } from '@langfuse/client';
 
 const args = Object.fromEntries(
   process.argv
@@ -158,9 +158,9 @@ export function buildQualOpsItem(data: RawDataItem, index: number): QualOpsItem 
 }
 
 
-async function ensureDataset(langfuse: Langfuse, name: string, description: string): Promise<void> {
+async function ensureDataset(langfuse: LangfuseClient, name: string, description: string): Promise<void> {
   try {
-    await langfuse.api.datasetsCreate({ name, description, metadata: { uploadedAt: new Date().toISOString() } });
+    await langfuse.api.datasets.create({ name, description, metadata: { uploadedAt: new Date().toISOString() } });
     console.log(`  Created dataset: ${name}`);
   } catch (err) {
     const e = err as { status?: number };
@@ -172,12 +172,12 @@ async function ensureDataset(langfuse: Langfuse, name: string, description: stri
   }
 }
 
-async function uploadBatch(langfuse: Langfuse, datasetName: string, items: (QualOpsItem | CrbItem)[]): Promise<void> {
+async function uploadBatch(langfuse: LangfuseClient, datasetName: string, items: (QualOpsItem | CrbItem)[]): Promise<void> {
   let uploaded = 0;
   let failed = 0;
   for (const item of items) {
     try {
-      await langfuse.api.datasetItemsCreate({
+      await langfuse.api.datasetItems.create({
         datasetName,
         id: item.id,
         input: item.input,
@@ -196,7 +196,7 @@ async function uploadBatch(langfuse: Langfuse, datasetName: string, items: (Qual
   console.log(`\n  Done: ${uploaded} uploaded, ${failed} failed`);
 }
 
-async function uploadQualOps(langfuse: Langfuse): Promise<void> {
+async function uploadQualOps(langfuse: LangfuseClient): Promise<void> {
   const datasetName = 'qualops/qualops';
   console.log(`\nUploading qualops dataset → ${datasetName}`);
   await ensureDataset(langfuse, datasetName, 'QualOps native eval dataset');
@@ -243,7 +243,7 @@ export function crbSliceToCrbItem(slice: CrbSlice, repoSlug: string): CrbItem {
   };
 }
 
-async function uploadCrb(langfuse: Langfuse): Promise<void> {
+async function uploadCrb(langfuse: LangfuseClient): Promise<void> {
   const repos = resolveCrbRepos(repo);
   for (const r of repos) {
     let slices = loadCrbItems(r);
@@ -274,7 +274,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const langfuse = new Langfuse({
+  const langfuse = new LangfuseClient({
     secretKey: langfuseSecretKey,
     publicKey: langfusePublicKey,
     baseUrl: langfuseHost,
@@ -294,7 +294,7 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  await langfuse.shutdownAsync();
+  await langfuse.shutdown();
   console.log('\nDone. View datasets at: ' + langfuseHost);
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "qualops": "dist/cli.js"
       },
       "devDependencies": {
+        "@langfuse/client": "^5.4.1",
         "@types/diff": "^7.0.2",
         "@types/glob": "9.0.0",
         "@types/jest": "^30.0.0",
@@ -42,7 +43,6 @@
         "eslint-plugin-import-x": "^4.16.2",
         "eslint-plugin-prettier": "^5.5.4",
         "jest": "^30.3.0",
-        "langfuse": "^3.38.6",
         "minimatch": "^10.0.1",
         "prettier": "^3.8.1",
         "ts-jest": "^29.4.9",
@@ -3452,6 +3452,21 @@
         "url": "https://opencollective.com/js-sdsl"
       }
     },
+    "node_modules/@langfuse/client": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@langfuse/client/-/client-5.4.1.tgz",
+      "integrity": "sha512-uANJfL52Y3zhN5wjQUsTVcOd4bmHoTqpRcpfxlbEyzjUCOhVyQymmP88hshbNHD+JfJa2sYLaHpsvt6owfVD7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@langfuse/core": "^5.4.1",
+        "@langfuse/tracing": "^5.4.1",
+        "mustache": "^4.2.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      }
+    },
     "node_modules/@langfuse/core": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/@langfuse/core/-/core-5.4.1.tgz",
@@ -3477,6 +3492,22 @@
         "@opentelemetry/core": "^2.0.1",
         "@opentelemetry/exporter-trace-otlp-http": ">=0.202.0 <1.0.0",
         "@opentelemetry/sdk-trace-base": "^2.0.1"
+      }
+    },
+    "node_modules/@langfuse/tracing": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/@langfuse/tracing/-/tracing-5.4.1.tgz",
+      "integrity": "sha512-nPyoPXXNMaJgaUZgIE0haWI/hrT7l4r/irp0o/FGaBYR2V07EFNvSKFcqOsX1pQvVvB6HyfNlYQm7AoQJj+fqQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@langfuse/core": "^5.4.1"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
@@ -13562,32 +13593,6 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/langfuse": {
-      "version": "3.38.20",
-      "resolved": "https://registry.npmjs.org/langfuse/-/langfuse-3.38.20.tgz",
-      "integrity": "sha512-MAmBAASSzJtmK1O9HQegA1mFsQhT8Yf+OJRGvE7FXkyv3g/eiBE0glLD0Ohg3pkxhoPdggM5SejK7ue9ctlaMA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "langfuse-core": "^3.38.20"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/langfuse-core": {
-      "version": "3.38.20",
-      "resolved": "https://registry.npmjs.org/langfuse-core/-/langfuse-core-3.38.20.tgz",
-      "integrity": "sha512-zBKVmQN/1oT5VWZUBYlWzvokIlkC/6mnpgr/2atMyTeAm+jR3ia7w2iJMjlrF5/oG8ukO1s8+LDRCzJpF1QeEA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "mustache": "^4.2.0"
-      },
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/leven": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
     "eslint-plugin-import-x": "^4.16.2",
     "eslint-plugin-prettier": "^5.5.4",
     "jest": "^30.3.0",
-    "langfuse": "^3.38.6",
+    "@langfuse/client": "^5.4.1",
     "minimatch": "^10.0.1",
     "prettier": "^3.8.1",
     "ts-jest": "^29.4.9",

--- a/src/ai/providers/factory.ts
+++ b/src/ai/providers/factory.ts
@@ -11,6 +11,7 @@ export const AIProviderType = {
   BEDROCK: 'bedrock',
   OPENAI: 'openai',
   GITHUB: 'github',
+  OPENAI_COMPATIBLE: 'openai-compatible',
 } as const;
 
 export class AIFactory {
@@ -43,7 +44,7 @@ export class AIFactory {
       case AIProviderType.GITHUB:
         provider = new GitHubModelsProvider(stageConfig);
         break;
-      case 'openai-compatible':
+      case AIProviderType.OPENAI_COMPATIBLE:
         provider = new OpenAIProvider(stageConfig);
         break;
       default: {

--- a/tests/unit/ai/providers/factory.spec.ts
+++ b/tests/unit/ai/providers/factory.spec.ts
@@ -285,13 +285,14 @@ describe('AIFactory', () => {
         AIProviderType.BEDROCK,
         AIProviderType.OPENAI,
         AIProviderType.GITHUB,
+        AIProviderType.OPENAI_COMPATIBLE,
       ]);
     });
 
     it('should return array with correct length', () => {
       const providers = AIFactory.getAvailableProviders();
 
-      expect(providers).toHaveLength(4);
+      expect(providers).toHaveLength(5);
     });
 
     it('should return array containing anthropic provider', () => {


### PR DESCRIPTION
This PR does two unrelated but both welcome things:

Langfuse SDK upgrade (langfuse@3 → @langfuse/client@5.4.1)

The v5 client ships a structured resource API (langfuse.api.datasetRunItems.create, langfuse.dataset.get, langfuse.score.create, etc.) instead of the flat method surface of v3. The migration is mechanical — every call site is updated to the new namespaced path, and the manual pagination loop for datasetItemsList is replaced by langfuse.dataset.get() which returns items directly.

The key functional addition: datasetRunItems.create now includes runDescription (model · mode · preset) and a richer metadata payload, so each eval run is properly registered as a Langfuse experiment with enough context to distinguish runs in the UI without needing to click into individual traces.