### PR TITLE
fix(security): clear Semgrep scan — fix real findings, suppress verified FPs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 10
     groups:
       aws-sdk:
@@ -35,3 +37,5 @@ updates:
     schedule:
       interval: weekly
       day: monday
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,33 @@ jobs:
       - name: Run lint
         run: npm run lint
 
+  semgrep:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+
+      - name: Setup Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Semgrep
+        run: pip install semgrep
+
+      # Same rulesets and scope as the pre-commit hook (.git/hooks/pre-commit),
+      # so local and CI agree. --error fails the job on any finding; verified
+      # false positives are suppressed with inline `nosemgrep`.
+      - name: Run Semgrep
+        run: |
+          semgrep scan \
+            --config p/default \
+            --config p/security-audit \
+            --config p/secrets \
+            --error \
+            --quiet \
+            src tests
+
   test:
     runs-on: ubuntu-latest
     steps:
@@ -190,17 +217,22 @@ jobs:
 
   all-checks-passed:
     if: always()
-    needs: [lint, test, changelog]
+    needs: [lint, semgrep, test, changelog]
     runs-on: ubuntu-latest
     steps:
       - name: Check all jobs passed
         env:
           LINT_RESULT: ${{ needs.lint.result }}
+          SEMGREP_RESULT: ${{ needs.semgrep.result }}
           TEST_RESULT: ${{ needs.test.result }}
           CHANGELOG_RESULT: ${{ needs.changelog.result }}
         run: |
           if [ "$LINT_RESULT" != "success" ]; then
             echo "Lint job failed"
+            exit 1
+          fi
+          if [ "$SEMGREP_RESULT" != "success" ]; then
+            echo "Semgrep job failed"
             exit 1
           fi
           if [ "$TEST_RESULT" != "success" ]; then

--- a/.qualops/examples/github/workflows/qualops-advanced.yml
+++ b/.qualops/examples/github/workflows/qualops-advanced.yml
@@ -20,12 +20,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0
 
       - name: Run QualOps
         id: qualops
+        # nosemgrep: github-actions-mutable-action-tag -- example intentionally shows the readable @stable release tag, not a pinned SHA
         uses: eggai-tech/qualops@stable
         with:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -42,7 +43,7 @@ jobs:
 
       - name: Comment on PR
         if: always() && steps.qualops.outputs.total-issues > 0
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const totalIssues = '${{ steps.qualops.outputs.total-issues }}';

--- a/.qualops/examples/github/workflows/qualops-basic.yml
+++ b/.qualops/examples/github/workflows/qualops-basic.yml
@@ -17,11 +17,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           fetch-depth: 0  # Full history for accurate git diff
 
       - name: Run QualOps
+        # nosemgrep: github-actions-mutable-action-tag -- example intentionally shows the readable @stable release tag, not a pinned SHA
         uses: eggai-tech/qualops@stable
         with:
           anthropic-api-key: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.qualops/examples/github/workflows/qualops-npm.yml
+++ b/.qualops/examples/github/workflows/qualops-npm.yml
@@ -17,11 +17,11 @@ jobs:
       checks: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0  # Full history for accurate git diff
 
-      - uses: actions/setup-node@v5
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: '24'
 
@@ -32,11 +32,13 @@ jobs:
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: qualops --base=${{ github.base_ref }} --head=${{ github.sha }}
+          BASE_REF: ${{ github.base_ref }}
+          HEAD_SHA: ${{ github.sha }}
+        run: qualops --base="$BASE_REF" --head="$HEAD_SHA"
 
       - name: Upload QualOps report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: qualops-report
           path: .qualops/reports/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 - Reduced dependency vulnerabilities: website advisories fully resolved (8→0); remaining root advisories trace to `@eggai/configurable-agent@0.2.1` (no upstream fix; slated for retirement). Note: the majority of GitHub's Dependabot alerts are frozen third-party eval fixtures under `evals/datasets/`, not shipped dependencies.
+- Cleared the Semgrep scan: fixed the real findings (shell-injection in the shipped `qualops-npm.yml` example, unpinned GitHub Actions, missing dependabot cooldown) and suppressed the verified false positives with inline `nosemgrep`.
 
 ### Fixed
 - Hardened the eval A/B tooling's CLI-path handling: filesystem access is confined to the repo/`evals/logs/` (run-log write path, `--eval-log` reads, and `--config`/`--experiment` values), and `--config`/`--repeats` are validated up front so a bad arg fails immediately rather than after a costly run.

--- a/action.yml
+++ b/action.yml
@@ -43,7 +43,7 @@ runs:
   using: 'composite'
   steps:
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
       with:
         node-version: '20'
 
@@ -117,7 +117,7 @@ runs:
 
     - name: Upload QualOps Reports
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
       with:
         name: qualops-reports
         path: .qualops/reports/

--- a/evals/src/run-eval.ts
+++ b/evals/src/run-eval.ts
@@ -441,6 +441,7 @@ function crbSliceToItem(slice: CrbSlice): NormalizedItem {
       language: slice.language,
       diff: slice.diff,
       git: {
+        // nosemgrep: path-join-resolve-traversal -- slice.id from local CRB dataset dir names read off disk
         repo_path: path.join(CRB_DATASETS_DIR, slice.id, 'repo'),
         head_sha: '', // empty = use repo_path directly (no worktree)
         base_sha: slice.baseSha,

--- a/src/github/github-integration.ts
+++ b/src/github/github-integration.ts
@@ -219,6 +219,7 @@ export class GitHubIntegration {
     }
 
     const sessionDirs = readdirSync(reportsDir).filter((name) => {
+      // nosemgrep: path-join-resolve-traversal -- reportsDir from process.cwd(), name from readdirSync of tool-created dir
       const fullPath = join(reportsDir, name);
       return existsSync(fullPath) && readdirSync(fullPath).length > 0;
     });

--- a/src/gitlab/gitlab-integration.ts
+++ b/src/gitlab/gitlab-integration.ts
@@ -498,6 +498,7 @@ class GitLabIntegration {
   }
 
   private findSessionsDir(reportsDir: string): string | null {
+    // nosemgrep: path-join-resolve-traversal -- reportsDir is a local constant, 'sessions' is a literal
     let sessionsDir = join(reportsDir, 'sessions');
     if (existsSync(sessionsDir)) return sessionsDir;
 
@@ -510,6 +511,7 @@ class GitLabIntegration {
         .reverse()[0];
 
       if (latestReport) {
+        // nosemgrep: path-join-resolve-traversal -- latestReport from readdirSync, regex-validated /^qualops-report-\d{8}$/
         sessionsDir = join(reportsDir, latestReport, 'sessions');
         if (existsSync(sessionsDir)) {
           logger.info(`Using report directory: ${latestReport}`);
@@ -561,8 +563,11 @@ class GitLabIntegration {
 
     for (const sessionFolder of sessionFolders) {
       // Read overall report for summary statistics
+      // nosemgrep: path-join-resolve-traversal -- sessionFolder from readdirSync of tool-created sessions dir
       const overallReportPath = join(sessionsDir, sessionFolder, 'overall-report.json');
+      // nosemgrep: path-join-resolve-traversal -- sessionFolder from readdirSync of tool-created sessions dir
       const reviewSummaryPath = join(sessionsDir, sessionFolder, 'review-summary.json');
+      // nosemgrep: path-join-resolve-traversal -- sessionFolder from readdirSync of tool-created sessions dir
       const analysisPath = join(sessionsDir, sessionFolder, 'analysis.json');
 
       if (!existsSync(overallReportPath)) {
@@ -649,6 +654,7 @@ class GitLabIntegration {
         .map((d) => d.name);
 
       for (const session of sessions) {
+        // nosemgrep: path-join-resolve-traversal -- session from readdirSync of local sessions dir
         const judgePath = join(sessionsDir, session, 'judge-decision.json');
         if (existsSync(judgePath)) {
           const data = JSON.parse(readFileSync(judgePath, 'utf8'));

--- a/src/scripts/resolve-issues-batch.ts
+++ b/src/scripts/resolve-issues-batch.ts
@@ -21,16 +21,20 @@ async function getIssueFiles(issuesDir: string, category?: string): Promise<stri
   const issues: string[] = [];
 
   if (category) {
+    // nosemgrep: path-join-resolve-traversal -- dev-only script; category is a local CLI arg
     const categoryPath = join(issuesDir, category);
     const files = await readdir(categoryPath);
+    // nosemgrep: path-join-resolve-traversal -- dev-only script; f is a readdir .md filename
     return files.filter((f) => f.endsWith('.md')).map((f) => join(categoryPath, f));
   }
 
   const categories = await readdir(issuesDir);
   for (const cat of categories) {
+    // nosemgrep: path-join-resolve-traversal -- dev-only script; cat is a readdir subdir entry
     const catPath = join(issuesDir, cat);
     try {
       const files = await readdir(catPath);
+      // nosemgrep: path-join-resolve-traversal -- dev-only script; f is a locally-read .md filename
       const mdFiles = files.filter((f) => f.endsWith('.md')).map((f) => join(catPath, f));
       issues.push(...mdFiles);
     } catch {

--- a/src/shared/runtime/session-context.ts
+++ b/src/shared/runtime/session-context.ts
@@ -113,6 +113,7 @@ export function getMostRecentSession(): string | null {
         return false;
       }
       try {
+        // nosemgrep: path-join-resolve-traversal -- dir is charset-validated /^[a-zA-Z0-9_-]+$/ before the join
         const fullPath = path.join(reportsDir, dir);
         return fs.statSync(fullPath).isDirectory();
       } catch {

--- a/src/shared/types/pattern.model.ts
+++ b/src/shared/types/pattern.model.ts
@@ -102,6 +102,7 @@ export class Pattern {
       name: data.name as string,
       type: data.type as PatternType,
       cleanupRequirement: data.cleanupRequirement as CleanupRequirement,
+      // nosemgrep: detect-non-literal-regexp -- pattern from operator's own stored config model, not attacker input
       regex: data.regex ? new RegExp(data.regex as string) : undefined,
       evidence: data.evidence as string | undefined,
       confidence: data.confidence as number | undefined,

--- a/src/shared/utils/security.ts
+++ b/src/shared/utils/security.ts
@@ -117,6 +117,7 @@ export function redactTokens(text: string, knownTokens: string[] = []): string {
   for (const token of knownTokens) {
     if (token && token.length > 0) {
       const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      // nosemgrep: detect-non-literal-regexp -- pattern escaped via metacharacter replace before RegExp
       redacted = redacted.replace(new RegExp(escaped, 'g'), REDACTED);
     }
   }

--- a/src/stages/fix/utils/code-locator.ts
+++ b/src/stages/fix/utils/code-locator.ts
@@ -77,6 +77,7 @@ export function findContextInFile(fileContent: string, context: string): Context
 
   for (const pattern of patterns) {
     try {
+      // nosemgrep: detect-non-literal-regexp -- context escaped via escapeRegExp before RegExp
       const regex = new RegExp(pattern.regex, 'g');
       const match = regex.exec(fileContent);
       if (match) {

--- a/src/stages/review/agentic/tools/bash/modes/ci.ts
+++ b/src/stages/review/agentic/tools/bash/modes/ci.ts
@@ -35,6 +35,7 @@ function snapshotHooks(hooksDir: string): HookSnapshot {
   if (!fs.existsSync(hooksDir)) return snapshot;
 
   for (const entry of fs.readdirSync(hooksDir)) {
+    // nosemgrep: path-join-resolve-traversal -- entry from readdirSync of operator-configured hooks dir
     const fullPath = path.join(hooksDir, entry);
     try {
       const stat = fs.statSync(fullPath);

--- a/src/stages/review/agentic/tools/bash/output-limit.ts
+++ b/src/stages/review/agentic/tools/bash/output-limit.ts
@@ -25,8 +25,10 @@ function spillToFile(
   callId: string,
   stream: 'stdout' | 'stderr',
 ): string {
+  // nosemgrep: path-join-resolve-traversal -- reviewId charset-validated /^[a-zA-Z0-9_-]+$/
   const dir = path.join(process.env['SANDBOX_TMP'] ?? os.tmpdir(), 'tool-output', reviewId);
   fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  // nosemgrep: path-join-resolve-traversal -- callId is `${reviewId}-${count}`, both non-traversal
   const filePath = path.join(dir, `${callId}.${stream}`);
   fs.writeFileSync(filePath, content, { encoding: 'utf8', mode: 0o600 });
   return filePath;

--- a/src/stages/review/agentic/tools/bash/policy.ts
+++ b/src/stages/review/agentic/tools/bash/policy.ts
@@ -671,6 +671,7 @@ function checkSingleCommand(cmd: ParsedCommand, config: PolicyConfig): PolicyOut
 
   if (config.extraDenyPatterns) {
     for (const pattern of config.extraDenyPatterns) {
+      // nosemgrep: detect-non-literal-regexp -- pattern from internal PolicyConfig, not attacker input
       if (new RegExp(pattern).test(analysis)) {
         return deny('extra-deny-pattern', `Command matched extra deny pattern: ${pattern}`);
       }

--- a/src/stages/review/agentic/tools/bash/secret-redact.ts
+++ b/src/stages/review/agentic/tools/bash/secret-redact.ts
@@ -50,6 +50,7 @@ export function redactOutput(text: string, knownTokens: string[] = []): string {
   for (const token of knownTokens) {
     if (token && token.length >= 8) {
       const escaped = token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+      // nosemgrep: detect-non-literal-regexp -- token escaped via metacharacter replace before RegExp
       redacted = redacted.replace(new RegExp(escaped, 'g'), REDACTED);
     }
   }

--- a/src/stages/review/loaders/doc-discovery.ts
+++ b/src/stages/review/loaders/doc-discovery.ts
@@ -28,6 +28,7 @@ export class DocDiscovery {
   }
 
   private static async findSplits(docRef: string): Promise<string[]> {
+    // nosemgrep: detect-non-literal-regexp -- docRef escaped via escapeRegex and anchored
     const splitPattern = new RegExp(`^${this.escapeRegex(docRef)}-(\\d+)\\.md$`);
 
     let files: string[];

--- a/src/stages/review/loaders/filter-matcher.ts
+++ b/src/stages/review/loaders/filter-matcher.ts
@@ -38,6 +38,7 @@ export class FilterMatcher {
     if (filters.detectionTriggers && filters.detectionTriggers.length > 0) {
       const matchesTrigger = filters.detectionTriggers.some((pattern) => {
         try {
+          // nosemgrep: detect-non-literal-regexp -- pattern from operator's own .qualopsrc config, not attacker input
           const regex = new RegExp(pattern);
           return regex.test(file.content);
         } catch {

--- a/src/stages/review/loaders/template-engine.ts
+++ b/src/stages/review/loaders/template-engine.ts
@@ -59,6 +59,7 @@ export class TemplateEngine {
 
     for (const part of parts) {
       if (current && typeof current === 'object' && part in current) {
+        // nosemgrep: prototype-pollution-loop -- read-only object walk (no write), path from operator-authored templates
         current = current[part];
       } else {
         return undefined;


### PR DESCRIPTION
Fix the shipped qualops-npm.yml example's shell injection (pass untrusted github.* via env: and reference "$VAR"), pin all third-party GitHub Actions to commit SHAs, and add a cooldown to both dependabot ecosystems. Annotate the 24 verified false positives (internal/validated path components, escaped or operator-authored regexes, a read-only object walk) with inline nosemgrep. Also reflow a pre-existing prettier violation in github-api-client.ts.